### PR TITLE
Generate functions associated with bitfields, enums and unions

### DIFF
--- a/src/codegen/sys/functions.rs
+++ b/src/codegen/sys/functions.rs
@@ -31,6 +31,36 @@ pub fn generate_classes_funcs(w: &mut Write, env: &Env, classes: &[&library::Cla
     Ok(())
 }
 
+pub fn generate_bitfields_funcs(w: &mut Write, env: &Env, bitfields: &[&library::Bitfield])
+        -> Result<()> {
+    for bitfield in bitfields {
+        try!(generate_object_funcs(w, env, &bitfield.c_type, INTERN, &bitfield.functions));
+    }
+
+    Ok(())
+}
+
+pub fn generate_enums_funcs(w: &mut Write, env: &Env, enums: &[&library::Enumeration])
+        -> Result<()> {
+    for en in enums {
+        try!(generate_object_funcs(w, env, &en.c_type, INTERN, &en.functions));
+    }
+
+    Ok(())
+}
+
+pub fn generate_unions_funcs(w: &mut Write, env: &Env, unions: &[&library::Union]) -> Result<()> {
+    for union in unions {
+        let c_type = match union.c_type {
+            Some(ref x) => x,
+            None => return Ok(()),
+        };
+        try!(generate_object_funcs(w, env, c_type, INTERN, &union.functions));
+    }
+
+    Ok(())
+}
+
 pub fn generate_interfaces_funcs(w: &mut Write, env: &Env, interfaces: &[&library::Interface]) -> Result<()> {
     for interface in interfaces {
         try!(generate_object_funcs(w, env,  &interface.c_type,

--- a/src/codegen/sys/lib_.rs
+++ b/src/codegen/sys/lib_.rs
@@ -45,12 +45,15 @@ fn generate_lib(w: &mut Write, env: &Env) -> Result<()>{
     let records = prepare(ns);
     let classes = prepare(ns);
     let interfaces = prepare(ns);
+    let bitfields = prepare(ns);
+    let enums = prepare(ns);
+    let unions = prepare(ns);
 
     try!(generate_aliases(w, env, &prepare(ns)));
-    try!(generate_enums(w, &prepare(ns)));
+    try!(generate_enums(w, &enums));
     try!(generate_constants(w, env, &ns.constants));
-    try!(generate_bitfields(w, &prepare(ns)));
-    try!(generate_unions(w, &prepare(ns)));
+    try!(generate_bitfields(w, &bitfields));
+    try!(generate_unions(w, &unions));
     try!(functions::generate_callbacks(w, env, &prepare(ns)));
     try!(generate_records(w, env, &records));
     try!(generate_classes_structs(w, &classes));
@@ -58,6 +61,9 @@ fn generate_lib(w: &mut Write, env: &Env) -> Result<()>{
 
     try!(writeln!(w, ""));
     try!(writeln!(w, "extern \"C\" {{"));
+    try!(functions::generate_enums_funcs(w, env, &enums));
+    try!(functions::generate_bitfields_funcs(w, env, &bitfields));
+    try!(functions::generate_unions_funcs(w, env, &unions));
     try!(functions::generate_records_funcs(w, env, &records));
     try!(functions::generate_classes_funcs(w, env, &classes));
     try!(functions::generate_interfaces_funcs(w, env, &interfaces));


### PR DESCRIPTION
Composing `GdkEvent*` wrappers is difficult without any `gdk_event_*` functions, which are associated with the `GdkEvent` union