### PR TITLE
Add doc formatting

### DIFF
--- a/src/codegen/doc/format.rs
+++ b/src/codegen/doc/format.rs
@@ -1,0 +1,59 @@
+use regex::{Captures, Regex};
+
+const LANGUAGE_SEP_END : &'static str = "\" -->";
+const LANGUAGE_BLOCK_BEGIN : &'static str = "|[<!-- language=\"";
+const LANGUAGE_BLOCK_END : &'static str = "\n]|";
+
+pub fn reformat_doc(input: &str) -> String {
+    let out = code_blocks_transformation(input);
+    replace_c_types(&out)
+}
+
+fn code_blocks_transformation(input: &str) -> String {
+    let mut out = String::new();
+
+    for entry in input.split(LANGUAGE_BLOCK_BEGIN) {
+        if out.is_empty() {
+            out.push_str(entry);
+            continue;
+        }
+        out.push_str("```");
+        let entry = get_language(entry, &mut out);
+        out.push_str(&format!("{}", entry.replace(LANGUAGE_BLOCK_END, "\n```")))
+    }
+    out
+}
+
+fn get_language<'a>(entry: &'a str, out: &mut String) -> &'a str {
+    if let Some(pos) = entry.find(LANGUAGE_SEP_END) {
+        out.push_str(&entry[0..pos]);
+        &entry[(pos + LANGUAGE_SEP_END.len())..]
+    } else {
+        out.push_str("\n");
+        entry
+    }
+}
+
+fn replace_c_types(entry: &str) -> String {
+    if let Ok(reg) = Regex::new(r"Gtk[\w]*") {
+        let mut out = vec!();
+
+        for (num, part) in entry.split("```").into_iter().enumerate() {
+            out.push(
+                if num & 1 == 0 {
+                    reg.replace_all(part, |caps: &Captures| {
+                        match caps.at(0) {
+                            Some(s) => format!("`{}`", &s[4..]),
+                            None => String::new(),
+                        }
+                    })
+                } else {
+                    part.to_owned()
+                }
+            );
+        }
+        out.join("```")
+    } else {
+        entry.to_owned()
+    }
+}

--- a/src/codegen/doc/format.rs
+++ b/src/codegen/doc/format.rs
@@ -1,3 +1,4 @@
+use std::ascii::AsciiExt;
 use regex::{Captures, Regex};
 
 const LANGUAGE_SEP_BEGIN : &'static str = "<!-- language=\"";
@@ -5,13 +6,8 @@ const LANGUAGE_SEP_END : &'static str = "\" -->";
 const LANGUAGE_BLOCK_BEGIN : &'static str = "|[";
 const LANGUAGE_BLOCK_END : &'static str = "\n]|";
 
-lazy_static! {
-    static ref REG : Regex = Regex::new(r"#?(G[dt]k)([\w]*)").unwrap();
-    static ref REG2 : Regex = Regex::new(r"@(\w*)").unwrap();
-}
-
-pub fn reformat_doc(input: &str) -> String {
-    code_blocks_transformation(input)
+pub fn reformat_doc(input: &str, namespace_name: &str) -> String {
+    code_blocks_transformation(input, namespace_name)
 }
 
 fn try_split<'a>(src: &'a str, needle: &str) -> (&'a str, Option<&'a str>) {
@@ -21,13 +17,13 @@ fn try_split<'a>(src: &'a str, needle: &str) -> (&'a str, Option<&'a str>) {
     }
 }
 
-fn code_blocks_transformation(mut input: &str) -> String {
+fn code_blocks_transformation(mut input: &str, namespace_name: &str) -> String {
     let mut out = String::new();
 
     loop {
         input = match try_split(input, LANGUAGE_BLOCK_BEGIN) {
             (before, Some(after)) => {
-                out.push_str(&replace_c_types(before));
+                out.push_str(&replace_c_types(before, namespace_name));
                 if let (before, Some(after)) = try_split(get_language(after, &mut out),
                                                          LANGUAGE_BLOCK_END) {
                     out.push_str(before);
@@ -38,28 +34,36 @@ fn code_blocks_transformation(mut input: &str) -> String {
                 }
             }
             (before, None) => {
-                out.push_str(&replace_c_types(before));
+                out.push_str(&replace_c_types(before, namespace_name));
                 return out
             }
         };
     }
 }
 
+lazy_static! {
+    static ref REG : Regex = Regex::new(r"#?(G[dt]k)([\w]*)").unwrap();
+    static ref REG2 : Regex = Regex::new(r"@(\w*)").unwrap();
+}
+
 fn get_language<'a>(entry: &'a str, out: &mut String) -> &'a str {
-    if let Some(pos) = entry.find(LANGUAGE_SEP_BEGIN) {
-        let entry = &entry[pos + LANGUAGE_SEP_BEGIN.len()..];
-        if let Some(pos) = entry.find(LANGUAGE_SEP_END) {
-            out.push_str(&format!("```{}", &entry[0..pos]));
-            return &entry[(pos + LANGUAGE_SEP_END.len())..]
+    if let (_, Some(after)) = try_split(entry, LANGUAGE_SEP_BEGIN) {
+        if let (before, Some(after)) = try_split(after, LANGUAGE_SEP_END) {
+            out.push_str(&format!("```{}", before));
+            return after
         }
     }
-    out.push_str("```");
+    out.push_str("```text");
     entry
 }
 
-fn replace_c_types(entry: &str) -> String {
+fn replace_c_types(entry: &str, namespace_name: &str) -> String {
     let out = &REG.replace_all(entry, |caps: &Captures| {
-        format!("`{}::{}`", &caps[1].to_lowercase(), &caps[2])
+        if caps[1].eq_ignore_ascii_case(namespace_name) {
+            format!("`{}`", &caps[2])
+        } else {
+            format!("`{}::{}`", &caps[1].to_lowercase(), &caps[2])
+        }
     });
     REG2.replace_all(out, "`$1`")
 }

--- a/src/codegen/doc/mod.rs
+++ b/src/codegen/doc/mod.rs
@@ -14,6 +14,8 @@ use stripper_interface::Type as SType;
 use stripper_interface::TypeStruct;
 use stripper_interface::{FILE, /*FILE_COMMENT, */MOD_COMMENT};
 
+mod format;
+
 trait FunctionTraitType {
     fn functions(&self) -> &Vec<Function>;
     fn name(&self) -> &str;
@@ -245,7 +247,7 @@ fn create_fn_doc(w: &mut Write, fn_: &Function, parent: Option<Box<TypeStruct>>)
 }
 
 fn write_lines(w: &mut Write, lines: &str, tabs: &str) -> Result<()> {
-    for line in lines.split("\n") {
+    for line in format::reformat_doc(&lines).split("\n") {
         try!(writeln!(w, "{}/// {}", tabs, line));
     }
     Ok(())

--- a/src/codegen/doc/mod.rs
+++ b/src/codegen/doc/mod.rs
@@ -84,8 +84,7 @@ pub fn generate(env: &Env) {
 }
 
 fn generate_doc(mut w: &mut Write, env: &Env) -> Result<()> {
-    //try!(create_sub_docs(&mut output, &namespace.constants, None));
-    let namespace_name = env.library.namespace(MAIN).name.clone();
+    let namespace = env.library.namespace(MAIN);
     for obj in env.config.objects.values() {
         if !obj.status.need_generate() {
             continue;
@@ -104,26 +103,26 @@ fn generate_doc(mut w: &mut Write, env: &Env) -> Result<()> {
         });
         try!(writeln!(w, "{}src/auto/{}.rs", FILE, mod_name));
         try!(handle_type(w, &env.library.type_(class_analysis.type_id), None, has_trait,
-                         true, &namespace_name));
+                         true, &env));
     }
 
-    let namespace = env.library.namespace(MAIN);
     for ty in namespace.types.iter().filter_map(|t| t.as_ref()) {
-        try!(handle_type(&mut w, &ty, None, false, false, &namespace_name));
+        try!(handle_type(&mut w, &ty, None, false, false, &env));
     }
     Ok(())
 }
 
 fn handle_type(w: &mut Write, ty: &LType, parent: Option<Box<TypeStruct>>,
-               has_trait: bool, handle_structs: bool, namespace_name: &str) -> Result<()> {
+               has_trait: bool, handle_structs: bool,
+               env: &Env) -> Result<()> {
     match *ty {
-        LType::Alias(ref a) => create_sub_doc(w, a, parent, namespace_name),
-        LType::Enumeration(ref e) => create_enum_doc(w, &e, parent, namespace_name),
-        LType::Function(ref f) => create_fn_doc(w, &f, parent, namespace_name),
+        LType::Alias(ref a) => create_sub_doc(w, a, parent, env),
+        LType::Enumeration(ref e) => create_enum_doc(w, &e, parent, env),
+        LType::Function(ref f) => create_fn_doc(w, &f, parent, env),
         LType::Interface(ref i) if handle_structs => create_class_doc(w, i, parent, has_trait,
-                                                                      namespace_name),
+                                                                      env),
         LType::Class(ref c) if handle_structs => create_class_doc(w, c, parent, has_trait,
-                                                                  namespace_name),
+                                                                  env),
         _ => Ok(()),
     }
 }
@@ -131,7 +130,7 @@ fn handle_type(w: &mut Write, ty: &LType, parent: Option<Box<TypeStruct>>,
 fn create_class_doc<T: FunctionTraitType + ToStripperType>(w: &mut Write, class: &T,
                                                            parent: Option<Box<TypeStruct>>,
                                                            has_trait: bool,
-                                                           namespace_name: &str)
+                                                           env: &Env)
                                                           -> Result<()> {
     let tabs : String = primitives::tabs(compute_indent(&parent));
     let mut ty = class.convert();
@@ -143,16 +142,16 @@ fn create_class_doc<T: FunctionTraitType + ToStripperType>(w: &mut Write, class:
     }
 
     if let Some(ref class_doc) = class.doc() {
-        try!(write_lines(w, &class_doc, &tabs, &namespace_name));
+        try!(write_lines(w, &class_doc, &tabs, env));
     }
     if let Some(ref class_doc) = class.doc_deprecated() {
         try!(write_header(w, &tabs, "Deprecated"));
-        try!(write_lines(w, &class_doc, &tabs, &namespace_name));
+        try!(write_lines(w, &class_doc, &tabs, env));
     }
 
     for function in class.functions().iter() {
         if function.parameters.iter().any(|p| p.instance_parameter) == false {
-            try!(create_fn_doc(w, &function, Some(Box::new(ty.clone())), namespace_name));
+            try!(create_fn_doc(w, &function, Some(Box::new(ty.clone())), env));
         }
     }
     if has_trait {
@@ -161,7 +160,7 @@ fn create_class_doc<T: FunctionTraitType + ToStripperType>(w: &mut Write, class:
 
         for function in class.functions().iter() {
             if function.parameters.iter().any(|p| p.instance_parameter) {
-                try!(create_fn_doc(w, &function, Some(Box::new(ty.clone())), namespace_name));
+                try!(create_fn_doc(w, &function, Some(Box::new(ty.clone())), env));
             }
         }
     }
@@ -170,7 +169,7 @@ fn create_class_doc<T: FunctionTraitType + ToStripperType>(w: &mut Write, class:
 
 fn create_enum_doc(w: &mut Write, enum_: &Enumeration,
                    parent: Option<Box<TypeStruct>>,
-                   namespace_name: &str) -> Result<()> {
+                   env: &Env) -> Result<()> {
     let indent = compute_indent(&parent);
     let mut ty = enum_.convert();
     ty.parent = parent;
@@ -181,11 +180,11 @@ fn create_enum_doc(w: &mut Write, enum_: &Enumeration,
     }
 
     if let Some(ref enum_doc) = enum_.doc() {
-        try!(write_lines(w, &enum_doc, &tabs, &namespace_name));
+        try!(write_lines(w, &enum_doc, &tabs, env));
     }
     if let Some(ref enum_doc) = enum_.doc_deprecated() {
         try!(write_header(w, &tabs, "Deprecated"));
-        try!(write_lines(w, &enum_doc, &tabs, &namespace_name));
+        try!(write_lines(w, &enum_doc, &tabs, env));
     }
 
     let tabs : String = primitives::tabs(indent + 1);
@@ -197,18 +196,18 @@ fn create_enum_doc(w: &mut Write, enum_: &Enumeration,
             try!(writeln!(w, "{}{}", MOD_COMMENT, sub_ty));
         }
         if let Some(ref m_doc) = member_doc.doc() {
-            try!(write_lines(w, &m_doc, &tabs, &namespace_name));
+            try!(write_lines(w, &m_doc, &tabs, env));
         }
         if let Some(ref m_doc) = member_doc.doc_deprecated() {
             try!(write_header(w, &tabs, "Deprecated"));
-            try!(write_lines(w, &m_doc, &tabs, &namespace_name));
+            try!(write_lines(w, &m_doc, &tabs, env));
         }
     }
     Ok(())
 }
 
 fn create_fn_doc(w: &mut Write, fn_: &Function, parent: Option<Box<TypeStruct>>,
-                 namespace_name: &str) -> Result<()> {
+                 env: &Env) -> Result<()> {
     let tabs : String = primitives::tabs(compute_indent(&parent) + 1);
 
     if fn_.doc().is_none() && fn_.doc_deprecated().is_none() && fn_.ret.doc().is_none() {
@@ -223,11 +222,11 @@ fn create_fn_doc(w: &mut Write, fn_: &Function, parent: Option<Box<TypeStruct>>,
     try!(writeln!(w, "{}{}", MOD_COMMENT, sub_ty));
 
     if let Some(ref docs) = fn_.doc() {
-        try!(write_lines(w, &docs, &tabs, &namespace_name));
+        try!(write_lines(w, &docs, &tabs, env));
     };
     if let Some(ref docs) = fn_.doc_deprecated() {
         try!(write_header(w, &tabs, "Deprecated"));
-        try!(write_lines(w, &docs, &tabs, &namespace_name));
+        try!(write_lines(w, &docs, &tabs, env));
     };
 
     if fn_.parameters.iter().any(|x| {
@@ -241,20 +240,20 @@ fn create_fn_doc(w: &mut Write, fn_: &Function, parent: Option<Box<TypeStruct>>,
         }
         if let Some(ref parameter_doc) = parameter.doc() {
             try!(writeln!(w, "{}/// ## {}:", tabs, parameter.name));
-            try!(write_lines(w, &parameter_doc, &tabs, &namespace_name));
+            try!(write_lines(w, &parameter_doc, &tabs, env));
         }
     }
 
     if let Some(ref doc) = fn_.ret.doc() {
         try!(write_header(w, &tabs, "Returns"));
-        try!(write_lines(w, &doc, &tabs, &namespace_name));
+        try!(write_lines(w, &doc, &tabs, env));
     }
     Ok(())
 }
 
 fn write_lines(w: &mut Write, lines: &str, tabs: &str,
-               namespace_name: &str) -> Result<()> {
-    for line in format::reformat_doc(&lines, namespace_name).split("\n") {
+               env: &Env) -> Result<()> {
+    for line in format::reformat_doc(&lines, env).split("\n") {
         try!(writeln!(w, "{}/// {}", tabs, line));
     }
     Ok(())
@@ -262,7 +261,7 @@ fn write_lines(w: &mut Write, lines: &str, tabs: &str,
 
 fn create_sub_doc<T: ToStripperType>(w: &mut Write, ty: &T,
                                      parent: Option<Box<TypeStruct>>,
-                                     namespace_name: &str) -> Result<()> {
+                                     env: &Env) -> Result<()> {
     let tabs : String = primitives::tabs(compute_indent(&parent));
     let mut sub_ty = ty.convert();
     sub_ty.parent = parent;
@@ -272,11 +271,11 @@ fn create_sub_doc<T: ToStripperType>(w: &mut Write, ty: &T,
     }
 
     if let Some(doc) = ty.doc() {
-        try!(write_lines(w, &doc, &tabs, &namespace_name));
+        try!(write_lines(w, &doc, &tabs, env));
     }
     if let Some(doc) = ty.doc_deprecated() {
         try!(write_header(w, &tabs, "Deprecated"));
-        try!(write_lines(w, &doc, &tabs, &namespace_name));
+        try!(write_lines(w, &doc, &tabs, env));
     }
     Ok(())
 }


### PR DESCRIPTION
I'll need to improve the regex part because for now, only "#Gtk" objects are replaced in their rust equivalent (the problem is with code blocks, I don't want them to change the C-name to rust-name).

#203 