### PR TITLE
Drop version detection in favor of features, add version support for enum variants

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ rust:
 addons:
   apt:
     packages:
-    - libgtk-3-dev
     - libssh2-1-dev
 script:
   - cargo build --release

--- a/src/codegen/function.rs
+++ b/src/codegen/function.rs
@@ -38,8 +38,7 @@ pub fn generate(w: &mut Write, env: &Env, analysis: &analysis::functions::Info,
 
     try!(writeln!(w, ""));
     try!(cfg_condition(w, &analysis.cfg_condition, commented, indent));
-    try!(version_condition(w, &env.config.library_name,
-        env.config.min_cfg_version, analysis.version, commented, indent));
+    try!(version_condition(w, env.config.min_cfg_version, analysis.version, commented, indent));
     try!(writeln!(w, "{}{}{}{}{}", tabs(indent),
         comment_prefix, pub_prefix, declaration, suffix));
 

--- a/src/codegen/general.rs
+++ b/src/codegen/general.rs
@@ -6,7 +6,6 @@ use analysis::imports::Imports;
 use config::Config;
 use git::repo_hash;
 use gir_version::VERSION;
-use nameutil::crate_name;
 use version::Version;
 use writer::primitives::tabs;
 
@@ -18,11 +17,11 @@ pub fn start_comments(w: &mut Write, conf: &Config) -> Result<()>{
     Ok(())
 }
 
-pub fn uses(w: &mut Write, imports: &Imports, library_name: &str, min_cfg_version: Version)
+pub fn uses(w: &mut Write, imports: &Imports, min_cfg_version: Version)
         -> Result<()>{
     try!(writeln!(w, ""));
     for (name, version) in imports.iter() {
-        try!(version_condition(w, library_name, min_cfg_version, version.clone(), false, 0));
+        try!(version_condition(w, min_cfg_version, version.clone(), false, 0));
         try!(writeln!(w, "use {};", name));
     }
 
@@ -70,22 +69,21 @@ pub fn define_boxed_type(w: &mut Write, type_name: &str, glib_name: &str,
     Ok(())
 }
 
-pub fn version_condition(w: &mut Write, library_name: &str, min_cfg_version: Version,
+pub fn version_condition(w: &mut Write, min_cfg_version: Version,
         version: Option<Version>, commented: bool, indent: usize) -> Result<()> {
-    let s = version_condition_string(library_name, min_cfg_version, version, commented, indent);
+    let s = version_condition_string(min_cfg_version, version, commented, indent);
     if let Some(s) = s {
         try!(writeln!(w, "{}", s));
     }
     Ok(())
 }
 
-pub fn version_condition_string(library_name: &str, min_cfg_version: Version,
+pub fn version_condition_string(min_cfg_version: Version,
         version: Option<Version>, commented: bool, indent: usize) -> Option<String> {
     match version {
         Some(v) if v >= min_cfg_version => {
             let comment = if commented { "//" } else { "" };
-            Some(format!("{}{}#[cfg({})]", tabs(indent), comment,
-                v.to_cfg(&crate_name(library_name))))
+            Some(format!("{}{}#[cfg({})]", tabs(indent), comment, v.to_cfg()))
         }
         _ => None
     }

--- a/src/codegen/general.rs
+++ b/src/codegen/general.rs
@@ -81,7 +81,7 @@ pub fn version_condition(w: &mut Write, min_cfg_version: Version,
 pub fn version_condition_string(min_cfg_version: Version,
         version: Option<Version>, commented: bool, indent: usize) -> Option<String> {
     match version {
-        Some(v) if v >= min_cfg_version => {
+        Some(v) if v > min_cfg_version => {
             let comment = if commented { "//" } else { "" };
             Some(format!("{}{}#[cfg({})]", tabs(indent), comment, v.to_cfg()))
         }

--- a/src/codegen/object.rs
+++ b/src/codegen/object.rs
@@ -10,7 +10,7 @@ pub fn generate(w: &mut Write, env: &Env, analysis: &analysis::object::Info) -> 
         .chain(analysis.implements.iter())
         .collect();
     try!(general::start_comments(w, &env.config));
-    try!(general::uses(w, &analysis.imports, &env.config.library_name, env.config.min_cfg_version));
+    try!(general::uses(w, &analysis.imports, env.config.min_cfg_version));
     try!(general::define_object_type(w, &analysis.name, &analysis.c_type, &analysis.get_type,
         &implements));
 
@@ -68,8 +68,7 @@ pub fn generate_reexports(env: &Env, analysis: &analysis::object::Info, module_n
     if let Some(cfg) = general::cfg_condition_string(&analysis.cfg_condition, false, 0) {
         cfgs.push(cfg);
     }
-    if let Some(cfg) = general::version_condition_string(&env.config.library_name,
-                                                         env.config.min_cfg_version,
+    if let Some(cfg) = general::version_condition_string(env.config.min_cfg_version,
                                                          analysis.version, false, 0) {
         cfgs.push(cfg);
     }

--- a/src/codegen/record.rs
+++ b/src/codegen/record.rs
@@ -9,7 +9,7 @@ pub fn generate(w: &mut Write, env: &Env, analysis: &analysis::record::Info) -> 
     let type_ = analysis.type_(&env.library);
 
     try!(general::start_comments(w, &env.config));
-    try!(general::uses(w, &analysis.imports, &env.config.library_name, env.config.min_cfg_version));
+    try!(general::uses(w, &analysis.imports, env.config.min_cfg_version));
 
     let copy_fn = analysis.specials.get(&Type::Copy).expect("No copy function for record");
     let free_fn = analysis.specials.get(&Type::Free).expect("No free function for record");
@@ -31,8 +31,8 @@ pub fn generate(w: &mut Write, env: &Env, analysis: &analysis::record::Info) -> 
 pub fn generate_reexports(env: &Env, analysis: &analysis::record::Info, module_name: &str,
                           contents: &mut Vec<String>) {
     let cfg_condition = general::cfg_condition_string(&analysis.cfg_condition, false, 0);
-    let version_cfg = general::version_condition_string(&env.config.library_name,
-        env.config.min_cfg_version, analysis.version, false, 0);
+    let version_cfg = general::version_condition_string(env.config.min_cfg_version,
+                                                        analysis.version, false, 0);
     let mut cfg = String::new();
     if let Some(s) = cfg_condition {
         cfg.push_str(&s);

--- a/src/codegen/sys/build.rs
+++ b/src/codegen/sys/build.rs
@@ -2,7 +2,6 @@ use std::io::{Result, Write};
 
 use env::Env;
 use file_saver::save_to_file;
-use version::Version;
 
 pub fn generate(env: &Env) {
     println!("generating sys build script for {}", env.config.library_name);
@@ -11,59 +10,9 @@ pub fn generate(env: &Env) {
 
     println!("Generating file {:?}", path);
     save_to_file(&path, env.config.make_backup,
-        |w| generate_build_script(w, env));
+        |w| generate_build_script(w));
 }
 
-fn generate_build_script(w: &mut Write, env: &Env) -> Result<()> {
-    try!(writeln!(w, "{}", "extern crate pkg_config;\n"));
-
-    let ns = env.namespaces.main();
-    try!(writeln!(w, "const LIBRARY_NAME: &'static str = \"{}\";", ns.crate_name));
-    try!(writeln!(w, "const PACKAGE_NAME: &'static str = \"{}\";",
-                  ns.package_name.as_ref().unwrap()));
-    try!(writeln!(w, "const VERSIONS: &'static [Version] = &["));
-    let versions = ns.versions.iter()
-        .filter(|v| **v >= env.config.min_cfg_version);
-    for &Version(major, minor, patch) in versions {
-        try!(writeln!(w, "\tVersion({}, {}, {}),", major, minor, patch));
-    }
-    try!(writeln!(w, "];"));
-
-    writeln!(w, "{}",
-r##"
-fn main() {
-    let lib = pkg_config::find_library(PACKAGE_NAME)
-        .unwrap_or_else(|e| panic!("{}", e));
-    let version = Version::new(&lib.version);
-    let mut cfgs = Vec::new();
-    for v in VERSIONS.iter().filter(|&&v| v <= version) {
-        let cfg = v.to_cfg();
-        println!("cargo:rustc-cfg={}", cfg);
-        cfgs.push(cfg);
-    }
-    println!("cargo:cfg={}", cfgs.join(" "));
-}
-
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-struct Version(pub u16, pub u16, pub u16);
-
-impl Version {
-    fn new(s: &str) -> Version {
-        let mut parts = s.splitn(4, '.')
-            .map(|s| s.parse())
-            .take_while(Result::is_ok)
-            .map(Result::unwrap);
-        Version(parts.next().unwrap_or(0),
-            parts.next().unwrap_or(0), parts.next().unwrap_or(0))
-    }
-
-    fn to_cfg(&self) -> String {
-        match *self {
-            Version(major, minor, 0) => format!("{}_{}_{}", LIBRARY_NAME, major, minor),
-            Version(major, minor, patch) =>
-                format!("{}_{}_{}_{}", LIBRARY_NAME, major, minor, patch),
-        }
-    }
-}
-"##)
+fn generate_build_script(w: &mut Write) -> Result<()> {
+    writeln!(w, "{}", "fn main() {{ }}")
 }

--- a/src/codegen/sys/cargo_toml.rs
+++ b/src/codegen/sys/cargo_toml.rs
@@ -68,6 +68,8 @@ fn fill_in(root: &mut Table, env: &Env) {
         set_string(deps, "libc", "0.1");
     }
 
+    root.remove("build-dependencies");
+
     {
         let build_deps = upsert_table(root, "build-dependencies");
         set_string(build_deps, "pkg-config", "0.3.5");

--- a/src/codegen/sys/cargo_toml.rs
+++ b/src/codegen/sys/cargo_toml.rs
@@ -6,6 +6,7 @@ use toml::{self, Parser, Table, Value};
 use env::Env;
 use file_saver::save_to_file;
 use nameutil::crate_name;
+use version::Version;
 
 pub fn generate(env: &Env) {
     println!("manipulating sys Cargo.toml for {}", env.config.library_name);
@@ -71,8 +72,17 @@ fn fill_in(root: &mut Table, env: &Env) {
     root.remove("build-dependencies");
 
     {
-        let build_deps = upsert_table(root, "build-dependencies");
-        set_string(build_deps, "pkg-config", "0.3.5");
+        let features = upsert_table(root, "features");
+        features.clear();
+        let versions = env.namespaces.main().versions.iter()
+            .filter(|&&v| v > env.config.min_cfg_version);
+        versions.fold(None::<Version>, |prev, &version| {
+            let prev_array: Vec<Value> = prev.iter()
+                .map(|v| Value::String(v.to_string()))
+                .collect();
+            features.insert(version.to_string(), Value::Array(prev_array));
+            Some(version)
+        });
     }
 }
 

--- a/src/codegen/sys/cargo_toml.rs
+++ b/src/codegen/sys/cargo_toml.rs
@@ -65,8 +65,8 @@ fn fill_in(root: &mut Table, env: &Env) {
 
     {
         let deps = upsert_table(root, "dependencies");
-        set_string(deps, "bitflags", "0.3");
-        set_string(deps, "libc", "0.1");
+        set_string(deps, "bitflags", "0.4");
+        set_string(deps, "libc", "0.2");
     }
 
     root.remove("build-dependencies");

--- a/src/codegen/sys/functions.rs
+++ b/src/codegen/sys/functions.rs
@@ -1,11 +1,11 @@
 use std::collections::HashMap;
 use std::io::{Result, Write};
 
+use codegen::general::version_condition;
 use env::Env;
 use library;
 use nameutil;
 use super::ffi_type::*;
-use super::super::general::version_condition;
 use traits::*;
 
 //used as glib:get-type in GLib-2.0.gir
@@ -90,15 +90,13 @@ fn generate_object_funcs(w: &mut Write, env: &Env, c_type: &str,
     for func in functions {
         let (commented, sig) = function_signature(env, func, false);
         let comment = if commented { "//" } else { "" };
-        try!(version_condition(w, &env.config.library_name,
-            env.config.min_cfg_version, func.version, commented, 1));
+        try!(version_condition(w, env.config.min_cfg_version, func.version, commented, 1));
         let name = func.c_identifier.as_ref().unwrap();
         // since we work with gir-files from Linux, some function names need to be adjusted
         if let Some(win_name) = RENAME_ON_WINDOWS.get(&name[..]) {
             try!(writeln!(w, "    {}#[cfg(windows)]", comment));
             try!(writeln!(w, "    {}pub fn {}{};", comment, win_name, sig));
-            try!(version_condition(w, &env.config.library_name,
-                env.config.min_cfg_version, func.version, commented, 1));
+            try!(version_condition(w, env.config.min_cfg_version, func.version, commented, 1));
             try!(writeln!(w, "    {}#[cfg(not(windows))]", comment));
         }
         try!(writeln!(w, "    {}pub fn {}{};", comment, name, sig));

--- a/src/config/gobjects.rs
+++ b/src/config/gobjects.rs
@@ -4,6 +4,7 @@ use std::str::FromStr;
 use toml::Value;
 
 use super::functions::Functions;
+use super::members::Members;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum GStatus {
@@ -47,6 +48,7 @@ impl FromStr for GStatus {
 pub struct GObject {
     pub name: String,
     pub functions: Functions,
+    pub members: Members,
     pub status: GStatus,
     pub module_name: Option<String>,
     pub cfg_condition: Option<String>,
@@ -57,6 +59,7 @@ impl Default for GObject {
         GObject {
             name: "Default".into(),
             functions: Functions::new(),
+            members: Members::new(),
             status: Default::default(),
             module_name: None,
             cfg_condition: None,
@@ -86,6 +89,7 @@ fn parse_object(toml_object: &Value) -> GObject {
     };
 
     let functions = Functions::parse(toml_object.lookup("function"), &name);
+    let members = Members::parse(toml_object.lookup("member"), &name);
     let module_name = toml_object.lookup("module_name")
         .and_then(|v| v.as_str())
         .map(|s| s.to_owned());
@@ -96,6 +100,7 @@ fn parse_object(toml_object: &Value) -> GObject {
     GObject {
         name: name,
         functions: functions,
+        members: members,
         status: status,
         module_name: module_name,
         cfg_condition: cfg_condition,

--- a/src/config/ident.rs
+++ b/src/config/ident.rs
@@ -1,0 +1,33 @@
+use regex::Regex;
+use toml::Value;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum Ident {
+    Name(String),
+    Pattern(Regex),
+}
+
+impl Ident {
+    pub fn parse(toml: &Value, object_name: &str, what: &str) -> Option<Ident> {
+        match toml.lookup("pattern").and_then(|v| v.as_str()) {
+            Some(s) => Regex::new(s)
+                .map(|r| Ident::Pattern(r))
+                .map_err(|e| {
+                    error!("Bad pattern `{}` in {} for `{}`: {}", s, what, object_name, e);
+                    e
+                })
+                .ok(),
+            None => toml.lookup("name")
+                .and_then(|val| val.as_str())
+                .map(|s| Ident::Name(s.into())),
+        }
+    }
+
+    pub fn is_match(&self, name: &str) -> bool {
+        use self::Ident::*;
+        match *self {
+            Name(ref n) => name == n,
+            Pattern(ref regex) => regex.is_match(name),
+        }
+    }
+}

--- a/src/config/members.rs
+++ b/src/config/members.rs
@@ -1,0 +1,106 @@
+use super::ident::Ident;
+use toml::Value;
+use version::Version;
+
+#[derive(Clone, Debug)]
+pub struct Member {
+    pub ident: Ident,
+    // some enum variants have multiple names
+    pub alias: bool,
+    pub version: Option<Version>,
+}
+
+impl Member {
+    pub fn parse(toml: &Value, object_name: &str) -> Option<Member> {
+        let ident = match Ident::parse(toml, object_name, "member") {
+            Some(ident) => ident,
+            None => {
+                error!("No 'name' or 'pattern' given for member for object {}", object_name);
+                return None
+            }
+        };
+        let alias = toml.lookup("alias")
+            .and_then(|val| val.as_bool())
+            .unwrap_or(false);
+        let version = toml.lookup("version")
+            .and_then(|v| v.as_str())
+            .and_then(|s| s.parse().ok());
+
+        Some(Member{
+            ident: ident,
+            alias: alias,
+            version: version,
+        })
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct Members(Vec<Member>);
+
+impl Members {
+    pub fn new() -> Members {
+        Members(Vec::new())
+    }
+
+    pub fn parse(toml: Option<&Value>, object_name: &str) -> Members {
+        let mut v = Vec::new();
+        if let Some(items) = toml.and_then(|val| val.as_slice()) {
+            for item in items {
+                if let Some(item) = Member::parse(item, object_name) {
+                    v.push(item);
+                }
+            }
+        }
+
+        Members(v)
+    }
+
+    pub fn matched(&self, member_name: &str) -> Vec<&Member> {
+        self.0.iter().filter(|m| m.ident.is_match(member_name)).collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::ident::Ident;
+    use super::*;
+    use toml;
+    use version::Version;
+
+    fn toml(input: &str) -> toml::Value {
+        let mut parser = toml::Parser::new(&input);
+        let value = parser.parse();
+        assert!(value.is_some());
+        toml::Value::Table(value.unwrap())
+    }
+
+    #[test]
+    fn member_parse_alias() {
+        let toml = toml(r#"
+name = "name1"
+alias = true
+"#);
+        let f = Member::parse(&toml, "a").unwrap();
+        assert_eq!(f.ident, Ident::Name("name1".into()));
+        assert_eq!(f.alias, true);
+    }
+
+    #[test]
+    fn member_parse_version_default() {
+        let toml = toml(r#"
+name = "name1"
+"#);
+        let f = Member::parse(&toml, "a").unwrap();
+        assert_eq!(f.version, None);
+    }
+
+    #[test]
+    fn member_parse_version() {
+        let toml = toml(r#"
+name = "name1"
+version = "3.20"
+"#);
+        let f = Member::parse(&toml, "a").unwrap();
+        assert_eq!(f.version, Some(Version(3, 20, 0)));
+    }
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -3,6 +3,7 @@ pub mod error;
 pub mod functions;
 pub mod gobjects;
 pub mod ident;
+pub mod members;
 pub mod work_mode;
 
 pub use self::config::Config;

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2,6 +2,7 @@ pub mod config;
 pub mod error;
 pub mod functions;
 pub mod gobjects;
+pub mod ident;
 pub mod work_mode;
 
 pub use self::config::Config;

--- a/src/version.rs
+++ b/src/version.rs
@@ -6,12 +6,8 @@ use std::str::FromStr;
 pub struct Version(pub u16, pub u16, pub u16);
 
 impl Version {
-    pub fn to_cfg(&self, crate_name: &str) -> String {
-        match *self {
-            Version(major, minor, 0) => format!("{}_{}_{}", crate_name, major, minor),
-            Version(major, minor, patch) =>
-                format!("{}_{}_{}_{}", crate_name, major, minor, patch),
-        }
+    pub fn to_cfg(&self) -> String {
+        format!("feature = \"{}\"", self)
     }
 }
 
@@ -31,7 +27,10 @@ impl FromStr for Version {
 
 impl Display for Version {
     fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {
-        write!(f, "{}.{}.{}", self.0, self.1, self.2)
+        match *self {
+            Version(major, minor, 0) => write!(f, "{}.{}", major, minor),
+            Version(major, minor, patch) => write!(f, "{}.{}.{}", major, minor, patch),
+        }
     }
 }
 

--- a/tests/sys/gir-gdk.toml
+++ b/tests/sys/gir-gdk.toml
@@ -13,3 +13,22 @@ external_libraries = [
    "Pango",
    "Cairo",
 ]
+
+[[object]]
+name = "Gdk.EventType"
+status = "generate"
+    [[object.member]]
+    name = "2button_press"
+    alias = true
+    [[object.member]]
+    name = "3button_press"
+    alias = true
+    [[object.member]]
+    name = "touchpad_swipe"
+    version = "3.18"
+    [[object.member]]
+    name = "touchpad_pinch"
+    version = "3.18"
+    [[object.member]]
+    name = "event_last"
+    alias = true

--- a/tests/sys/sys_build/Cargo.toml
+++ b/tests/sys/sys_build/Cargo.toml
@@ -12,6 +12,7 @@ full = [
 
 [dependencies.gtk-sys]
 path = "../gtk-sys"
+features = ["3.16"]
 
 [dependencies.secret-sys]
 optional = true

--- a/tests/sys/sys_build/Cargo.toml
+++ b/tests/sys/sys_build/Cargo.toml
@@ -5,15 +5,9 @@ version = "0.0.1"
 [lib]
 name = "sys_build"
 
-[features]
-full = [
-	"secret-sys",
-]
-
 [dependencies.gtk-sys]
 path = "../gtk-sys"
 features = ["3.16"]
 
 [dependencies.secret-sys]
-optional = true
 path = "../secret-sys"

--- a/tests/sys/test.sh
+++ b/tests/sys/test.sh
@@ -1,10 +1,6 @@
 #!/bin/sh
 
 GIR="cargo run --release --"
-FEATURES=""
-if [ "$1" = "full" ]; then
-	FEATURES="$FEATURES full"
-fi
 export RUST_LOG="gir=warn"
 
 cd "`dirname $0`"
@@ -15,5 +11,5 @@ for TOML in gir-*.toml; do
 done
 
 cd sys_build
-cargo build --features "$FEATURES" || exit 3
+cargo build || exit 3
 cd ..


### PR DESCRIPTION
This should ensure better API stability control as described in https://github.com/gtk-rs/gtk/issues/243 (new upstream library versions support should not introduce breaking changes in code that sticks to earlier versions).