### PR TITLE
Version reform

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,31 @@
+environment:
+  matrix:
+    - RUST_VERSION: 1.6.0
+      BITS: 32
+    - RUST_VERSION: 1.6.0
+      BITS: 64
+
+install:
+  - IF "%BITS%" == "32" SET ARCH=i686
+  - IF "%BITS%" == "64" SET ARCH=x86_64
+  - ps: Start-FileDownload "https://static.rust-lang.org/dist/rust-${env:RUST_VERSION}-${env:ARCH}-pc-windows-gnu.exe" -FileName rust-dist.exe
+  - rust-dist.exe /VERYSILENT /NORESTART /COMPONENTS="Rustc,Gcc,Cargo,Std" /DIR="C:\Rust"
+  - SET PATH=C:\Rust\bin;C:\Program Files\Git\cmd;C:\Program Files\Git\usr\bin
+  - SET PATH=C:\msys64\mingw%BITS%\bin;C:\msys64\usr\bin;%PATH%
+  - pacman --noconfirm -S mingw-w64-%ARCH%-gtk3
+  - SET GTK_LIB_DIR=C:\msys64\mingw%BITS%\lib
+
+build_script:
+  - git clone -q https://github.com/gkoz/gir-files tests/gir-files
+  - rustc -V
+  - cargo build --release
+  - cargo test --release
+  - ps: >-
+      foreach ($file in Get-ChildItem "tests\sys\gir-*.toml") {
+          cargo run --release -- -c $file
+      }
+  - cd tests\sys\sys_build
+  - cargo build
+  - cargo build --features 3.16
+
+test: false

--- a/src/analysis/namespaces.rs
+++ b/src/analysis/namespaces.rs
@@ -13,6 +13,7 @@ pub struct Namespace {
     pub name: String,
     pub crate_name: String,
     pub package_name: Option<String>,
+    pub shared_libs: Vec<String>,
     pub versions: Vec<Version>,
 }
 
@@ -54,6 +55,7 @@ pub fn run(gir: &library::Library) -> Info {
             name: ns.name.clone(),
             crate_name: nameutil::crate_name(&ns.name),
             package_name: ns.package_name.clone(),
+            shared_libs: ns.shared_library.clone(),
             versions: ns.versions.iter().cloned().collect(),
         });
         //name_index.insert(ns.name.clone(), ns_id);

--- a/src/codegen/function.rs
+++ b/src/codegen/function.rs
@@ -38,8 +38,7 @@ pub fn generate(w: &mut Write, env: &Env, analysis: &analysis::functions::Info,
 
     try!(writeln!(w, ""));
     try!(cfg_condition(w, &analysis.cfg_condition, commented, indent));
-    try!(version_condition(w, &env.config.library_name,
-        env.config.min_cfg_version, analysis.version, commented, indent));
+    try!(version_condition(w, env.config.min_cfg_version, analysis.version, commented, indent));
     try!(writeln!(w, "{}{}{}{}{}", tabs(indent),
         comment_prefix, pub_prefix, declaration, suffix));
 

--- a/src/codegen/general.rs
+++ b/src/codegen/general.rs
@@ -6,7 +6,6 @@ use analysis::imports::Imports;
 use config::Config;
 use git::repo_hash;
 use gir_version::VERSION;
-use nameutil::crate_name;
 use version::Version;
 use writer::primitives::tabs;
 
@@ -18,11 +17,11 @@ pub fn start_comments(w: &mut Write, conf: &Config) -> Result<()>{
     Ok(())
 }
 
-pub fn uses(w: &mut Write, imports: &Imports, library_name: &str, min_cfg_version: Version)
+pub fn uses(w: &mut Write, imports: &Imports, min_cfg_version: Version)
         -> Result<()>{
     try!(writeln!(w, ""));
     for (name, version) in imports.iter() {
-        try!(version_condition(w, library_name, min_cfg_version, version.clone(), false, 0));
+        try!(version_condition(w, min_cfg_version, version.clone(), false, 0));
         try!(writeln!(w, "use {};", name));
     }
 
@@ -70,22 +69,21 @@ pub fn define_boxed_type(w: &mut Write, type_name: &str, glib_name: &str,
     Ok(())
 }
 
-pub fn version_condition(w: &mut Write, library_name: &str, min_cfg_version: Version,
+pub fn version_condition(w: &mut Write, min_cfg_version: Version,
         version: Option<Version>, commented: bool, indent: usize) -> Result<()> {
-    let s = version_condition_string(library_name, min_cfg_version, version, commented, indent);
+    let s = version_condition_string(min_cfg_version, version, commented, indent);
     if let Some(s) = s {
         try!(writeln!(w, "{}", s));
     }
     Ok(())
 }
 
-pub fn version_condition_string(library_name: &str, min_cfg_version: Version,
+pub fn version_condition_string(min_cfg_version: Version,
         version: Option<Version>, commented: bool, indent: usize) -> Option<String> {
     match version {
         Some(v) if v >= min_cfg_version => {
             let comment = if commented { "//" } else { "" };
-            Some(format!("{}{}#[cfg({})]", tabs(indent), comment,
-                v.to_cfg(&crate_name(library_name))))
+            Some(format!("{}{}#[cfg({})]", tabs(indent), comment, v.to_cfg()))
         }
         _ => None
     }

--- a/src/codegen/general.rs
+++ b/src/codegen/general.rs
@@ -81,7 +81,7 @@ pub fn version_condition(w: &mut Write, min_cfg_version: Version,
 pub fn version_condition_string(min_cfg_version: Version,
         version: Option<Version>, commented: bool, indent: usize) -> Option<String> {
     match version {
-        Some(v) if v >= min_cfg_version => {
+        Some(v) if v > min_cfg_version => {
             let comment = if commented { "//" } else { "" };
             Some(format!("{}{}#[cfg({})]", tabs(indent), comment, v.to_cfg()))
         }

--- a/src/codegen/object.rs
+++ b/src/codegen/object.rs
@@ -10,7 +10,7 @@ pub fn generate(w: &mut Write, env: &Env, analysis: &analysis::object::Info) -> 
         .chain(analysis.implements.iter())
         .collect();
     try!(general::start_comments(w, &env.config));
-    try!(general::uses(w, &analysis.imports, &env.config.library_name, env.config.min_cfg_version));
+    try!(general::uses(w, &analysis.imports, env.config.min_cfg_version));
     try!(general::define_object_type(w, &analysis.name, &analysis.c_type, &analysis.get_type,
         &implements));
 
@@ -68,8 +68,7 @@ pub fn generate_reexports(env: &Env, analysis: &analysis::object::Info, module_n
     if let Some(cfg) = general::cfg_condition_string(&analysis.cfg_condition, false, 0) {
         cfgs.push(cfg);
     }
-    if let Some(cfg) = general::version_condition_string(&env.config.library_name,
-                                                         env.config.min_cfg_version,
+    if let Some(cfg) = general::version_condition_string(env.config.min_cfg_version,
                                                          analysis.version, false, 0) {
         cfgs.push(cfg);
     }

--- a/src/codegen/record.rs
+++ b/src/codegen/record.rs
@@ -9,7 +9,7 @@ pub fn generate(w: &mut Write, env: &Env, analysis: &analysis::record::Info) -> 
     let type_ = analysis.type_(&env.library);
 
     try!(general::start_comments(w, &env.config));
-    try!(general::uses(w, &analysis.imports, &env.config.library_name, env.config.min_cfg_version));
+    try!(general::uses(w, &analysis.imports, env.config.min_cfg_version));
 
     let copy_fn = analysis.specials.get(&Type::Copy).expect("No copy function for record");
     let free_fn = analysis.specials.get(&Type::Free).expect("No free function for record");
@@ -31,8 +31,8 @@ pub fn generate(w: &mut Write, env: &Env, analysis: &analysis::record::Info) -> 
 pub fn generate_reexports(env: &Env, analysis: &analysis::record::Info, module_name: &str,
                           contents: &mut Vec<String>) {
     let cfg_condition = general::cfg_condition_string(&analysis.cfg_condition, false, 0);
-    let version_cfg = general::version_condition_string(&env.config.library_name,
-        env.config.min_cfg_version, analysis.version, false, 0);
+    let version_cfg = general::version_condition_string(env.config.min_cfg_version,
+                                                        analysis.version, false, 0);
     let mut cfg = String::new();
     if let Some(s) = cfg_condition {
         cfg.push_str(&s);

--- a/src/codegen/sys/cargo_toml.rs
+++ b/src/codegen/sys/cargo_toml.rs
@@ -6,6 +6,7 @@ use toml::{self, Parser, Table, Value};
 use env::Env;
 use file_saver::save_to_file;
 use nameutil::crate_name;
+use version::Version;
 
 pub fn generate(env: &Env) {
     println!("manipulating sys Cargo.toml for {}", env.config.library_name);
@@ -71,6 +72,20 @@ fn fill_in(root: &mut Table, env: &Env) {
     {
         let build_deps = upsert_table(root, "build-dependencies");
         set_string(build_deps, "pkg-config", "0.3.5");
+    }
+
+    {
+        let features = upsert_table(root, "features");
+        features.clear();
+        let versions = env.namespaces.main().versions.iter()
+            .filter(|&&v| v > env.config.min_cfg_version);
+        versions.fold(None::<Version>, |prev, &version| {
+            let prev_array: Vec<Value> = prev.iter()
+                .map(|v| Value::String(v.to_string()))
+                .collect();
+            features.insert(version.to_string(), Value::Array(prev_array));
+            Some(version)
+        });
     }
 }
 

--- a/src/codegen/sys/cargo_toml.rs
+++ b/src/codegen/sys/cargo_toml.rs
@@ -65,8 +65,8 @@ fn fill_in(root: &mut Table, env: &Env) {
 
     {
         let deps = upsert_table(root, "dependencies");
-        set_string(deps, "bitflags", "0.3");
-        set_string(deps, "libc", "0.1");
+        set_string(deps, "bitflags", "0.4");
+        set_string(deps, "libc", "0.2");
     }
 
     {

--- a/src/codegen/sys/functions.rs
+++ b/src/codegen/sys/functions.rs
@@ -1,11 +1,11 @@
 use std::collections::HashMap;
 use std::io::{Result, Write};
 
+use codegen::general::version_condition;
 use env::Env;
 use library;
 use nameutil;
 use super::ffi_type::*;
-use super::super::general::version_condition;
 use traits::*;
 
 //used as glib:get-type in GLib-2.0.gir
@@ -90,15 +90,13 @@ fn generate_object_funcs(w: &mut Write, env: &Env, c_type: &str,
     for func in functions {
         let (commented, sig) = function_signature(env, func, false);
         let comment = if commented { "//" } else { "" };
-        try!(version_condition(w, &env.config.library_name,
-            env.config.min_cfg_version, func.version, commented, 1));
+        try!(version_condition(w, env.config.min_cfg_version, func.version, commented, 1));
         let name = func.c_identifier.as_ref().unwrap();
         // since we work with gir-files from Linux, some function names need to be adjusted
         if let Some(win_name) = RENAME_ON_WINDOWS.get(&name[..]) {
             try!(writeln!(w, "    {}#[cfg(windows)]", comment));
             try!(writeln!(w, "    {}pub fn {}{};", comment, win_name, sig));
-            try!(version_condition(w, &env.config.library_name,
-                env.config.min_cfg_version, func.version, commented, 1));
+            try!(version_condition(w, env.config.min_cfg_version, func.version, commented, 1));
             try!(writeln!(w, "    {}#[cfg(not(windows))]", comment));
         }
         try!(writeln!(w, "    {}pub fn {}{};", comment, name, sig));

--- a/src/config/gobjects.rs
+++ b/src/config/gobjects.rs
@@ -4,6 +4,7 @@ use std::str::FromStr;
 use toml::Value;
 
 use super::functions::Functions;
+use super::members::Members;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum GStatus {
@@ -47,6 +48,7 @@ impl FromStr for GStatus {
 pub struct GObject {
     pub name: String,
     pub functions: Functions,
+    pub members: Members,
     pub status: GStatus,
     pub module_name: Option<String>,
     pub cfg_condition: Option<String>,
@@ -57,6 +59,7 @@ impl Default for GObject {
         GObject {
             name: "Default".into(),
             functions: Functions::new(),
+            members: Members::new(),
             status: Default::default(),
             module_name: None,
             cfg_condition: None,
@@ -86,6 +89,7 @@ fn parse_object(toml_object: &Value) -> GObject {
     };
 
     let functions = Functions::parse(toml_object.lookup("function"), &name);
+    let members = Members::parse(toml_object.lookup("member"), &name);
     let module_name = toml_object.lookup("module_name")
         .and_then(|v| v.as_str())
         .map(|s| s.to_owned());
@@ -96,6 +100,7 @@ fn parse_object(toml_object: &Value) -> GObject {
     GObject {
         name: name,
         functions: functions,
+        members: members,
         status: status,
         module_name: module_name,
         cfg_condition: cfg_condition,

--- a/src/config/ident.rs
+++ b/src/config/ident.rs
@@ -1,0 +1,33 @@
+use regex::Regex;
+use toml::Value;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum Ident {
+    Name(String),
+    Pattern(Regex),
+}
+
+impl Ident {
+    pub fn parse(toml: &Value, object_name: &str, what: &str) -> Option<Ident> {
+        match toml.lookup("pattern").and_then(|v| v.as_str()) {
+            Some(s) => Regex::new(s)
+                .map(|r| Ident::Pattern(r))
+                .map_err(|e| {
+                    error!("Bad pattern `{}` in {} for `{}`: {}", s, what, object_name, e);
+                    e
+                })
+                .ok(),
+            None => toml.lookup("name")
+                .and_then(|val| val.as_str())
+                .map(|s| Ident::Name(s.into())),
+        }
+    }
+
+    pub fn is_match(&self, name: &str) -> bool {
+        use self::Ident::*;
+        match *self {
+            Name(ref n) => name == n,
+            Pattern(ref regex) => regex.is_match(name),
+        }
+    }
+}

--- a/src/config/members.rs
+++ b/src/config/members.rs
@@ -1,0 +1,106 @@
+use super::ident::Ident;
+use toml::Value;
+use version::Version;
+
+#[derive(Clone, Debug)]
+pub struct Member {
+    pub ident: Ident,
+    // some enum variants have multiple names
+    pub alias: bool,
+    pub version: Option<Version>,
+}
+
+impl Member {
+    pub fn parse(toml: &Value, object_name: &str) -> Option<Member> {
+        let ident = match Ident::parse(toml, object_name, "member") {
+            Some(ident) => ident,
+            None => {
+                error!("No 'name' or 'pattern' given for member for object {}", object_name);
+                return None
+            }
+        };
+        let alias = toml.lookup("alias")
+            .and_then(|val| val.as_bool())
+            .unwrap_or(false);
+        let version = toml.lookup("version")
+            .and_then(|v| v.as_str())
+            .and_then(|s| s.parse().ok());
+
+        Some(Member{
+            ident: ident,
+            alias: alias,
+            version: version,
+        })
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct Members(Vec<Member>);
+
+impl Members {
+    pub fn new() -> Members {
+        Members(Vec::new())
+    }
+
+    pub fn parse(toml: Option<&Value>, object_name: &str) -> Members {
+        let mut v = Vec::new();
+        if let Some(items) = toml.and_then(|val| val.as_slice()) {
+            for item in items {
+                if let Some(item) = Member::parse(item, object_name) {
+                    v.push(item);
+                }
+            }
+        }
+
+        Members(v)
+    }
+
+    pub fn matched(&self, member_name: &str) -> Vec<&Member> {
+        self.0.iter().filter(|m| m.ident.is_match(member_name)).collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::ident::Ident;
+    use super::*;
+    use toml;
+    use version::Version;
+
+    fn toml(input: &str) -> toml::Value {
+        let mut parser = toml::Parser::new(&input);
+        let value = parser.parse();
+        assert!(value.is_some());
+        toml::Value::Table(value.unwrap())
+    }
+
+    #[test]
+    fn member_parse_alias() {
+        let toml = toml(r#"
+name = "name1"
+alias = true
+"#);
+        let f = Member::parse(&toml, "a").unwrap();
+        assert_eq!(f.ident, Ident::Name("name1".into()));
+        assert_eq!(f.alias, true);
+    }
+
+    #[test]
+    fn member_parse_version_default() {
+        let toml = toml(r#"
+name = "name1"
+"#);
+        let f = Member::parse(&toml, "a").unwrap();
+        assert_eq!(f.version, None);
+    }
+
+    #[test]
+    fn member_parse_version() {
+        let toml = toml(r#"
+name = "name1"
+version = "3.20"
+"#);
+        let f = Member::parse(&toml, "a").unwrap();
+        assert_eq!(f.version, Some(Version(3, 20, 0)));
+    }
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -3,6 +3,7 @@ pub mod error;
 pub mod functions;
 pub mod gobjects;
 pub mod ident;
+pub mod members;
 pub mod work_mode;
 
 pub use self::config::Config;

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2,6 +2,7 @@ pub mod config;
 pub mod error;
 pub mod functions;
 pub mod gobjects;
+pub mod ident;
 pub mod work_mode;
 
 pub use self::config::Config;

--- a/src/library.rs
+++ b/src/library.rs
@@ -517,6 +517,7 @@ pub struct Namespace {
     pub versions: BTreeSet<Version>,
     pub doc: Option<String>,
     pub doc_deprecated: Option<String>,
+    pub shared_library: Vec<String>,
 }
 
 impl Namespace {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -99,6 +99,9 @@ impl Library {
         let name = try!(attrs.get("name").ok_or_else(|| mk_error!("Missing namespace name", parser)));
         let ns_id = self.add_namespace(name);
         self.namespace_mut(ns_id).package_name = package;
+        if let Some(s) = attrs.get("shared-library") {
+            self.namespace_mut(ns_id).shared_library = s.split(",").map(String::from).collect();
+        }
         trace!("Reading {}-{}", name, attrs.get("version").unwrap());
         loop {
             let event = try!(parser.next());

--- a/src/version.rs
+++ b/src/version.rs
@@ -6,12 +6,8 @@ use std::str::FromStr;
 pub struct Version(pub u16, pub u16, pub u16);
 
 impl Version {
-    pub fn to_cfg(&self, crate_name: &str) -> String {
-        match *self {
-            Version(major, minor, 0) => format!("{}_{}_{}", crate_name, major, minor),
-            Version(major, minor, patch) =>
-                format!("{}_{}_{}_{}", crate_name, major, minor, patch),
-        }
+    pub fn to_cfg(&self) -> String {
+        format!("feature = \"{}\"", self)
     }
 }
 
@@ -31,7 +27,10 @@ impl FromStr for Version {
 
 impl Display for Version {
     fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {
-        write!(f, "{}.{}.{}", self.0, self.1, self.2)
+        match *self {
+            Version(major, minor, 0) => write!(f, "{}.{}", major, minor),
+            Version(major, minor, patch) => write!(f, "{}.{}.{}", major, minor, patch),
+        }
     }
 }
 

--- a/tests/sys/atk-sys/Cargo.toml
+++ b/tests/sys/atk-sys/Cargo.toml
@@ -3,14 +3,22 @@
 pkg-config = "0.3.5"
 
 [dependencies]
-bitflags = "0.3"
-libc = "0.1"
+bitflags = "0.4"
+libc = "0.2"
 
 [dependencies.glib-sys]
 path = "../glib-sys"
 
 [dependencies.gobject-sys]
 path = "../gobject-sys"
+
+[features]
+"2.10" = ["2.9.4"]
+"2.12" = ["2.10"]
+"2.7.90" = []
+"2.8" = ["2.7.90"]
+"2.9.3" = ["2.8"]
+"2.9.4" = ["2.9.3"]
 
 [lib]
 name = "atk_sys"

--- a/tests/sys/gdk-pixbuf-sys/Cargo.toml
+++ b/tests/sys/gdk-pixbuf-sys/Cargo.toml
@@ -3,8 +3,8 @@
 pkg-config = "0.3.5"
 
 [dependencies]
-bitflags = "0.3"
-libc = "0.1"
+bitflags = "0.4"
+libc = "0.2"
 
 [dependencies.gio-sys]
 path = "../gio-sys"
@@ -14,6 +14,11 @@ path = "../glib-sys"
 
 [dependencies.gobject-sys]
 path = "../gobject-sys"
+
+[features]
+"2.28" = []
+"2.30" = ["2.28"]
+"2.32" = ["2.30"]
 
 [lib]
 name = "gdk_pixbuf_sys"

--- a/tests/sys/gdk-sys/Cargo.toml
+++ b/tests/sys/gdk-sys/Cargo.toml
@@ -3,11 +3,11 @@
 pkg-config = "0.3.5"
 
 [dependencies]
-bitflags = "0.3"
-libc = "0.1"
+bitflags = "0.4"
+libc = "0.2"
 
 [dependencies.cairo-sys-rs]
-git = "https://github.com/rust-gnome/cairo"
+git = "https://github.com/gtk-rs/cairo"
 
 [dependencies.gdk-pixbuf-sys]
 path = "../gdk-pixbuf-sys"
@@ -23,6 +23,14 @@ path = "../gobject-sys"
 
 [dependencies.pango-sys]
 path = "../pango-sys"
+
+[features]
+"3.10" = ["3.8"]
+"3.12" = ["3.10"]
+"3.14" = ["3.12"]
+"3.16" = ["3.14"]
+"3.6" = []
+"3.8" = ["3.6"]
 
 [lib]
 name = "gdk_sys"

--- a/tests/sys/gio-sys/Cargo.toml
+++ b/tests/sys/gio-sys/Cargo.toml
@@ -3,14 +3,22 @@
 pkg-config = "0.3.5"
 
 [dependencies]
-bitflags = "0.3"
-libc = "0.1"
+bitflags = "0.4"
+libc = "0.2"
 
 [dependencies.glib-sys]
 path = "../glib-sys"
 
 [dependencies.gobject-sys]
 path = "../gobject-sys"
+
+[features]
+"2.34" = []
+"2.36" = ["2.34"]
+"2.38" = ["2.36"]
+"2.40" = ["2.38"]
+"2.42" = ["2.40"]
+"2.44" = ["2.42"]
 
 [lib]
 name = "gio_sys"

--- a/tests/sys/gir-gdk.toml
+++ b/tests/sys/gir-gdk.toml
@@ -13,3 +13,22 @@ external_libraries = [
    "Pango",
    "Cairo",
 ]
+
+[[object]]
+name = "Gdk.EventType"
+status = "generate"
+    [[object.member]]
+    name = "2button_press"
+    alias = true
+    [[object.member]]
+    name = "3button_press"
+    alias = true
+    [[object.member]]
+    name = "touchpad_swipe"
+    version = "3.18"
+    [[object.member]]
+    name = "touchpad_pinch"
+    version = "3.18"
+    [[object.member]]
+    name = "event_last"
+    alias = true

--- a/tests/sys/glib-sys/Cargo.toml
+++ b/tests/sys/glib-sys/Cargo.toml
@@ -3,8 +3,15 @@
 pkg-config = "0.3.5"
 
 [dependencies]
-bitflags = "0.3"
-libc = "0.1"
+bitflags = "0.4"
+libc = "0.2"
+
+[features]
+"2.34" = []
+"2.36" = ["2.34"]
+"2.38" = ["2.36"]
+"2.40" = ["2.38"]
+"2.44" = ["2.40"]
 
 [lib]
 name = "glib_sys"

--- a/tests/sys/gobject-sys/Cargo.toml
+++ b/tests/sys/gobject-sys/Cargo.toml
@@ -3,11 +3,18 @@
 pkg-config = "0.3.5"
 
 [dependencies]
-bitflags = "0.3"
-libc = "0.1"
+bitflags = "0.4"
+libc = "0.2"
 
 [dependencies.glib-sys]
 path = "../glib-sys"
+
+[features]
+"2.34" = []
+"2.36" = ["2.34"]
+"2.38" = ["2.36"]
+"2.42" = ["2.38"]
+"2.44" = ["2.42"]
 
 [lib]
 name = "gobject_sys"

--- a/tests/sys/gtk-sys/Cargo.toml
+++ b/tests/sys/gtk-sys/Cargo.toml
@@ -3,14 +3,14 @@
 pkg-config = "0.3.5"
 
 [dependencies]
-bitflags = "0.3"
-libc = "0.1"
+bitflags = "0.4"
+libc = "0.2"
 
 [dependencies.atk-sys]
 path = "../atk-sys"
 
 [dependencies.cairo-sys-rs]
-git = "https://github.com/rust-gnome/cairo"
+git = "https://github.com/gtk-rs/cairo"
 
 [dependencies.gdk-pixbuf-sys]
 path = "../gdk-pixbuf-sys"
@@ -29,6 +29,14 @@ path = "../gobject-sys"
 
 [dependencies.pango-sys]
 path = "../pango-sys"
+
+[features]
+"3.10" = ["3.8"]
+"3.12" = ["3.10"]
+"3.14" = ["3.12"]
+"3.16" = ["3.14"]
+"3.6" = []
+"3.8" = ["3.6"]
 
 [lib]
 name = "gtk_sys"

--- a/tests/sys/pango-sys/Cargo.toml
+++ b/tests/sys/pango-sys/Cargo.toml
@@ -3,14 +3,20 @@
 pkg-config = "0.3.5"
 
 [dependencies]
-bitflags = "0.3"
-libc = "0.1"
+bitflags = "0.4"
+libc = "0.2"
 
 [dependencies.glib-sys]
 path = "../glib-sys"
 
 [dependencies.gobject-sys]
 path = "../gobject-sys"
+
+[features]
+"1.31" = []
+"1.32" = ["1.31"]
+"1.32.4" = ["1.32"]
+"1.34" = ["1.32.4"]
 
 [lib]
 name = "pango_sys"

--- a/tests/sys/secret-sys/Cargo.toml
+++ b/tests/sys/secret-sys/Cargo.toml
@@ -3,8 +3,8 @@
 pkg-config = "0.3.5"
 
 [dependencies]
-bitflags = "0.3"
-libc = "0.1"
+bitflags = "0.4"
+libc = "0.2"
 
 [dependencies.gio-sys]
 path = "../gio-sys"
@@ -14,6 +14,8 @@ path = "../glib-sys"
 
 [dependencies.gobject-sys]
 path = "../gobject-sys"
+
+[features]
 
 [lib]
 name = "secret_sys"

--- a/tests/sys/sys_build/Cargo.toml
+++ b/tests/sys/sys_build/Cargo.toml
@@ -2,13 +2,9 @@
 name = "sys_build"
 version = "0.0.1"
 
-[lib]
-name = "sys_build"
-
 [features]
-full = [
-	"secret-sys",
-]
+full = ["secret-sys"]
+"3.16" = ["gtk-sys/3.16"]
 
 [dependencies.gtk-sys]
 path = "../gtk-sys"

--- a/tests/sys/sys_build/src/lib.rs
+++ b/tests/sys/sys_build/src/lib.rs
@@ -1,1 +1,0 @@
-//No code here

--- a/tests/sys/sys_build/src/main.rs
+++ b/tests/sys/sys_build/src/main.rs
@@ -1,0 +1,8 @@
+extern crate gtk_sys;
+use std::ptr;
+
+fn main() {
+    unsafe {
+        gtk_sys::gtk_init(ptr::null_mut(), ptr::null_mut());
+    }
+}


### PR DESCRIPTION
Implement changes outlined in https://github.com/gtk-rs/gtk/issues/243
- Make library version selection manual via cargo features, fail if `pkg-config` returns an older version.
- Allow skipping `pkg-config` by setting `GTK_LIB_DIR`.
- Support setting enum and bitfield member required versions in the config.