### PR TITLE
More intelligent symbol name handling and other docs generator improvements

### DIFF
--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -18,3 +18,4 @@ pub mod return_value;
 pub mod rust_type;
 pub mod safety_assertion_mode;
 pub mod special_functions;
+pub mod symbols;

--- a/src/analysis/namespaces.rs
+++ b/src/analysis/namespaces.rs
@@ -7,6 +7,7 @@ use version::Version;
 
 pub type NsId = u16;
 pub const MAIN: NsId = library::MAIN_NAMESPACE;
+pub const INTERNAL: NsId = library::INTERNAL_NAMESPACE;
 
 #[derive(Debug)]
 pub struct Namespace {

--- a/src/analysis/object.rs
+++ b/src/analysis/object.rs
@@ -94,6 +94,16 @@ pub fn class(env: &Env, obj: &GObject) -> Option<Info> {
         cfg_condition: obj.cfg_condition.clone(),
     };
 
+    // patch up trait methods in the symbol table
+    if has_children {
+        let mut symbols = env.symbols.borrow_mut();
+        for func in base.methods() {
+            if let Some(symbol) = symbols.by_c_name_mut(&func.glib_name) {
+                symbol.make_trait_method();
+            }
+        }
+    }
+
     let has_constructors = !base.constructors().is_empty();
     let has_methods = !base.methods().is_empty();
     let has_functions = !base.functions().is_empty();

--- a/src/analysis/symbols.rs
+++ b/src/analysis/symbols.rs
@@ -1,0 +1,144 @@
+use analysis::namespaces::{self, NsId};
+use case::CaseExt;
+use library::*;
+use std::collections::HashMap;
+
+#[derive(Clone, Debug, Default)]
+pub struct Symbol {
+    crate_name: Option<String>,
+    owner_name: Option<String>,
+    name: String,
+}
+
+impl Symbol {
+    pub fn full_rust_name(&self) -> String {
+        let mut ret = String::new();
+        if let Some(ref s) = self.crate_name {
+            ret.push_str(s);
+            ret.push_str("::");
+        }
+        if let Some(ref s) = self.owner_name {
+            ret.push_str(s);
+            ret.push_str("::");
+        }
+        ret.push_str(&self.name);
+        ret
+    }
+
+    pub fn make_trait_method(&mut self) {
+        let name = self.owner_name.take();
+        self.owner_name = name.map(|s| format!("{}Ext", s));
+    }
+}
+
+#[derive(Debug)]
+pub struct Info {
+    symbols: Vec<Symbol>,
+    c_name_index: HashMap<String, u32>,
+}
+
+pub fn run(library: &Library, namespaces: &namespaces::Info) -> Info {
+    let mut info = Info {
+        symbols: Vec::new(),
+        c_name_index: HashMap::new(),
+    };
+
+    info.insert("NULL", Symbol { name: "None".into(), ..Default::default() });
+    info.insert("FALSE", Symbol { name: "false".into(), ..Default::default() });
+    info.insert("TRUE", Symbol { name: "true".into(), ..Default::default() });
+
+    for (ns_id, ref ns) in library.namespaces.iter().enumerate() {
+        let ns_id = ns_id as NsId;
+        if ns_id == namespaces::INTERNAL {
+            continue
+        }
+
+        let crate_name = if ns_id == namespaces::MAIN {
+            None
+        } else {
+            Some(&namespaces[ns_id].crate_name)
+        };
+
+        for typ in ns.types.iter().map(|t| t.as_ref().unwrap()) {
+            let symbol = Symbol {
+                crate_name: crate_name.cloned(),
+                name: typ.get_name(),
+                ..Default::default()
+            };
+            
+            match *typ {
+                Type::Alias(Alias { ref c_identifier, .. }) => {
+                    info.insert(c_identifier, symbol);
+                }
+                Type::Enumeration(Enumeration {
+                    ref name,
+                    ref c_type,
+                    ref members,
+                    ref functions,
+                        ..
+                }) |
+                    Type::Bitfield(Bitfield {
+                        ref name,
+                        ref c_type,
+                        ref members,
+                        ref functions,
+                        ..
+                    }) => {
+                    info.insert(c_type, symbol);
+                    for member in members {
+                        let symbol = Symbol {
+                            crate_name: crate_name.cloned(),
+                            owner_name: Some(name.clone()),
+                            name: member.name.to_camel(),
+                        };
+                        info.insert(&member.c_identifier, symbol);
+                    }
+                    for func in functions {
+                        let symbol = Symbol {
+                            crate_name: crate_name.cloned(),
+                            owner_name: Some(name.clone()),
+                            name: func.name.clone(),
+                        };
+                        info.insert(func.c_identifier.as_ref().unwrap(), symbol);
+                    }
+                }
+                Type::Record(Record { ref name, ref c_type, ref functions, .. }) |
+                    Type::Class(Class { ref name, ref c_type, ref functions, .. }) |
+                    Type::Interface(Interface { ref name, ref c_type, ref functions, .. }) => {
+                    info.insert(c_type, symbol);
+                    for func in functions {
+                        let symbol = Symbol {
+                            crate_name: crate_name.cloned(),
+                            owner_name: Some(name.clone()),
+                            name: func.name.clone(),
+                        };
+                        info.insert(func.c_identifier.as_ref().unwrap(), symbol);
+                    }
+                }
+                _ => { }
+            }
+        }
+    }
+
+    info
+}
+
+impl Info {
+    pub fn by_c_name(&self, name: &str) -> Option<&Symbol> {
+        self.c_name_index.get(name).map(|&id| &self.symbols[id as usize])
+    }
+
+    pub fn by_c_name_mut(&mut self, name: &str) -> Option<&mut Symbol> {
+        if let Some(&id) = self.c_name_index.get(name) {
+            Some(&mut self.symbols[id as usize])
+        } else {
+            None
+        }
+    }
+
+    fn insert(&mut self, name: &str, symbol: Symbol) {
+        let id = self.symbols.len();
+        self.symbols.push(symbol);
+        self.c_name_index.insert(name.to_owned(), id as u32);
+    }
+}

--- a/src/codegen/doc/format.rs
+++ b/src/codegen/doc/format.rs
@@ -55,7 +55,8 @@ fn get_language<'a>(entry: &'a str, out: &mut String) -> &'a str {
 lazy_static! {
     static ref SYMBOL: Regex = Regex::new(r"(^|[^\\])[@#%]([\w]+\b)([:.]+[\w_-]+\b)?") .unwrap();
     static ref FUNCTION: Regex = Regex::new(r"(\b[a-z0-9_]+)\(\)") .unwrap();
-    static ref GDK_GTK: Regex = Regex::new(r"(G[dt]k[A-Z][\w]+\b)").unwrap();
+    static ref GDK_GTK: Regex = Regex::new(r"G[dt]k[A-Z][\w]+\b").unwrap();
+    static ref TAGS: Regex = Regex::new(r"<[\w/-]+>").unwrap();
     static ref SPACES: Regex = Regex::new(r"[ ][ ]+").unwrap();
 }
 
@@ -94,7 +95,8 @@ fn replace_c_types(entry: &str, symbols: &symbols::Info) -> String {
         format!("`{}`", lookup(&caps[1]))
     });
     let out = GDK_GTK.replace_all(&out, |caps: &Captures| {
-        format!("`{}`", lookup(&caps[1]))
+        format!("`{}`", lookup(&caps[0]))
     });
+    let out = TAGS.replace_all(&out, "`$0`");
     SPACES.replace_all(&out, " ")
 }

--- a/src/codegen/doc/format.rs
+++ b/src/codegen/doc/format.rs
@@ -57,6 +57,7 @@ fn get_language<'a>(entry: &'a str, out: &mut String) -> &'a str {
 lazy_static! {
     static ref REG : Regex = Regex::new(r"#?(G[dt]k)([\w]+:?:?\.?[\w-]+)").unwrap();
     static ref REG2 : Regex = Regex::new(r"@(\w*)").unwrap();
+    static ref SPACES: Regex = Regex::new(r"[ ][ ]+").unwrap();
 }
 
 fn replace_c_types(entry: &str, env: &Env) -> String {
@@ -68,5 +69,6 @@ fn replace_c_types(entry: &str, env: &Env) -> String {
             format!("`{}::{}`", &env.namespaces[pos].crate_name, &caps[2])
         }
     });
-    REG2.replace_all(out, "`$1`")
+    let out = REG2.replace_all(&out, "`$1`");
+    SPACES.replace_all(&out, " ")
 }

--- a/src/codegen/doc/format.rs
+++ b/src/codegen/doc/format.rs
@@ -1,14 +1,13 @@
+use analysis::symbols;
 use regex::{Captures, Regex};
-use analysis::namespaces::MAIN;
-use env::Env;
 
 const LANGUAGE_SEP_BEGIN : &'static str = "<!-- language=\"";
 const LANGUAGE_SEP_END : &'static str = "\" -->";
 const LANGUAGE_BLOCK_BEGIN : &'static str = "|[";
 const LANGUAGE_BLOCK_END : &'static str = "\n]|";
 
-pub fn reformat_doc(input: &str, env: &Env) -> String {
-    code_blocks_transformation(input, env)
+pub fn reformat_doc(input: &str, symbols: &symbols::Info) -> String {
+    code_blocks_transformation(input, symbols)
 }
 
 fn try_split<'a>(src: &'a str, needle: &str) -> (&'a str, Option<&'a str>) {
@@ -18,14 +17,13 @@ fn try_split<'a>(src: &'a str, needle: &str) -> (&'a str, Option<&'a str>) {
     }
 }
 
-fn code_blocks_transformation(mut input: &str,
-                              env: &Env) -> String {
+fn code_blocks_transformation(mut input: &str, symbols: &symbols::Info) -> String {
     let mut out = String::new();
 
     loop {
         input = match try_split(input, LANGUAGE_BLOCK_BEGIN) {
             (before, Some(after)) => {
-                out.push_str(&replace_c_types(before, env));
+                out.push_str(&replace_c_types(before, symbols));
                 if let (before, Some(after)) = try_split(get_language(after, &mut out),
                                                          LANGUAGE_BLOCK_END) {
                     out.push_str(before);
@@ -36,7 +34,7 @@ fn code_blocks_transformation(mut input: &str,
                 }
             }
             (before, None) => {
-                out.push_str(&replace_c_types(before, env));
+                out.push_str(&replace_c_types(before, symbols));
                 return out
             }
         };
@@ -55,20 +53,26 @@ fn get_language<'a>(entry: &'a str, out: &mut String) -> &'a str {
 }
 
 lazy_static! {
-    static ref REG : Regex = Regex::new(r"#?(G[dt]k)([\w]+:?:?\.?[\w-]+)").unwrap();
-    static ref REG2 : Regex = Regex::new(r"@(\w*)").unwrap();
+    static ref SYMBOL: Regex = Regex::new(r"(^|[^\\])[@#%]([\w]+\b)([:.]+[\w_-]+\b)?") .unwrap();
+    static ref FUNCTION: Regex = Regex::new(r"(\b[a-z0-9_]+)\(\)") .unwrap();
+    static ref GDK_GTK: Regex = Regex::new(r"(G[dt]k[A-Z][\w]+\b)").unwrap();
     static ref SPACES: Regex = Regex::new(r"[ ][ ]+").unwrap();
 }
 
-fn replace_c_types(entry: &str, env: &Env) -> String {
-    let out = &REG.replace_all(entry, |caps: &Captures| {
-        let pos = env.library.find_namespace(&caps[1]).unwrap();
-        if pos == MAIN {
-            format!("`{}`", &caps[2])
-        } else {
-            format!("`{}::{}`", &env.namespaces[pos].crate_name, &caps[2])
-        }
+fn replace_c_types(entry: &str, symbols: &symbols::Info) -> String {
+    let lookup = |s: &str| -> String {
+        symbols.by_c_name(s)
+            .map(|s| s.full_rust_name())
+            .unwrap_or(s.into())
+    };
+    let out = SYMBOL.replace_all(entry, |caps: &Captures| {
+        format!("{}`{}{}`", &caps[1], lookup(&caps[2]), caps.at(3).unwrap_or(""))
     });
-    let out = REG2.replace_all(&out, "`$1`");
+    let out = FUNCTION.replace_all(&out, |caps: &Captures| {
+        format!("`{}`", lookup(&caps[1]))
+    });
+    let out = GDK_GTK.replace_all(&out, |caps: &Captures| {
+        format!("`{}`", lookup(&caps[1]))
+    });
     SPACES.replace_all(&out, " ")
 }

--- a/src/codegen/doc/format.rs
+++ b/src/codegen/doc/format.rs
@@ -46,11 +46,11 @@ fn code_blocks_transformation(mut input: &str,
 fn get_language<'a>(entry: &'a str, out: &mut String) -> &'a str {
     if let (_, Some(after)) = try_split(entry, LANGUAGE_SEP_BEGIN) {
         if let (before, Some(after)) = try_split(after, LANGUAGE_SEP_END) {
-            out.push_str(&format!("```{}", before));
+            out.push_str(&format!("\n```{}", before));
             return after
         }
     }
-    out.push_str("```text");
+    out.push_str("\n```text");
     entry
 }
 

--- a/src/codegen/doc/mod.rs
+++ b/src/codegen/doc/mod.rs
@@ -269,7 +269,8 @@ fn create_fn_doc(w: &mut Write, fn_: &Function, parent: Option<Box<TypeStruct>>,
             continue
         }
         if let Some(ref parameter_doc) = parameter.doc() {
-            try!(writeln!(w, "{}/// ## {}:", tabs, parameter.name));
+            try!(writeln!(w, "{}/// ## `{}`", tabs,
+                          nameutil::mangle_keywords(&parameter.name[..])));
             try!(write_lines(w, &fix_param_names(parameter_doc, &self_name), &tabs, symbols));
         }
     }

--- a/src/codegen/doc/mod.rs
+++ b/src/codegen/doc/mod.rs
@@ -7,7 +7,6 @@ use file_saver::save_to_file;
 use library::*;
 use library::Type as LType;
 use writer::primitives;
-use nameutil::*;
 
 use stripper_interface as stripper;
 use stripper_interface::Type as SType;
@@ -84,6 +83,8 @@ pub fn generate(env: &Env) {
 }
 
 fn generate_doc(mut w: &mut Write, env: &Env) -> Result<()> {
+    try!(writeln!(w, "{}*", FILE));
+
     let namespace = env.library.namespace(MAIN);
     for obj in env.config.objects.values() {
         if !obj.status.need_generate() {
@@ -98,10 +99,6 @@ fn generate_doc(mut w: &mut Write, env: &Env) -> Result<()> {
         };
         let has_trait = class_analysis.has_children;
 
-        let mod_name = obj.module_name.clone().unwrap_or_else(|| {
-            module_name(split_namespace_name(&class_analysis.full_name).1)
-        });
-        try!(writeln!(w, "{}src/auto/{}.rs", FILE, mod_name));
         try!(handle_type(w, &env.library.type_(class_analysis.type_id), None, has_trait,
                          true, &env));
     }

--- a/src/env.rs
+++ b/src/env.rs
@@ -1,12 +1,14 @@
-use analysis::namespaces;
+use analysis;
 use config::Config;
 use config::gobjects::GStatus;
 use library::*;
+use std::cell::RefCell;
 
 pub struct Env {
     pub library: Library,
     pub config: Config,
-    pub namespaces: namespaces::Info,
+    pub namespaces: analysis::namespaces::Info,
+    pub symbols: RefCell<analysis::symbols::Info>,
 }
 
 impl Env {

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ extern crate toml;
 extern crate regex;
 extern crate stripper_interface;
 
+use std::cell::RefCell;
 use std::error::Error;
 use std::process;
 
@@ -63,11 +64,13 @@ fn do_main() -> Result<(), Box<Error>> {
     library.postprocessing();
 
     let namespaces = analysis::namespaces::run(&library);
+    let symbols = analysis::symbols::run(&library, &namespaces);
 
     let env = Env{
         library: library,
         config: cfg,
         namespaces: namespaces,
+        symbols: RefCell::new(symbols),
     };
     codegen::generate(&env);
 


### PR DESCRIPTION
Implement more of #203

- Small fixes (#213)
- Add symbol dictionary to translate C names to Rust correctly
- Avoid mangling inline code in backquotes
- Mangle parameter names and change instance parameter to `self`
- Shield XML tags