### PR TITLE
Build script update

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,6 @@ install:
   - SET PATH=C:\Rust\bin;C:\Program Files\Git\cmd;C:\Program Files\Git\usr\bin
   - SET PATH=C:\msys64\mingw%BITS%\bin;C:\msys64\usr\bin;%PATH%
   - pacman --noconfirm -S mingw-w64-%ARCH%-gtk3
-  - SET GTK_LIB_DIR=C:\msys64\mingw%BITS%\lib
 
 build_script:
   - git clone -q https://github.com/gkoz/gir-files tests/gir-files

--- a/src/codegen/sys/build.rs
+++ b/src/codegen/sys/build.rs
@@ -17,6 +17,8 @@ pub fn generate(env: &Env) {
 fn generate_build_script(w: &mut Write, env: &Env) -> Result<()> {
     try!(write!(w, "{}",
 r##"extern crate pkg_config;
+
+use pkg_config::{Config, Error};
 use std::env;
 use std::io::prelude::*;
 use std::io;
@@ -29,7 +31,7 @@ fn main() {
     }
 }
 
-fn find() -> Result<(), String> {
+fn find() -> Result<(), Error> {
 "##));
 
     let ns = env.namespaces.main();
@@ -40,15 +42,15 @@ fn find() -> Result<(), String> {
 
     try!(writeln!(w, "\tlet package_name = \"{}\";", ns.package_name.as_ref().unwrap()));
     try!(writeln!(w, "\tlet shared_libs = [{}];", shared_libs.join(", ")));
-    try!(write!(w, "\tlet expected_version =\n\t\t"));
+    try!(write!(w, "\tlet version = "));
     let versions = ns.versions.iter()
         .filter(|v| **v >= env.config.min_cfg_version)
         .skip(1)
         .collect::<Vec<_>>();
     for v in versions.iter().rev() {
-        try!(write!(w, "if cfg!({}) {{\n\t\t\t\"{}\"\n\t\t}} else ", v.to_cfg(), v));
+        try!(write!(w, "if cfg!({}) {{\n\t\t\"{}\"\n\t}} else ", v.to_cfg(), v));
     }
-    try!(writeln!(w, "{{\n\t\t\t\"{}\"\n\t\t}};", env.config.min_cfg_version));
+    try!(writeln!(w, "{{\n\t\t\"{}\"\n\t}};", env.config.min_cfg_version));
 
     writeln!(w, "{}",
 r##"
@@ -57,29 +59,40 @@ r##"
             println!("cargo:rustc-link-lib=dylib={}", lib_);
         }
         println!("cargo:rustc-link-search=native={}", lib_dir);
-        Ok(())
-    } else {
-        let lib = try!(pkg_config::find_library(package_name));
-        if Version::new(&lib.version) >= Version::new(expected_version) {
-            Ok(())
-        } else {
-            Err(format!("Installed `{}` version `{}` lower than `{}` requested by cargo features",
-                        package_name, lib.version, expected_version))
-        }
+        return Ok(())
     }
-}
 
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-struct Version(pub u16, pub u16, pub u16);
+    let target = env::var("TARGET").unwrap();
+    let hardcode_shared_libs = target.contains("windows");
 
-impl Version {
-    fn new(s: &str) -> Version {
-        let mut parts = s.splitn(4, '.')
-            .map(|s| s.parse())
-            .take_while(Result::is_ok)
-            .map(Result::unwrap);
-        Version(parts.next().unwrap_or(0),
-            parts.next().unwrap_or(0), parts.next().unwrap_or(0))
+    let mut config = Config::new();
+    config.atleast_version(version);
+    if hardcode_shared_libs {
+        config.cargo_metadata(false);
+    }
+    match config.probe(package_name) {
+        Ok(library) => {
+            if hardcode_shared_libs {
+                for lib_ in shared_libs.iter() {
+                    println!("cargo:rustc-link-lib=dylib={}", lib_);
+                }
+            } else {
+                for lib_ in library.libs.iter() {
+                    println!("cargo:rustc-link-lib=dylib={}", lib_);
+                }
+            }
+            for path in library.link_paths.iter() {
+                println!("cargo:rustc-link-search=native={}", path.to_str().unwrap());
+            }
+            Ok(())
+        }
+        Err(Error::EnvNoPkgConfig(_)) | Err(Error::Command { .. }) => {
+            for lib_ in shared_libs.iter() {
+                println!("cargo:rustc-link-lib=dylib={}", lib_);
+            }
+            Ok(())
+        }
+        Err(err) => Err(err),
     }
 }
 "##)

--- a/src/codegen/sys/cargo_toml.rs
+++ b/src/codegen/sys/cargo_toml.rs
@@ -71,7 +71,7 @@ fn fill_in(root: &mut Table, env: &Env) {
 
     {
         let build_deps = upsert_table(root, "build-dependencies");
-        set_string(build_deps, "pkg-config", "0.3.5");
+        set_string(build_deps, "pkg-config", "0.3.7");
     }
 
     {

--- a/tests/sys/atk-sys/Cargo.toml
+++ b/tests/sys/atk-sys/Cargo.toml
@@ -1,6 +1,6 @@
 
 [build-dependencies]
-pkg-config = "0.3.5"
+pkg-config = "0.3.7"
 
 [dependencies]
 bitflags = "0.4"

--- a/tests/sys/gdk-pixbuf-sys/Cargo.toml
+++ b/tests/sys/gdk-pixbuf-sys/Cargo.toml
@@ -1,6 +1,6 @@
 
 [build-dependencies]
-pkg-config = "0.3.5"
+pkg-config = "0.3.7"
 
 [dependencies]
 bitflags = "0.4"

--- a/tests/sys/gdk-sys/Cargo.toml
+++ b/tests/sys/gdk-sys/Cargo.toml
@@ -1,6 +1,6 @@
 
 [build-dependencies]
-pkg-config = "0.3.5"
+pkg-config = "0.3.7"
 
 [dependencies]
 bitflags = "0.4"

--- a/tests/sys/gio-sys/Cargo.toml
+++ b/tests/sys/gio-sys/Cargo.toml
@@ -1,6 +1,6 @@
 
 [build-dependencies]
-pkg-config = "0.3.5"
+pkg-config = "0.3.7"
 
 [dependencies]
 bitflags = "0.4"

--- a/tests/sys/glib-sys/Cargo.toml
+++ b/tests/sys/glib-sys/Cargo.toml
@@ -1,6 +1,6 @@
 
 [build-dependencies]
-pkg-config = "0.3.5"
+pkg-config = "0.3.7"
 
 [dependencies]
 bitflags = "0.4"

--- a/tests/sys/gobject-sys/Cargo.toml
+++ b/tests/sys/gobject-sys/Cargo.toml
@@ -1,6 +1,6 @@
 
 [build-dependencies]
-pkg-config = "0.3.5"
+pkg-config = "0.3.7"
 
 [dependencies]
 bitflags = "0.4"

--- a/tests/sys/gtk-sys/Cargo.toml
+++ b/tests/sys/gtk-sys/Cargo.toml
@@ -1,6 +1,6 @@
 
 [build-dependencies]
-pkg-config = "0.3.5"
+pkg-config = "0.3.7"
 
 [dependencies]
 bitflags = "0.4"

--- a/tests/sys/pango-sys/Cargo.toml
+++ b/tests/sys/pango-sys/Cargo.toml
@@ -1,6 +1,6 @@
 
 [build-dependencies]
-pkg-config = "0.3.5"
+pkg-config = "0.3.7"
 
 [dependencies]
 bitflags = "0.4"

--- a/tests/sys/secret-sys/Cargo.toml
+++ b/tests/sys/secret-sys/Cargo.toml
@@ -1,6 +1,6 @@
 
 [build-dependencies]
-pkg-config = "0.3.5"
+pkg-config = "0.3.7"
 
 [dependencies]
 bitflags = "0.4"


### PR DESCRIPTION
- Update pkg-config to 0.3.7.
- Let pkg-config compare version numbers.
- If pkg-config can't be run emit hardcoded library names.
- On Windows always emit hardcoded library names to avoid the `-lmm32` issue.