### PR TITLE
sys build script: avoid duplicate metadata when it's not suppressed

### DIFF
--- a/src/codegen/sys/build.rs
+++ b/src/codegen/sys/build.rs
@@ -76,13 +76,9 @@ r##"
                 for lib_ in shared_libs.iter() {
                     println!("cargo:rustc-link-lib=dylib={}", lib_);
                 }
-            } else {
-                for lib_ in library.libs.iter() {
-                    println!("cargo:rustc-link-lib=dylib={}", lib_);
+                for path in library.link_paths.iter() {
+                    println!("cargo:rustc-link-search=native={}", path.to_str().unwrap());
                 }
-            }
-            for path in library.link_paths.iter() {
-                println!("cargo:rustc-link-search=native={}", path.to_str().unwrap());
             }
             Ok(())
         }


### PR DESCRIPTION
The `!hardcode_shared_libs` branch should not print anything because `pkg_config` does that.