### PR TITLE
Add a separate analysis pass

### DIFF
--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -1,3 +1,6 @@
+use env::Env;
+use library::Type;
+
 pub mod bounds;
 pub mod c_type;
 pub mod class_hierarchy;
@@ -22,3 +25,39 @@ pub mod special_functions;
 pub mod supertypes;
 pub mod symbols;
 pub mod trampolines;
+
+#[derive(Default)]
+pub struct Analysis {
+    pub objects: Vec<object::Info>,
+    pub records: Vec<record::Info>,
+}
+
+pub fn run(env: &mut Env) {
+    for obj in env.config.objects.values() {
+        if obj.status.ignored() {
+            continue;
+        }
+        let tid = match env.library.find_type(0, &obj.name) {
+            Some(x) => x,
+            None => continue,
+        };
+        match *env.library.type_(tid) {
+            Type::Class(_) => {
+                if let Some(info) = object::class(env, obj) {
+                    env.analysis.objects.push(info);
+                }
+            }
+            Type::Interface(_) => {
+                if let Some(info) = object::interface(env, obj) {
+                    env.analysis.objects.push(info);
+                }
+            }
+            Type::Record(_) => {
+                if let Some(info) = record::new(env, obj) {
+                    env.analysis.records.push(info);
+                }
+            }
+            _ => {}
+        }
+    }
+}

--- a/src/analysis/object.rs
+++ b/src/analysis/object.rs
@@ -38,6 +38,7 @@ impl Deref for Info {
 }
 
 pub fn class(env: &Env, obj: &GObject) -> Option<Info> {
+    info!("Analyzing class {}", obj.name);
     let full_name = obj.name.clone();
 
     let class_tid = match env.library.find_type(0, &full_name) {
@@ -140,6 +141,7 @@ pub fn class(env: &Env, obj: &GObject) -> Option<Info> {
 }
 
 pub fn interface(env: &Env, obj: &GObject) -> Option<Info> {
+    info!("Analyzing interface {}", obj.name);
     let full_name = obj.name.clone();
 
     let iface_tid = match env.library.find_type(0, &full_name) {

--- a/src/analysis/record.rs
+++ b/src/analysis/record.rs
@@ -32,6 +32,7 @@ impl Info {
 }
 
 pub fn new(env: &Env, obj: &GObject) -> Option<Info> {
+    info!("Analyzing record {}", obj.name);
     let full_name = obj.name.clone();
 
     let record_tid = match env.library.find_type(0, &full_name) {

--- a/src/codegen/function_body_chunk.rs
+++ b/src/codegen/function_body_chunk.rs
@@ -4,7 +4,7 @@ use analysis::out_parameters::Mode;
 use analysis::return_value;
 use analysis::rust_type::rust_type;
 use analysis::safety_assertion_mode::SafetyAssertionMode;
-use chunk::{chunks, Chunk, TupleMode};
+use chunk::{Chunk, TupleMode};
 use chunk::parameter_ffi_call_in;
 use chunk::parameter_ffi_call_out;
 use env::Env;

--- a/src/codegen/objects.rs
+++ b/src/codegen/objects.rs
@@ -1,24 +1,16 @@
 use std::path::Path;
 
-use analysis;
 use env::Env;
 use file_saver::*;
 use nameutil::*;
 
 pub fn generate(env: &Env, root_path: &Path, mod_rs: &mut Vec<String>, traits: &mut Vec<String>) {
     info!("Generate objects");
-    for obj in env.config.objects.values() {
+    for class_analysis in &env.analysis.objects {
+        let obj = &env.config.objects[&class_analysis.full_name];
         if !obj.status.need_generate() {
             continue;
         }
-
-        info!("Analyzing {:?}", obj.name);
-        let info = analysis::object::class(env, obj)
-            .or_else(|| analysis::object::interface(env, obj));
-        let class_analysis = match info {
-            Some(info) => info,
-            None => continue,
-        };
 
         let mod_name = obj.module_name.clone().unwrap_or_else(|| {
             module_name(split_namespace_name(&class_analysis.full_name).1)

--- a/src/codegen/records.rs
+++ b/src/codegen/records.rs
@@ -1,22 +1,16 @@
 use std::path::Path;
 
-use analysis;
 use env::Env;
 use file_saver::*;
 use nameutil::*;
 
 pub fn generate(env: &Env, root_path: &Path, mod_rs: &mut Vec<String>) {
     info!("Generate records");
-    for obj in env.config.objects.values() {
+    for record_analysis in &env.analysis.records {
+        let obj = &env.config.objects[&record_analysis.full_name];
         if !obj.status.need_generate() {
             continue;
         }
-
-        info!("Analyzing {:?}", obj.name);
-        let record_analysis = match analysis::record::new(env, obj) {
-            Some(info) => info,
-            None => continue,
-        };
 
         let mod_name = obj.module_name.clone().unwrap_or_else(|| {
             module_name(split_namespace_name(&record_analysis.full_name).1)

--- a/src/env.rs
+++ b/src/env.rs
@@ -12,6 +12,7 @@ pub struct Env {
     pub namespaces: analysis::namespaces::Info,
     pub symbols: RefCell<analysis::symbols::Info>,
     pub class_hierarchy: analysis::class_hierarchy::Info,
+    pub analysis: analysis::Analysis,
 }
 
 impl Env {

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,15 +77,21 @@ fn do_main() -> Result<(), Box<Error>> {
     let symbols = analysis::symbols::run(&library, &namespaces);
     let class_hierarchy = analysis::class_hierarchy::run(&library);
 
-    let env = Env{
+    let mut env = Env{
         library: library,
         config: cfg,
         namespaces: namespaces,
         symbols: RefCell::new(symbols),
         class_hierarchy: class_hierarchy,
+        analysis: Default::default(),
     };
 
     drop(watcher_loading);
+    {
+        let _watcher = statistics.enter("Analysing");
+        analysis::run(&mut env);
+    }
+
     {
         let _watcher_generating = statistics.enter("Generating");
 


### PR DESCRIPTION
Objects (classes and interfaces) and records ('generated' and 'manual' ones from all namespaces) get analyzed prior to generation. The `Info`s are collected into vectors with no indexing by name yet.
This partially implements #136. Fixes #252.