### PR TITLE
Trampolines parameters transformations

### DIFF
--- a/src/analysis/conversion_type.rs
+++ b/src/analysis/conversion_type.rs
@@ -5,6 +5,7 @@ pub enum ConversionType {
     Direct,     //coded without conversion
     Scalar,     //coded with from_glib
     Pointer,    //coded with from_glib_xxx
+    Borrow,     //same as Pointer, except that use from_glib_borrow instead from_glib_none
     Unknown,
 }
 

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -25,6 +25,7 @@ pub mod signals;
 pub mod special_functions;
 pub mod supertypes;
 pub mod symbols;
+pub mod trampoline_parameters;
 pub mod trampolines;
 
 #[derive(Default)]

--- a/src/analysis/out_parameters.rs
+++ b/src/analysis/out_parameters.rs
@@ -96,7 +96,9 @@ fn can_as_return(env: &Env, par: &Parameter) -> bool {
     match ConversionType::of(&env.library, par.typ) {
         Direct => true,
         Scalar => true,
-        Pointer => parameter_rust_type(env, par.typ, ParameterDirection::Out, Nullable(false), RefMode::None).is_ok(),
+        Pointer => parameter_rust_type(env, par.typ, ParameterDirection::Out, Nullable(false),
+                                       RefMode::None).is_ok(),
+        Borrow => false,
         Unknown => false,
     }
 }

--- a/src/analysis/parameter.rs
+++ b/src/analysis/parameter.rs
@@ -2,7 +2,6 @@ use std::borrow::Cow;
 
 use config::functions::Function;
 use config::parameter_matchable::ParameterMatchable;
-use config::signals::Signal;
 use env::Env;
 use library;
 use nameutil;
@@ -46,37 +45,6 @@ pub fn analyze(env: &Env, par: &library::Parameter, configured_functions: &[&Fun
         .next();
     let nullable = nullable_override.unwrap_or(par.nullable);
     let to_glib_extra = Bounds::to_glib_extra(&env.library, par.typ);
-
-    Parameter {
-        name: name.into_owned(),
-        typ: par.typ,
-        c_type: par.c_type.clone(),
-        instance_parameter: par.instance_parameter,
-        direction: par.direction,
-        transfer: par.transfer,
-        caller_allocates: par.caller_allocates,
-        nullable: nullable,
-        allow_none: par.allow_none,
-        ref_mode: ref_mode,
-        is_error: par.is_error,
-        to_glib_extra: to_glib_extra,
-    }
-}
-
-pub fn analyze_for_trampoline(env: &Env, par: &library::Parameter, configured_signals: &[&Signal]) -> Parameter {
-    let name = if par.instance_parameter {
-        Cow::Borrowed(&*par.name)
-    } else {
-        nameutil::mangle_keywords(&*par.name)
-    };
-
-    let ref_mode = RefMode::without_unneeded_mut(&env.library, par, false);
-
-    let nullable_override = configured_signals.matched_parameters(&name).iter()
-        .filter_map(|p| p.nullable)
-        .next();
-    let nullable = nullable_override.unwrap_or(par.nullable);
-    let to_glib_extra = String::new();
 
     Parameter {
         name: name.into_owned(),

--- a/src/analysis/trampoline_parameters.rs
+++ b/src/analysis/trampoline_parameters.rs
@@ -121,6 +121,9 @@ pub fn analyze(env: &Env, signal_parameters: &[library::Parameter], type_tid: li
 
         let conversion_type = ConversionType::of(&env.library, par.typ);
 
+        let new_name = configured_signals.matched_parameters(&name).iter()
+            .filter_map(|p| p.new_name.clone())
+            .next();
         let transformation_override = configured_signals.matched_parameters(&name).iter()
             .filter_map(|p| p.transformation)
             .next();
@@ -128,6 +131,11 @@ pub fn analyze(env: &Env, signal_parameters: &[library::Parameter], type_tid: li
         let mut transform = parameters.prepare_transformation(par.typ, name, par.c_type.clone(),
                                                               par.direction, par.transfer,
                                                               nullable, ref_mode, conversion_type);
+
+        if let Some(new_name) = new_name {
+            transform.name = new_name;
+        }
+
         if let Some(transformation_type) = transformation_override {
             apply_transformation_type(env, &mut parameters, &mut transform, transformation_type);
         }

--- a/src/analysis/trampoline_parameters.rs
+++ b/src/analysis/trampoline_parameters.rs
@@ -1,0 +1,130 @@
+use config;
+use config::parameter_matchable::ParameterMatchable;
+use env::Env;
+use library;
+use nameutil;
+use super::conversion_type::ConversionType;
+use super::ref_mode::RefMode;
+
+#[derive(Clone, Debug)]
+pub struct RustParameter {
+    pub name: String,
+    pub typ: library::TypeId,
+    pub direction: library::ParameterDirection,
+    pub nullable: library::Nullable,
+    pub ref_mode: RefMode,
+}
+
+#[derive(Clone, Debug)]
+pub struct CParameter {
+    pub name: String,
+    pub typ: library::TypeId,
+    pub c_type: String,
+}
+
+#[derive(Clone, Debug)]
+pub enum TransformationType {
+    None,
+}
+
+#[derive(Clone, Debug)]
+pub struct Transformation {
+    pub ind_c: usize,     //index in `Vec<CParameter>`
+    pub ind_rust: usize,  //index in `Vec<RustParameter>`
+    pub transformation: TransformationType,
+    pub name: String,
+    pub typ: library::TypeId,
+    pub transfer: library::Transfer,
+    pub ref_mode: RefMode,
+    pub conversion_type: ConversionType,
+}
+
+#[derive(Clone, Default, Debug)]
+pub struct Parameters {
+    pub rust_parameters: Vec<RustParameter>,
+    pub c_parameters: Vec<CParameter>,
+    pub transformations: Vec<Transformation>,
+}
+
+impl Parameters {
+    fn new(capacity: usize) -> Parameters {
+        Parameters {
+            rust_parameters: Vec::with_capacity(capacity),
+            c_parameters: Vec::with_capacity(capacity),
+            transformations: Vec::with_capacity(capacity),
+        }
+    }
+
+    //TODO: temp
+    fn push(&mut self, type_tid: library::TypeId, name: String, c_type: String,
+            direction: library::ParameterDirection, transfer: library::Transfer,
+            nullable: library::Nullable, ref_mode: RefMode,
+            conversion_type: ConversionType) {
+        let c_par = CParameter {
+            name: name.clone(),
+            typ: type_tid,
+            c_type: c_type,
+        };
+        let ind_c = self.c_parameters.len();
+        self.c_parameters.push(c_par);
+
+        let rust_par = RustParameter {
+            name: name.clone(),
+            typ: type_tid,
+            direction: direction,
+            nullable: nullable,
+            ref_mode: ref_mode,
+        };
+        let ind_rust = self.rust_parameters.len();
+        self.rust_parameters.push(rust_par);
+
+        let transform = Transformation {
+            ind_c: ind_c,
+            ind_rust: ind_rust,
+            transformation: TransformationType::None,
+            name: name,
+            typ: type_tid,
+            transfer: transfer,
+            ref_mode: ref_mode,
+            conversion_type: conversion_type,
+        };
+        self.transformations.push(transform);
+    }
+
+    pub fn get(&self, ind_rust: usize) -> Option<&Transformation> {
+        self.transformations.iter()
+            .filter(|tr| tr.ind_rust==ind_rust)
+            .next()
+    }
+}
+
+pub fn analyze(env: &Env, signal_parameters: &[library::Parameter], type_tid: library::TypeId,
+               configured_signals: &[&config::signals::Signal]) -> Parameters {
+    let mut parameters = Parameters::new(signal_parameters.len() + 1);
+
+    let owner = env.type_(type_tid);
+    let c_type = format!("{}*", owner.get_glib_name().unwrap());
+
+    parameters.push(type_tid, "this".to_owned(), c_type,
+                    library::ParameterDirection::In, library::Transfer::None,
+                    library::Nullable(false), RefMode::ByRef,
+                    ConversionType::Pointer);
+
+    for par in signal_parameters {
+        let name = nameutil::mangle_keywords(&*par.name).into_owned();
+
+        let ref_mode = RefMode::without_unneeded_mut(&env.library, par, false);
+
+        let nullable_override = configured_signals.matched_parameters(&name).iter()
+            .filter_map(|p| p.nullable)
+            .next();
+        let nullable = nullable_override.unwrap_or(par.nullable);
+
+        let conversion_type = ConversionType::of(&env.library, par.typ);
+
+        parameters.push(par.typ, name, par.c_type.clone(), par.direction,
+                        par.transfer, nullable, ref_mode, conversion_type);
+    }
+
+    parameters
+}

--- a/src/codegen/trampoline_from_glib.rs
+++ b/src/codegen/trampoline_from_glib.rs
@@ -15,8 +15,9 @@ impl TrampolineFromGlib for Transformation {
         match self.conversion_type {
             Direct => self.name.clone(),
             Scalar => format!("from_glib({})", self.name),
-            Pointer => {
-                let (mut left, mut right) = from_glib_xxx(self.transfer);
+            Borrow | Pointer => {
+                let is_borrow = self.conversion_type == Borrow;
+                let (mut left, mut right) = from_glib_xxx(self.transfer, is_borrow);
                 if need_type_name {
                     let type_name = rust_type(env, self.typ).into_string();
                     left = format!("&{}::{}", type_name, left);
@@ -33,9 +34,10 @@ impl TrampolineFromGlib for Transformation {
     }
 }
 
-fn from_glib_xxx(transfer: library::Transfer) -> (String, String) {
+fn from_glib_xxx(transfer: library::Transfer, is_borrow: bool) -> (String, String) {
     use library::Transfer::*;
     match transfer {
+        None if is_borrow => ("from_glib_borrow(".into(), ")".into()),
         None => ("from_glib_none(".into(), ")".into()),
         Full => ("from_glib_full(".into(), ")".into()),
         Container => ("from_glib_container(".into(), ")".into()),

--- a/src/codegen/trampoline_from_glib.rs
+++ b/src/codegen/trampoline_from_glib.rs
@@ -1,6 +1,5 @@
-use analysis::parameter::Parameter;
 use analysis::rust_type::rust_type;
-use analysis::conversion_type::ConversionType;
+use analysis::trampoline_parameters::Transformation;
 use env::Env;
 use library;
 use traits::*;
@@ -9,11 +8,11 @@ pub trait TrampolineFromGlib {
     fn trampoline_from_glib(&self, env: &Env, need_downcast: bool) -> String;
 }
 
-impl TrampolineFromGlib for Parameter {
+impl TrampolineFromGlib for Transformation {
     fn trampoline_from_glib(&self, env: &Env, need_downcast: bool) -> String {
         use analysis::conversion_type::ConversionType::*;
         let need_type_name = need_downcast || is_need_type_name(env, self.typ);
-        match ConversionType::of(&env.library, self.typ) {
+        match self.conversion_type {
             Direct => self.name.clone(),
             Scalar => format!("from_glib({})", self.name),
             Pointer => {

--- a/src/codegen/trampoline_to_glib.rs
+++ b/src/codegen/trampoline_to_glib.rs
@@ -12,6 +12,7 @@ impl TrampolineToGlib for library::Parameter {
             Direct => String::new(),
             Scalar => ".to_glib()".to_owned(),
             Pointer => to_glib_xxx(self.transfer).to_owned(),
+            Borrow => "/*Not applicable conversion Borrow*/".to_owned(),
             Unknown => "/*Unknown conversion*/".to_owned(),
         }
     }

--- a/src/codegen/translate_from_glib.rs
+++ b/src/codegen/translate_from_glib.rs
@@ -27,6 +27,7 @@ impl TranslateFromGlib for Mode {
                     _ => trans,
                 }
             }
+            Borrow => ("/*TODO: conversion Borrow*/".into(), String::new()),
             Unknown => ("/*Unknown conversion*/".into(), String::new()),
         }
     }

--- a/src/codegen/translate_to_glib.rs
+++ b/src/codegen/translate_to_glib.rs
@@ -22,6 +22,7 @@ impl TranslateToGlib for chunk::parameter_ffi_call_in::Parameter {
                     format!("{}{}{}{}", left, self.name, self.to_glib_extra, right)
                 }
             }
+            Borrow => "/*Not applicable conversion Borrow*/".to_owned(),
             Unknown => format!("/*Unknown conversion*/{}", self.name),
         }
     }

--- a/src/config/signals.rs
+++ b/src/config/signals.rs
@@ -1,3 +1,5 @@
+use std::str::FromStr;
+
 use library::Nullable;
 use super::functions::Return;
 use super::ident::Ident;
@@ -6,10 +8,28 @@ use super::parsable::{Parsable, Parse};
 use toml::Value;
 use version::Version;
 
+#[derive(Clone, Copy, Debug)]
+pub enum TransformationType {
+    None,
+    Borrow, //replace from_glib_none to from_glib_borrow
+}
+
+impl FromStr for TransformationType {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "none" => Ok(TransformationType::None),
+            "borrow" => Ok(TransformationType::Borrow),
+            _ => Err(format!("Wrong transformation \"{}\"", s))
+        }
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct Parameter {
     pub ident: Ident,
     pub nullable: Option<Nullable>,
+    pub transformation: Option<TransformationType>,
 }
 
 impl Parse for Parameter {
@@ -24,10 +44,18 @@ impl Parse for Parameter {
         let nullable = toml.lookup("nullable")
             .and_then(|val| val.as_bool())
             .map(|b| Nullable(b));
+        let transformation = toml.lookup("transformation")
+            .and_then(|val| val.as_str())
+            .and_then(|s| TransformationType::from_str(s)
+                      .map_err(|err| {
+                          error!("{0}", err);
+                          err
+                      }).ok());
 
         Some(Parameter{
             ident: ident,
             nullable: nullable,
+            transformation: transformation,
         })
     }
 }

--- a/src/config/signals.rs
+++ b/src/config/signals.rs
@@ -33,6 +33,7 @@ pub struct Parameter {
     pub ident: Ident,
     pub nullable: Option<Nullable>,
     pub transformation: Option<TransformationType>,
+    pub new_name: Option<String>,
 }
 
 impl Parse for Parameter {
@@ -54,11 +55,15 @@ impl Parse for Parameter {
                           error!("{0}", err);
                           err
                       }).ok());
+        let new_name = toml.lookup("new_name")
+            .and_then(|val| val.as_str())
+            .map(|s| s.to_owned());
 
         Some(Parameter{
             ident: ident,
             nullable: nullable,
             transformation: transformation,
+            new_name: new_name,
         })
     }
 }

--- a/src/config/signals.rs
+++ b/src/config/signals.rs
@@ -12,6 +12,8 @@ use version::Version;
 pub enum TransformationType {
     None,
     Borrow, //replace from_glib_none to from_glib_borrow
+    //TODO: configure
+    TreePath, //convert string to TreePath
 }
 
 impl FromStr for TransformationType {
@@ -20,6 +22,7 @@ impl FromStr for TransformationType {
         match s {
             "none" => Ok(TransformationType::None),
             "borrow" => Ok(TransformationType::Borrow),
+            "treepath" => Ok(TransformationType::TreePath),
             _ => Err(format!("Wrong transformation \"{}\"", s))
         }
     }


### PR DESCRIPTION
Rework of trampoline parameters by idea in #264.
Added 2 transformation:
- "borrow" for replace `from_glib_none` to `from_glib_borrow`
- "treepath" for adding string to `TreePath` conversion

Currently not adding return values to parameters.

Warning: based on #292 so better merge it first.