### PR TITLE
Fix load latest girs

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -737,6 +737,7 @@ impl Library {
                         }
                         "doc" => doc = try!(read_text(parser)),
                         "doc-deprecated" => doc_deprecated = try!(read_text(parser)),
+                        "doc-version" => try!(ignore_element(parser)),
                         x => return Err(mk_error!(format!("Unexpected element <{}>", x), parser)),
                     }
                 }


### PR DESCRIPTION
Fixes error on loading latest ubuntu gir's
```
thread 'main' panicked at 'src\parser.rs:740 Unexpected element <doc-version> in D:\eap\rust\0\gtk\gir-files\Gdk-3.0.gir:22214:9', src\parser.rs:53
```
On this method:
```xml
<method name="fullscreen_on_monitor"
        c:identifier="gdk_window_fullscreen_on_monitor">
  <doc xml:space="preserve">Moves the window into fullscreen mode on the given monitor. This means
the window covers the entire screen and is above any panels or task bars.

If the window was already fullscreen, then this function does nothing.</doc>
  <doc-version xml:space="preserve">UNRELEASED</doc-version>
  <return-value transfer-ownership="none">
    <type name="none" c:type="void"/>
  </return-value>
  <parameters>
    <instance-parameter name="window" transfer-ownership="none">
      <doc xml:space="preserve">a toplevel #GdkWindow</doc>
      <type name="Window" c:type="GdkWindow*"/>
    </instance-parameter>
    <parameter name="monitor" transfer-ownership="none">
      <doc xml:space="preserve">Which monitor to display fullscreen on.</doc>
      <type name="gint" c:type="gint"/>
    </parameter>
  </parameters>
</method>
```

Closes #268

Blocker of https://github.com/gtk-rs/gir-files/issues/1