### PR TITLE
Don't implement Display trait for non-standard to_string

### DIFF
--- a/src/analysis/special_functions.rs
+++ b/src/analysis/special_functions.rs
@@ -50,6 +50,9 @@ pub fn extract(functions: &mut Vec<FuncInfo>) -> Infos {
                 if let Some(par) = func.ret.parameter.as_mut() {
                     *par.nullable = false;
                 }
+                if func.parameters.len() != 1 {
+                    continue;
+                }
             }
             specials.insert(type_, func.glib_name.clone());
         }


### PR DESCRIPTION
Fixes StyleContext for Gtk 3.20 (https://github.com/gtk-rs/gtk/pull/443#issuecomment-278370871)