### PR TITLE
Add Into<&str> for optional parameters

### DIFF
--- a/src/analysis/bounds.rs
+++ b/src/analysis/bounds.rs
@@ -114,23 +114,23 @@ mod tests {
     fn get_new_all() {
         let mut bounds: Bounds = Default::default();
         let typ = BoundType::IsA;
-        assert_eq!(bounds.add_parameter("a", "", typ), true);
-        assert_eq!(bounds.add_parameter("a", "", typ), false);  //Don't add second time
-        assert_eq!(bounds.add_parameter("b", "", typ), true);
-        assert_eq!(bounds.add_parameter("c", "", typ), true);
-        assert_eq!(bounds.add_parameter("d", "", typ), true);
-        assert_eq!(bounds.add_parameter("e", "", typ), true);
-        assert_eq!(bounds.add_parameter("f", "", typ), true);
-        assert_eq!(bounds.add_parameter("g", "", typ), true);
-        assert_eq!(bounds.add_parameter("h", "", typ), false);
+        assert_eq!(bounds.add_parameter("a", "", typ, false), true);
+        assert_eq!(bounds.add_parameter("a", "", typ, false), false);  //Don't add second time
+        assert_eq!(bounds.add_parameter("b", "", typ, false), true);
+        assert_eq!(bounds.add_parameter("c", "", typ, false), true);
+        assert_eq!(bounds.add_parameter("d", "", typ, false), true);
+        assert_eq!(bounds.add_parameter("e", "", typ, false), true);
+        assert_eq!(bounds.add_parameter("f", "", typ, false), true);
+        assert_eq!(bounds.add_parameter("g", "", typ, false), true);
+        assert_eq!(bounds.add_parameter("h", "", typ, false), false);
     }
 
     #[test]
     fn get_parameter_alias_info() {
         let mut bounds: Bounds = Default::default();
         let typ = BoundType::IsA;
-        bounds.add_parameter("a", "", typ);
-        bounds.add_parameter("b", "", typ);
+        bounds.add_parameter("a", "", typ, false);
+        bounds.add_parameter("b", "", typ, false);
         assert_eq!(bounds.get_parameter_alias_info("a"), Some(("T", typ)));
         assert_eq!(bounds.get_parameter_alias_info("b"), Some(("U", typ)));
         assert_eq!(bounds.get_parameter_alias_info("c"), None);

--- a/src/analysis/bounds.rs
+++ b/src/analysis/bounds.rs
@@ -56,12 +56,6 @@ impl Bounds {
             _ => String::new(),
         }
     }
-    pub fn get_cast(library: &Library, type_id: TypeId, is_nullable: bool) -> String {
-        match *library.type_(type_id) {
-            Type::Fundamental(Fundamental::Utf8) if is_nullable => "Option<&'a str>".to_owned(),
-            _ => String::new(),
-        }
-    }
     pub fn add_parameter(&mut self, name: &str, type_str: &str, bound_type: BoundType,
                          is_nullable: bool) -> bool {
         if self.used.iter().any(|ref n| n.0 == name) { return false; }

--- a/src/analysis/bounds.rs
+++ b/src/analysis/bounds.rs
@@ -49,9 +49,16 @@ impl Bounds {
             _ => None,
         }
     }
-    pub fn to_glib_extra(library: &Library, type_id: TypeId) -> String {
+    pub fn to_glib_extra(library: &Library, type_id: TypeId, is_nullable: bool) -> String {
         match *library.type_(type_id) {
             Type::Fundamental(Fundamental::Filename) => ".as_ref()".to_owned(),
+            Type::Fundamental(Fundamental::Utf8) if is_nullable => ".into()".to_owned(),
+            _ => String::new(),
+        }
+    }
+    pub fn get_cast(library: &Library, type_id: TypeId, is_nullable: bool) -> String {
+        match *library.type_(type_id) {
+            Type::Fundamental(Fundamental::Utf8) if is_nullable => "Option<&'a str>".to_owned(),
             _ => String::new(),
         }
     }

--- a/src/analysis/functions.rs
+++ b/src/analysis/functions.rs
@@ -119,7 +119,8 @@ fn analyze_function(env: &Env, name: String, func: &library::Function, type_tid:
         if !par.instance_parameter && par.direction != ParameterDirection::Out {
             if let Some(bound_type) = Bounds::type_for(env, par.typ) {
                 let type_name = bounds_rust_type(env, par.typ);
-                if !bounds.add_parameter(&par.name, &type_name.into_string(), bound_type) {
+                if !bounds.add_parameter(&par.name, &type_name.into_string(), bound_type,
+                                         *par.nullable) {
                     panic!("Too many parameters upcasts for {}", func.c_identifier.as_ref().unwrap())
                 }
             }

--- a/src/analysis/parameter.rs
+++ b/src/analysis/parameter.rs
@@ -27,6 +27,7 @@ pub struct Parameter {
     //for AsRef trait bound
     //TODO: Find normal way to do it
     pub to_glib_extra: String,
+    pub cast: String,
 }
 
 pub fn analyze(env: &Env, par: &library::Parameter, configured_functions: &[&Function]) -> Parameter {
@@ -44,7 +45,8 @@ pub fn analyze(env: &Env, par: &library::Parameter, configured_functions: &[&Fun
         .filter_map(|p| p.nullable)
         .next();
     let nullable = nullable_override.unwrap_or(par.nullable);
-    let to_glib_extra = Bounds::to_glib_extra(&env.library, par.typ);
+    let to_glib_extra = Bounds::to_glib_extra(&env.library, par.typ, *nullable);
+    let cast = Bounds::get_cast(&env.library, par.typ, *nullable);
 
     Parameter {
         name: name.into_owned(),
@@ -59,5 +61,6 @@ pub fn analyze(env: &Env, par: &library::Parameter, configured_functions: &[&Fun
         ref_mode: ref_mode,
         is_error: par.is_error,
         to_glib_extra: to_glib_extra,
+        cast: cast,
     }
 }

--- a/src/analysis/parameter.rs
+++ b/src/analysis/parameter.rs
@@ -27,7 +27,6 @@ pub struct Parameter {
     //for AsRef trait bound
     //TODO: Find normal way to do it
     pub to_glib_extra: String,
-    pub cast: String,
 }
 
 pub fn analyze(env: &Env, par: &library::Parameter, configured_functions: &[&Function]) -> Parameter {
@@ -46,7 +45,6 @@ pub fn analyze(env: &Env, par: &library::Parameter, configured_functions: &[&Fun
         .next();
     let nullable = nullable_override.unwrap_or(par.nullable);
     let to_glib_extra = Bounds::to_glib_extra(&env.library, par.typ, *nullable);
-    let cast = Bounds::get_cast(&env.library, par.typ, *nullable);
 
     Parameter {
         name: name.into_owned(),
@@ -61,6 +59,5 @@ pub fn analyze(env: &Env, par: &library::Parameter, configured_functions: &[&Fun
         ref_mode: ref_mode,
         is_error: par.is_error,
         to_glib_extra: to_glib_extra,
-        cast: cast,
     }
 }

--- a/src/analysis/rust_type.rs
+++ b/src/analysis/rust_type.rs
@@ -94,8 +94,7 @@ fn rust_type_full(env: &Env, type_id: library::TypeId, nullable: Nullable, ref_m
                 Filename => {
                     if ref_mode.is_ref() {
                         ok("std::path::Path")
-                    }
-                    else {
+                    } else {
                         ok("std::path::PathBuf")
                     }
                 }
@@ -103,7 +102,7 @@ fn rust_type_full(env: &Env, type_id: library::TypeId, nullable: Nullable, ref_m
                 Unsupported => err("Unsupported"),
                 _ => err(&format!("Fundamental: {:?}", fund)),
             }
-        },
+        }
         Alias(ref alias) => {
             rust_type_full(env, alias.typ, nullable, ref_mode)
                 .map_any(|_| alias.name.clone())
@@ -213,6 +212,7 @@ pub fn parameter_rust_type(env: &Env, type_id:library::TypeId,
                 rust_type.map_any(|s| format_parameter(s, direction))
             }
         }
+
         Alias(ref alias) => {
             rust_type.and_then(|s| {
                 parameter_rust_type(env, alias.typ, direction, nullable, ref_mode)

--- a/src/analysis/trampolines.rs
+++ b/src/analysis/trampolines.rs
@@ -49,7 +49,7 @@ pub fn analyze(env: &Env, signal: &library::Signal, type_tid: library::TypeId, i
 
     if in_trait {
         let type_name = bounds_rust_type(env, type_tid);
-        bounds.add_parameter("this", &type_name.into_string(), BoundType::IsA);
+        bounds.add_parameter("this", &type_name.into_string(), BoundType::IsA, false);
     }
 
     let parameters = trampoline_parameters::analyze(env, &signal.parameters,
@@ -57,7 +57,7 @@ pub fn analyze(env: &Env, signal: &library::Signal, type_tid: library::TypeId, i
 
     if in_trait {
         let type_name = bounds_rust_type(env, type_tid);
-        bounds.add_parameter("this", &type_name.into_string(), BoundType::IsA);
+        bounds.add_parameter("this", &type_name.into_string(), BoundType::IsA, false);
     }
 
 

--- a/src/chunk/parameter_ffi_call_in.rs
+++ b/src/chunk/parameter_ffi_call_in.rs
@@ -11,6 +11,7 @@ pub struct Parameter {
     pub nullable: library::Nullable,
     pub ref_mode: analysis::ref_mode::RefMode,
     pub to_glib_extra: String,
+    pub cast: String,
 }
 
 impl<'a> From<&'a analysis::parameter::Parameter> for Parameter {
@@ -24,6 +25,7 @@ impl<'a> From<&'a analysis::parameter::Parameter> for Parameter {
             nullable: orig.nullable,
             ref_mode: orig.ref_mode,
             to_glib_extra: orig.to_glib_extra.clone(),
+            cast: orig.cast.clone(),
         }
     }
 }

--- a/src/chunk/parameter_ffi_call_in.rs
+++ b/src/chunk/parameter_ffi_call_in.rs
@@ -11,7 +11,6 @@ pub struct Parameter {
     pub nullable: library::Nullable,
     pub ref_mode: analysis::ref_mode::RefMode,
     pub to_glib_extra: String,
-    pub cast: String,
 }
 
 impl<'a> From<&'a analysis::parameter::Parameter> for Parameter {
@@ -25,7 +24,6 @@ impl<'a> From<&'a analysis::parameter::Parameter> for Parameter {
             nullable: orig.nullable,
             ref_mode: orig.ref_mode,
             to_glib_extra: orig.to_glib_extra.clone(),
-            cast: orig.cast.clone(),
         }
     }
 }

--- a/src/codegen/function.rs
+++ b/src/codegen/function.rs
@@ -13,7 +13,7 @@ use writer::primitives::tabs;
 use writer::ToCode;
 
 pub fn generate(w: &mut Write, env: &Env, analysis: &analysis::functions::Info,
-    in_trait: bool, only_declaration: bool, indent: usize) -> Result<()> {
+                in_trait: bool, only_declaration: bool, indent: usize) -> Result<()> {
     let mut commented = false;
     let mut comment_prefix = "";
     let mut pub_prefix = if in_trait { "" } else { "pub " };
@@ -79,11 +79,14 @@ pub fn declaration(env: &Env, analysis: &analysis::functions::Info) -> String {
 fn bounds(bounds: &Bounds) -> String {
     use analysis::bounds::BoundType::*;
     if bounds.is_empty() { return String::new() }
-    let strs: Vec<String> = bounds.iter()
-        .map(|bound| match bound.3 {
-            IsA => format!("{}: IsA<{}>", bound.1, bound.2),
-            AsRef => format!("{}: AsRef<{}>", bound.1, bound.2),
-        })
+    let strs: Vec<String> = bounds.iter_lifetimes()
+        .map(|s| format!("'{}", s))
+        .chain(bounds.iter()
+                     .map(|bound| match bound.3 {
+                         IsA => format!("{}: IsA<{}>", bound.1, bound.2),
+                         AsRef => format!("{}: AsRef<{}>", bound.1, bound.2),
+                         Into => format!("{}: Into<Option<&'a {}>>", bound.1, bound.2),
+                     }))
         .collect();
     format!("<{}>", strs.join(", "))
 }

--- a/src/codegen/parameter.rs
+++ b/src/codegen/parameter.rs
@@ -25,7 +25,7 @@ impl ToParameter for Parameter {
                         } else {
                             type_str = format!("&{}{}", mut_str, t)
                         },
-                        BoundType::AsRef  => type_str = t.to_owned(),
+                        BoundType::AsRef | BoundType::Into => type_str = t.to_owned(),
                     }
                 }
                 None => {
@@ -34,7 +34,7 @@ impl ToParameter for Parameter {
                     let type_name = rust_type.into_string();
                     type_str = match ConversionType::of(&env.library, self.typ) {
                         ConversionType::Unknown => format!("/*Unknown conversion*/{}", type_name),
-                        _ => type_name
+                        _ => type_name,
                     }
                 }
             }

--- a/src/codegen/trampoline.rs
+++ b/src/codegen/trampoline.rs
@@ -88,7 +88,7 @@ fn func_parameter(env: &Env, par: &RustParameter, bounds: &Bounds,
                     };
                     type_str = format!("&{}{}", mut_str, t)
                 },
-                BoundType::AsRef  => type_str = t.to_owned(),
+                BoundType::AsRef | BoundType::Into => type_str = t.to_owned(),
             }
         }
         None => {

--- a/src/codegen/translate_to_glib.rs
+++ b/src/codegen/translate_to_glib.rs
@@ -17,9 +17,12 @@ impl TranslateToGlib for chunk::parameter_ffi_call_in::Parameter {
                 let (left, right) = to_glib_xxx(self.transfer, self.ref_mode);
                 if self.instance_parameter {
                     format!("{}self{}", left, right)
-                }
-                else {
-                    format!("{}{}{}{}", left, self.name, self.to_glib_extra, right)
+                } else {
+                    if self.cast.len() == 0 {
+                        format!("{}{}{}{}", left, self.name, self.to_glib_extra, right)
+                    } else {
+                        format!("{}({}{} as {}){}", left, self.name, self.to_glib_extra, self.cast, right)
+                    }
                 }
             }
             Borrow => "/*Not applicable conversion Borrow*/".to_owned(),

--- a/src/codegen/translate_to_glib.rs
+++ b/src/codegen/translate_to_glib.rs
@@ -18,11 +18,7 @@ impl TranslateToGlib for chunk::parameter_ffi_call_in::Parameter {
                 if self.instance_parameter {
                     format!("{}self{}", left, right)
                 } else {
-                    if self.cast.len() == 0 {
-                        format!("{}{}{}{}", left, self.name, self.to_glib_extra, right)
-                    } else {
-                        format!("{}({}{} as {}){}", left, self.name, self.to_glib_extra, self.cast, right)
-                    }
+                    format!("{}{}{}{}", left, self.name, self.to_glib_extra, right)
                 }
             }
             Borrow => "/*Not applicable conversion Borrow*/".to_owned(),

--- a/src/library.rs
+++ b/src/library.rs
@@ -173,7 +173,7 @@ pub struct TypeId {
 }
 
 impl TypeId {
-    pub fn full_name(&self, library: &Library) -> String{
+    pub fn full_name(&self, library: &Library) -> String {
         let ns_name = &library.namespace(self.ns_id).name;
         let type_ = &library.type_(*self);
         format!("{}.{}", ns_name, &type_.get_name()).into()


### PR DESCRIPTION
Remains to call `.into()` on the arguments (didn't look yet where I can do it in the code).

cc @EPashkin 