### PR TITLE
Bounds

### DIFF
--- a/src/analysis/bounds.rs
+++ b/src/analysis/bounds.rs
@@ -19,9 +19,9 @@ pub enum BoundType {
 
 #[derive(Debug)]
 pub struct Bounds {
-    unused: VecDeque<String>,
+    unused: VecDeque<char>,
     //Vector tuples <parameter name>, <alias>, <type>, <bound type>
-    used: Vec<(String, String, String, BoundType)>,
+    used: Vec<(String, char, String, BoundType)>,
     unused_lifetimes: VecDeque<char>,
     lifetimes: Vec<char>,
 }
@@ -29,7 +29,7 @@ pub struct Bounds {
 impl Default for Bounds {
     fn default () -> Bounds {
         Bounds {
-            unused: "TUVWXYZ".chars().map(|ch| ch.to_string()).collect(),
+            unused: "TUVWXYZ".chars().collect(),
             used: Vec::new(),
             unused_lifetimes: "abcdefg".chars().collect(),
             lifetimes: Vec::new(),
@@ -86,15 +86,15 @@ impl Bounds {
             }
         }
         if let Some(alias) = self.unused.pop_front() {
-            self.used.push((name.into(), alias.clone(), type_str.into(), bound_type));
+            self.used.push((name.into(), alias, type_str.into(), bound_type));
             true
         } else {
             false
         }
     }
-    pub fn get_parameter_alias_info(&self, name: &str) -> Option<(&str, BoundType)> {
+    pub fn get_parameter_alias_info(&self, name: &str) -> Option<(char, BoundType)> {
         self.used.iter().find(|ref n| n.0 == name)
-            .map(|t| (&*t.1, t.3))
+            .map(|t| (t.1, t.3))
     }
     pub fn update_imports(&self, imports: &mut Imports) {
         //TODO: import with versions
@@ -110,7 +110,7 @@ impl Bounds {
     pub fn is_empty(&self) -> bool {
         self.used.is_empty()
     }
-    pub fn iter(&self) ->  Iter<(String, String, String, BoundType)> {
+    pub fn iter(&self) ->  Iter<(String, char, String, BoundType)> {
         self.used.iter()
     }
     pub fn iter_lifetimes(&self) -> Iter<char> {
@@ -144,8 +144,8 @@ mod tests {
         let typ = BoundType::IsA;
         bounds.add_parameter("a", "", typ);
         bounds.add_parameter("b", "", typ);
-        assert_eq!(bounds.get_parameter_alias_info("a"), Some(("T", typ)));
-        assert_eq!(bounds.get_parameter_alias_info("b"), Some(("U", typ)));
+        assert_eq!(bounds.get_parameter_alias_info("a"), Some(('T', typ)));
+        assert_eq!(bounds.get_parameter_alias_info("b"), Some(('U', typ)));
         assert_eq!(bounds.get_parameter_alias_info("c"), None);
     }
 }

--- a/src/analysis/functions.rs
+++ b/src/analysis/functions.rs
@@ -11,7 +11,7 @@ use analysis::safety_assertion_mode::SafetyAssertionMode;
 use analysis::signatures::{Signature, Signatures};
 use config;
 use env::Env;
-use library::{self, Nullable, ParameterDirection};
+use library::{self, Nullable};
 use nameutil;
 use traits::*;
 use version::Version;
@@ -115,17 +115,8 @@ fn analyze_function(env: &Env, name: String, func: &library::Function, type_tid:
         if let Ok(s) = used_rust_type(env, par.typ) {
             used_types.push(s);
         }
+        bounds.add_for_parameter(env, func, par);
         let type_error = parameter_rust_type(env, par.typ, par.direction, Nullable(false), RefMode::None).is_err();
-        if !par.instance_parameter && par.direction != ParameterDirection::Out {
-            if let Some(bound_type) = Bounds::type_for(env, par.typ, par.nullable) {
-                let to_glib_extra = Bounds::to_glib_extra(bound_type);
-                par.to_glib_extra = to_glib_extra;
-                let type_name = bounds_rust_type(env, par.typ);
-                if !bounds.add_parameter(&par.name, &type_name.into_string(), bound_type) {
-                    panic!("Too many parameters upcasts for {}", func.c_identifier.as_ref().unwrap())
-                }
-            }
-        }
         if type_error {
             commented = true;
         }

--- a/src/analysis/special_functions.rs
+++ b/src/analysis/special_functions.rs
@@ -43,7 +43,7 @@ pub fn extract(functions: &mut Vec<FuncInfo>) -> Infos {
     for func in functions.iter_mut() {
         if let Ok(type_) = Type::from_str(&func.name) {
             if func.visibility != Visibility::Comment {
-                func.visibility = visibility(type_);
+                func.visibility = visibility(type_, func.parameters.len());
             }
             // I assume `to_string` functions never return `NULL`
             if type_ == Type::ToString {
@@ -61,7 +61,7 @@ pub fn extract(functions: &mut Vec<FuncInfo>) -> Infos {
     specials
 }
 
-fn visibility(t: Type) -> Visibility {
+fn visibility(t: Type, args_len: usize) -> Visibility {
     use self::Type::*;
     match t {
         Copy |
@@ -69,8 +69,9 @@ fn visibility(t: Type) -> Visibility {
             Ref |
             Unref => Visibility::Hidden,
         Compare |
-            Equal |
-            ToString => Visibility::Private,
+            Equal => Visibility::Private,
+        ToString if args_len == 1 => Visibility::Private,
+        ToString => Visibility::Public,
     }
 }
 

--- a/src/codegen/function.rs
+++ b/src/codegen/function.rs
@@ -85,7 +85,7 @@ fn bounds(bounds: &Bounds) -> String {
                      .map(|bound| match bound.3 {
                          IsA => format!("{}: IsA<{}>", bound.1, bound.2),
                          AsRef => format!("{}: AsRef<{}>", bound.1, bound.2),
-                         Into => format!("{}: Into<Option<&'a {}>>", bound.1, bound.2),
+                         Into(l) => format!("{}: Into<Option<&'{} {}>>", bound.1, l, bound.2),
                      }))
         .collect();
     format!("<{}>", strs.join(", "))

--- a/src/codegen/parameter.rs
+++ b/src/codegen/parameter.rs
@@ -25,7 +25,7 @@ impl ToParameter for Parameter {
                         } else {
                             type_str = format!("&{}{}", mut_str, t)
                         },
-                        BoundType::AsRef | BoundType::Into(_) => type_str = t.to_owned(),
+                        BoundType::AsRef | BoundType::Into(_) => type_str = t.to_string(),
                     }
                 }
                 None => {

--- a/src/codegen/parameter.rs
+++ b/src/codegen/parameter.rs
@@ -25,7 +25,7 @@ impl ToParameter for Parameter {
                         } else {
                             type_str = format!("&{}{}", mut_str, t)
                         },
-                        BoundType::AsRef | BoundType::Into => type_str = t.to_owned(),
+                        BoundType::AsRef | BoundType::Into(_) => type_str = t.to_owned(),
                     }
                 }
                 None => {

--- a/src/codegen/signal.rs
+++ b/src/codegen/signal.rs
@@ -62,7 +62,7 @@ fn function_type_string(env: &Env, analysis: &analysis::signals::Info,
         None => panic!("Internal error: can't find trampoline '{}'", trampoline_name),
     };
 
-    let type_ = func_string(env, trampoline, Some(("T", "Self")));
+    let type_ = func_string(env, trampoline, Some(('T', "Self")));
     Some(type_)
 }
 

--- a/src/codegen/trampoline.rs
+++ b/src/codegen/trampoline.rs
@@ -88,7 +88,7 @@ fn func_parameter(env: &Env, par: &RustParameter, bounds: &Bounds,
                     };
                     type_str = format!("&{}{}", mut_str, t)
                 },
-                BoundType::AsRef | BoundType::Into => type_str = t.to_owned(),
+                BoundType::AsRef | BoundType::Into(_) => type_str = t.to_owned(),
             }
         }
         None => {


### PR DESCRIPTION
Add multiple lifetimes for Into bound. Affected `glib`, `gio`, no uncommented changes in `gtk`
```diff
-    pub fn set_comment<'a, T: Into<Option<&'a str>>, U: Into<Option<&'a str>>>(&self, group_name: T, key: U, comment: &str) -> Result<(), Error> {
+    pub fn set_comment<'a, 'b, T: Into<Option<&'a str>>, U: Into<Option<&'b str>>>(&self, group_name: T, key: U, comment: &str) -> Result<(), Error> {
```
Fixed generation private and unused StyleContext::to_string
```diff
     #[cfg(feature = "v3_20")]
-    fn to_string(&self, flags: StyleContextPrintFlags) -> String {
+    pub fn to_string(&self, flags: StyleContextPrintFlags) -> String {
```

@GuillaumeGomez, IMHO regen affected can wait until we done with `Into`