### PR TITLE
Add into conversion for every nullable type

### DIFF
--- a/src/analysis/return_value.rs
+++ b/src/analysis/return_value.rs
@@ -7,7 +7,7 @@ use library::{self, Nullable};
 #[derive(Clone, Debug, Default)]
 pub struct Info {
     pub parameter: Option<library::Parameter>,
-    pub base_tid: Option<library::TypeId>,  //Some only if need downcast
+    pub base_tid: Option<library::TypeId>,  // Some only if need downcast
     pub commented: bool,
 }
 
@@ -66,8 +66,7 @@ pub fn analyze(env: &Env, func: &library::Function, type_tid: library::TypeId,
     }
 }
 
-fn can_be_nullable_return(env: &Env, type_id: library::TypeId) -> bool
-{
+fn can_be_nullable_return(env: &Env, type_id: library::TypeId) -> bool {
     use library::Type::*;
     use library::Fundamental::*;
     match *env.library.type_(type_id) {

--- a/src/analysis/trampolines.rs
+++ b/src/analysis/trampolines.rs
@@ -49,7 +49,7 @@ pub fn analyze(env: &Env, signal: &library::Signal, type_tid: library::TypeId, i
 
     if in_trait {
         let type_name = bounds_rust_type(env, type_tid);
-        bounds.add_parameter("this", &type_name.into_string(), BoundType::IsA);
+        bounds.add_parameter("this", &type_name.into_string(), BoundType::IsA(None));
     }
 
     let parameters = trampoline_parameters::analyze(env, &signal.parameters,
@@ -57,7 +57,7 @@ pub fn analyze(env: &Env, signal: &library::Signal, type_tid: library::TypeId, i
 
     if in_trait {
         let type_name = bounds_rust_type(env, type_tid);
-        bounds.add_parameter("this", &type_name.into_string(), BoundType::IsA);
+        bounds.add_parameter("this", &type_name.into_string(), BoundType::IsA(None));
     }
 
 

--- a/src/chunk/parameter_ffi_call_in.rs
+++ b/src/chunk/parameter_ffi_call_in.rs
@@ -11,6 +11,7 @@ pub struct Parameter {
     pub nullable: library::Nullable,
     pub ref_mode: analysis::ref_mode::RefMode,
     pub to_glib_extra: String,
+    pub is_into: bool,
 }
 
 impl<'a> From<&'a analysis::parameter::Parameter> for Parameter {
@@ -24,6 +25,7 @@ impl<'a> From<&'a analysis::parameter::Parameter> for Parameter {
             nullable: orig.nullable,
             ref_mode: orig.ref_mode,
             to_glib_extra: orig.to_glib_extra.clone(),
+            is_into: orig.is_into,
         }
     }
 }

--- a/src/codegen/function.rs
+++ b/src/codegen/function.rs
@@ -90,8 +90,10 @@ fn bounds(bounds: &Bounds) -> String {
                          AsRef(Some(lifetime)) => format!("{}: AsRef<{}> + '{}",
                                                           bound.alias, bound.type_str, lifetime),
                          AsRef(None) => format!("{}: AsRef<{}>", bound.alias, bound.type_str),
-                         Into(l, _) => format!("{}: Into<Option<&'{} {}>>",
-                                               bound.alias, l, bound.type_str),
+                         Into(Some(l), _) => format!("{}: Into<Option<&'{} {}>>",
+                                                     bound.alias, l, bound.type_str),
+                         Into(None, _) => format!("{}: Into<Option<{}>>",
+                                                  bound.alias, bound.type_str),
                      }))
         .collect();
     format!("<{}>", strs.join(", "))

--- a/src/codegen/function.rs
+++ b/src/codegen/function.rs
@@ -83,12 +83,15 @@ fn bounds(bounds: &Bounds) -> String {
         .map(|s| format!("'{}", s))
         .chain(bounds.iter()
                      .map(|bound| match bound.bound_type {
-                         IsA => format!("{}: IsA<{}>", bound.alias, bound.type_str),
-                         AsRef => format!("{}: AsRef<{}>", bound.alias, bound.type_str),
-                         Into(l, Some(_)) => format!("{}: Into<Option<&'{} IsA<{}>>>",
-                                                     bound.alias, l, bound.type_str),
-                         Into(l, None) => format!("{}: Into<Option<&'{} {}>>",
-                                                  bound.alias, l, bound.type_str),
+                         IsA(Some(lifetime)) => format!("{}: IsA<{}> + '{}",
+                                                        bound.alias, bound.type_str, lifetime),
+                         IsA(None) => format!("{}: IsA<{}>", bound.alias, bound.type_str),
+                         // This case should normally never happened
+                         AsRef(Some(lifetime)) => format!("{}: AsRef<{}> + '{}",
+                                                          bound.alias, bound.type_str, lifetime),
+                         AsRef(None) => format!("{}: AsRef<{}>", bound.alias, bound.type_str),
+                         Into(l, _) => format!("{}: Into<Option<&'{} {}>>",
+                                               bound.alias, l, bound.type_str),
                      }))
         .collect();
     format!("<{}>", strs.join(", "))

--- a/src/codegen/function.rs
+++ b/src/codegen/function.rs
@@ -85,8 +85,10 @@ fn bounds(bounds: &Bounds) -> String {
                      .map(|bound| match bound.bound_type {
                          IsA => format!("{}: IsA<{}>", bound.alias, bound.type_str),
                          AsRef => format!("{}: AsRef<{}>", bound.alias, bound.type_str),
-                         Into(l) => format!("{}: Into<Option<&'{} {}>>",
-                                            bound.alias, l, bound.type_str),
+                         Into(l, Some(_)) => format!("{}: Into<Option<&'{} IsA<{}>>>",
+                                                     bound.alias, l, bound.type_str),
+                         Into(l, None) => format!("{}: Into<Option<&'{} {}>>",
+                                                  bound.alias, l, bound.type_str),
                      }))
         .collect();
     format!("<{}>", strs.join(", "))

--- a/src/codegen/parameter.rs
+++ b/src/codegen/parameter.rs
@@ -20,15 +20,16 @@ impl ToParameter for Parameter {
             match bounds.get_parameter_alias_info(&self.name) {
                 Some((t, bound_type)) => {
                     match bound_type {
-                        BoundType::IsA => if *self.nullable {
-                            type_str = format!("Option<&{}{}>", mut_str, t)
+                        BoundType::IsA(_) => if *self.nullable {
+                            // should not happen!
+                            type_str = String::new()
                         } else {
                             type_str = format!("&{}{}", mut_str, t)
                         },
                         BoundType::Into(_, Some(_)) => {
                             type_str = format!("{}", t)
                         }
-                        BoundType::AsRef | BoundType::Into(_, None) => type_str = t.to_string(),
+                        BoundType::AsRef(_) | BoundType::Into(_, None) => type_str = t.to_string(),
                     }
                 }
                 None => {

--- a/src/codegen/parameter.rs
+++ b/src/codegen/parameter.rs
@@ -25,7 +25,10 @@ impl ToParameter for Parameter {
                         } else {
                             type_str = format!("&{}{}", mut_str, t)
                         },
-                        BoundType::AsRef | BoundType::Into(_) => type_str = t.to_string(),
+                        BoundType::Into(_, Some(_)) => {
+                            type_str = format!("{}", t)
+                        }
+                        BoundType::AsRef | BoundType::Into(_, None) => type_str = t.to_string(),
                     }
                 }
                 None => {

--- a/src/codegen/parameter.rs
+++ b/src/codegen/parameter.rs
@@ -27,7 +27,7 @@ impl ToParameter for Parameter {
                             type_str = format!("&{}{}", mut_str, t)
                         },
                         BoundType::Into(_, Some(_)) => {
-                            type_str = format!("{}", t)
+                            type_str = t.to_string()
                         }
                         BoundType::AsRef(_) | BoundType::Into(_, None) => type_str = t.to_string(),
                     }

--- a/src/codegen/property_body.rs
+++ b/src/codegen/property_body.rs
@@ -84,11 +84,11 @@ impl Builder {
             base_tid: None,
             commented: false,
         };
-        let ffi_call = Chunk::FfiCall{
+        let ffi_call = Chunk::FfiCall {
             name: self.get_ffi_func(),
             params: params,
         };
-        body.push(Chunk::FfiCallConversion{
+        body.push(Chunk::FfiCallConversion {
             ret: return_info,
             call: Box::new(ffi_call),
         });
@@ -137,7 +137,7 @@ impl Builder {
 
         let mut body = Vec::new();
 
-        let ffi_call = Chunk::FfiCall{
+        let ffi_call = Chunk::FfiCall {
             name: self.set_ffi_func(),
             params: params,
         };
@@ -146,7 +146,7 @@ impl Builder {
             base_tid: None,
             commented: false,
         };
-        body.push(Chunk::FfiCallConversion{
+        body.push(Chunk::FfiCallConversion {
             ret: return_info,
             call: Box::new(ffi_call),
         });

--- a/src/codegen/signal.rs
+++ b/src/codegen/signal.rs
@@ -2,6 +2,7 @@ use std::io::{Result, Write};
 
 use analysis;
 use chunk::Chunk;
+use consts::TYPE_PARAMETERS_START;
 use env::Env;
 use super::general::version_condition;
 use super::signal_body;
@@ -62,7 +63,7 @@ fn function_type_string(env: &Env, analysis: &analysis::signals::Info,
         None => panic!("Internal error: can't find trampoline '{}'", trampoline_name),
     };
 
-    let type_ = func_string(env, trampoline, Some(('T', "Self")));
+    let type_ = func_string(env, trampoline, Some((TYPE_PARAMETERS_START, "Self")));
     Some(type_)
 }
 

--- a/src/codegen/trampoline.rs
+++ b/src/codegen/trampoline.rs
@@ -88,7 +88,7 @@ fn func_parameter(env: &Env, par: &RustParameter, bounds: &Bounds,
                 } else {
                     format!("&{}{}", mut_str, t)
                 },
-                BoundType::AsRef | BoundType::Into(_) => t.to_string(),
+                BoundType::AsRef | BoundType::Into(_, _) => t.to_string(),
             }
         }
         None => {

--- a/src/codegen/translate_to_glib.rs
+++ b/src/codegen/translate_to_glib.rs
@@ -12,7 +12,8 @@ impl TranslateToGlib for chunk::parameter_ffi_call_in::Parameter {
         use analysis::conversion_type::ConversionType::*;
         match ConversionType::of(library, self.typ) {
             Direct => self.name.clone(),
-            Scalar => format!("{}{}", self.name, ".to_glib()"),
+            Scalar => format!("{}{}{}",
+                              self.name, if !*self.nullable { "" } else {".into()" }, ".to_glib()"),
             Pointer => {
                 let (left, right) = to_glib_xxx(self.transfer, self.ref_mode);
                 if self.instance_parameter {

--- a/src/codegen/translate_to_glib.rs
+++ b/src/codegen/translate_to_glib.rs
@@ -13,9 +13,9 @@ impl TranslateToGlib for chunk::parameter_ffi_call_in::Parameter {
         match ConversionType::of(library, self.typ) {
             Direct => self.name.clone(),
             Scalar => format!("{}{}{}",
-                              self.name, if !*self.nullable { "" } else {".into()" }, ".to_glib()"),
+                              self.name, if !*self.nullable { "" } else { ".into()" }, ".to_glib()"),
             Pointer => {
-                let (left, right) = to_glib_xxx(self.transfer, self.ref_mode);
+                let (left, right) = to_glib_xxx(self.transfer, self.ref_mode, self.is_into);
                 if self.instance_parameter {
                     format!("{}self{}", left, right)
                 } else {
@@ -28,15 +28,17 @@ impl TranslateToGlib for chunk::parameter_ffi_call_in::Parameter {
     }
 }
 
-fn to_glib_xxx(transfer: library::Transfer, ref_mode: RefMode) -> (&'static str, &'static str) {
+fn to_glib_xxx(transfer: library::Transfer, ref_mode: RefMode,
+               is_into: bool) -> (&'static str, &'static str) {
     use library::Transfer::*;
     match transfer {
         None => match ref_mode {
             RefMode::None => ("", ".to_glib_none_mut().0"),//unreachable!(),
-            RefMode::ByRef => ("", ".to_glib_none().0"),
+            RefMode::ByRef if !is_into => ("", ".to_glib_none().0"),
             RefMode::ByRefMut => ("", ".to_glib_none_mut().0"),
             RefMode::ByRefImmut => ("mut_override(", ".to_glib_none().0)"),
             RefMode::ByRefFake => ("", ""),//unreachable!(),
+            _ => ("", ""),
         },
         Full => ("", ".to_glib_full()"),
         Container => ("", ".to_glib_container().0"),

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -1,0 +1,1 @@
+pub const TYPE_PARAMETERS_START: char = 'P';

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,7 @@ mod analysis;
 mod chunk;
 mod codegen;
 mod config;
+mod consts;
 mod env;
 mod file_saver;
 mod git;


### PR DESCRIPTION
However, I can't make it work because (small subset of errors):

```
error[E0191]: the value of the associated type `Storage` (from the trait `glib::translate::ToGlibPtr`) must be specified
   --> src/auto/window.rs:993:49
    |
993 |     fn set_transient_for<'a, T: Into<Option<&'a IsA<Window>>>>(&self, parent: T) {
    |                                                 ^^^^^^^^^^^ missing associated type `Storage` value

error[E0191]: the value of the associated type `GlibType` (from the trait `glib::wrapper::Wrapper`) must be specified
   --> src/auto/window.rs:993:49
    |
993 |     fn set_transient_for<'a, T: Into<Option<&'a IsA<Window>>>>(&self, parent: T) {
    |                                                 ^^^^^^^^^^^ missing associated type `GlibType` value
```

Apparently, it cannot determine the type if there is too much indirection. Quite annoying. :-/

Edit: Rust issue about problem that caused need of local variables https://github.com/rust-lang/rust/issues/40613