### PR TITLE
Use dependencies when checking for property duplicates

### DIFF
--- a/src/analysis/object.rs
+++ b/src/analysis/object.rs
@@ -96,7 +96,7 @@ pub fn class(env: &Env, obj: &GObject, deps: &[library::TypeId]) -> Option<Info>
     let signals = signals::analyze(env, &klass.signals, class_tid, has_children,
                                    &mut trampolines, obj, &mut imports);
     let properties = properties::analyze(env, &klass.properties, class_tid, obj, &mut imports,
-                                         &signatures);
+                                         &signatures, deps);
 
     let (version, deprecated_version) = info_base::versions(env, obj, &functions, klass.version,
          klass.deprecated_version);
@@ -191,7 +191,7 @@ pub fn interface(env: &Env, obj: &GObject, deps: &[library::TypeId]) -> Option<I
     let signals = signals::analyze(env, &iface.signals, iface_tid, true,
                                    &mut trampolines, obj, &mut imports);
     let properties = properties::analyze(env, &iface.properties, iface_tid, obj, &mut imports,
-                                         &signatures);
+                                         &signatures, deps);
 
     let (version, deprecated_version) = info_base::versions(env, obj, &functions, iface.version,
          iface.deprecated_version);

--- a/src/analysis/signatures.rs
+++ b/src/analysis/signatures.rs
@@ -27,12 +27,20 @@ impl Signature {
         (false, None)
     }
 
-    pub fn has_by_name(name:&String, signatures: &Signatures) -> (bool, Option<Version>) {
+    pub fn has_by_name_and_in_deps(env: &Env, name:&String, signatures: &Signatures,
+                                   deps: &[library::TypeId]) -> (bool, Option<Version>) {
         if let Some(params) = signatures.get(name) {
             return (true, params.2);
-        } else {
-            return (false, None);
         }
+        for tid in deps {
+            let full_name = tid.full_name(&env.library);
+            if let Some(info) = env.analysis.objects.get(&full_name) {
+                if let Some(params) = info.signatures.get(name) {
+                    return (true, params.2);
+                }
+            }
+        }
+        (false, None)
     }
 }
 


### PR DESCRIPTION
Removes properties when parent or interface has same functions.
Ex. `ColorButton::set_property_rgba` duplicate for `ColorChooser::set_rgba`