### PR TITLE
Fix generation of versioned enum member

### DIFF
--- a/src/codegen/enums.rs
+++ b/src/codegen/enums.rs
@@ -97,6 +97,7 @@ fn generate_enum(env: &Env, w: &mut Write, enum_: &Enumeration, config: &GObject
     try!(writeln!(w, "#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]"));
     try!(writeln!(w, "pub enum {} {{", enum_.name));
     for member in &members {
+        try!(version_condition(w, env, member.version, false, 1));
         try!(writeln!(w, "\t{},", member.name));
     }
     try!(writeln!(w, "{}", "    #[doc(hidden)]


### PR DESCRIPTION
Fixed generation unversioned members of `Gdk.EventType` that versioned in https://github.com/gtk-rs/sys/blob/master/gdk-sys/src/lib.rs#L371-L374