### PR TITLE
Fix parser atribute parameter and possible conflict with `std::slice::SliceIndex`

### DIFF
--- a/src/analysis/signatures.rs
+++ b/src/analysis/signatures.rs
@@ -13,7 +13,7 @@ impl Signature {
         Signature(params, func.ret.typ, func.version)
     }
 
-    pub fn has_in_deps(&self, env: &Env, name: &String, deps: &[library::TypeId]) -> (bool, Option<Version>) {
+    pub fn has_in_deps(&self, env: &Env, name: &str, deps: &[library::TypeId]) -> (bool, Option<Version>) {
         for tid in deps {
             let full_name = tid.full_name(&env.library);
             if let Some(info) = env.analysis.objects.get(&full_name) {
@@ -27,7 +27,7 @@ impl Signature {
         (false, None)
     }
 
-    pub fn has_by_name_and_in_deps(env: &Env, name:&String, signatures: &Signatures,
+    pub fn has_by_name_and_in_deps(env: &Env, name:&str, signatures: &Signatures,
                                    deps: &[library::TypeId]) -> (bool, Option<Version>) {
         if let Some(params) = signatures.get(name) {
             return (true, params.2);


### PR DESCRIPTION
Changed parsers functions attribute parameters from `&Vec<>` to `&[]` and renamed getter to remove conflict with `std::slice::SliceIndex`
```
error[E0277]: the trait bound `&str: std::slice::SliceIndex<xml::attribute::OwnedAttribute>` is not satisfied
   --> src\parser.rs:131:59
    |
131 |                             trace!("class {}", attributes.get("name").unwrap());
    |                                                           ^^^ the trait `std::slice::SliceIndex<xml::attribute::OwnedAttribute>` is not implemented for `&str`
    |
    = note: slice indices are of type `usize` or ranges of `usize`
```