### PR TITLE
Use FFI instead of Rust types for constants too

### DIFF
--- a/src/codegen/sys/lib_.rs
+++ b/src/codegen/sys/lib_.rs
@@ -157,10 +157,11 @@ fn generate_constants(w: &mut Write, env: &Env, constants: &[Constant]) -> Resul
             type_ = "&'static str".into();
             value = format!("r##\"{}\"##", value)
         } else if type_ == "gboolean" {
+            let prefix = if env.config.library_name == "GLib" { "" } else { "glib::" };
             if value == "true" {
-                value = "glib::GTRUE".into();
+                value = format!("{}GTRUE", prefix);
             } else {
-                value = "glib::GFALSE".into();
+                value = format!("{}GFALSE", prefix);
             }
         }
         try!(writeln!(w, "{}pub const {}: {} = {};", comment,

--- a/src/codegen/sys/lib_.rs
+++ b/src/codegen/sys/lib_.rs
@@ -155,10 +155,13 @@ fn generate_constants(w: &mut Write, env: &Env, constants: &[Constant]) -> Resul
         let mut value = constant.value.clone();
         if type_ == "*mut c_char" {
             type_ = "&'static str".into();
-            value = format!("r##\"{}\"##", value);
-        } else if type_ == "Glyph" && env.config.library_name == "Pango"  {
-            //Fix single constant alias
-            type_ = "PangoGlyph".into();
+            value = format!("r##\"{}\"##", value)
+        } else if type_ == "gboolean" {
+            if value == "true" {
+                value = "glib::GTRUE".into();
+            } else {
+                value = "glib::GFALSE".into();
+            }
         }
         try!(writeln!(w, "{}pub const {}: {} = {};", comment,
             constant.c_identifier, type_, value));


### PR DESCRIPTION
Otherwise we will make them to possibly incorrect Rust types, which do
not exist, and by this we map them to the same types as used inside
structs, function parameters, etc.

Case in question was GStreamer's GST_CLOCK_TIME_NONE which is of type
GstClockTime in C. By using the Rust type this would map to "ClockTime",
which does not exist in the FFI bindings.