### PR TITLE
Generate property setters with IsA

### DIFF
--- a/src/analysis/bounds.rs
+++ b/src/analysis/bounds.rs
@@ -44,6 +44,24 @@ impl Default for Bounds {
     }
 }
 
+impl Bound {
+    pub fn get_for_property_setter(env: &Env, var_name:&str, type_id: TypeId,
+                                   nullable: Nullable) -> Option<Bound> {
+        match Bounds::type_for(env, type_id, nullable) {
+            Some(BoundType::IsA) => {
+                let type_str = bounds_rust_type(env, type_id);
+                Some(Bound{
+                    bound_type: BoundType::IsA,
+                    parameter_name: var_name.to_owned(),
+                    alias: 'T',
+                    type_str: type_str.into_string(),
+                })
+            }
+            _ => None,
+        }
+    }
+}
+
 impl Bounds {
     pub fn add_for_parameter(&mut self, env: &Env, func: &Function, par: &mut Parameter) {
         if !par.instance_parameter && par.direction != ParameterDirection::Out {
@@ -55,17 +73,6 @@ impl Bounds {
                     panic!("Too many type constraints for {}", func.c_identifier.as_ref().unwrap())
                 }
             }
-        }
-    }
-
-    pub fn add_for_property_setter(&mut self, env: &Env, var_name:&str, type_id: TypeId,
-                                   nullable: Nullable) {
-        match Bounds::type_for(env, type_id, nullable) {
-            Some(BoundType::IsA) => {
-                let type_name = bounds_rust_type(env, type_id);
-                self.add_parameter(var_name, &type_name.into_string(), BoundType::IsA);
-            }
-            _ => (),
         }
     }
 

--- a/src/analysis/bounds.rs
+++ b/src/analysis/bounds.rs
@@ -51,6 +51,17 @@ impl Bounds {
         }
     }
 
+    pub fn add_for_property_setter(&mut self, env: &Env, var_name:&str, type_id: TypeId,
+                                   nullable: Nullable) {
+        match Bounds::type_for(env, type_id, nullable) {
+            Some(BoundType::IsA) => {
+                let type_name = bounds_rust_type(env, type_id);
+                self.add_parameter(var_name, &type_name.into_string(), BoundType::IsA);
+            }
+            _ => (),
+        }
+    }
+
     fn type_for(env: &Env, type_id: TypeId, nullable: Nullable) -> Option<BoundType> {
         use self::BoundType::*;
         match *env.library.type_(type_id) {

--- a/src/analysis/properties.rs
+++ b/src/analysis/properties.rs
@@ -1,4 +1,4 @@
-use analysis::bounds::Bounds;
+use analysis::bounds::Bound;
 use analysis::imports::Imports;
 use analysis::ref_mode::RefMode;
 use analysis::rust_type::*;
@@ -25,7 +25,7 @@ pub struct Property {
     pub set_in_ref_mode: RefMode,
     pub version: Option<Version>,
     pub deprecated_version: Option<Version>,
-    pub bounds: Bounds,
+    pub bound: Option<Bound>,
 }
 
 pub fn analyze(env: &Env, props: &[library::Property], type_tid: library::TypeId,
@@ -70,8 +70,8 @@ pub fn analyze(env: &Env, props: &[library::Property], type_tid: library::TypeId
             if type_string.is_ok() {
                 imports.add("glib::Value", prop.version);
                 imports.add("gobject_ffi", prop.version);
-                if !prop.bounds.is_empty() {
-                    prop.bounds.update_imports(imports);
+                if prop.bound.is_some() {
+                    imports.add("glib::object::IsA", prop.version);
                     imports.add("Object", prop.version);
                 }
             }
@@ -144,13 +144,12 @@ fn analyze_property(env: &Env, prop: &library::Property, type_tid: library::Type
             set_in_ref_mode: set_in_ref_mode,
             version: prop_version,
             deprecated_version: prop.deprecated_version,
-            bounds: Default::default(),
+            bound: None,
         })
     } else { None };
 
     let setter = if writable {
-        let mut bounds: Bounds = Default::default();
-        bounds.add_for_property_setter(env, &var_name, prop.typ, nullable);
+        let bound = Bound::get_for_property_setter(env, &var_name, prop.typ, nullable);
         Some(Property{
             name: name.clone(),
             var_name: var_name,
@@ -164,7 +163,7 @@ fn analyze_property(env: &Env, prop: &library::Property, type_tid: library::Type
             set_in_ref_mode: set_in_ref_mode,
             version: prop_version,
             deprecated_version: prop.deprecated_version,
-            bounds: bounds,
+            bound: bound,
         })
     } else { None };
 

--- a/src/codegen/function.rs
+++ b/src/codegen/function.rs
@@ -82,10 +82,11 @@ fn bounds(bounds: &Bounds) -> String {
     let strs: Vec<String> = bounds.iter_lifetimes()
         .map(|s| format!("'{}", s))
         .chain(bounds.iter()
-                     .map(|bound| match bound.3 {
-                         IsA => format!("{}: IsA<{}>", bound.1, bound.2),
-                         AsRef => format!("{}: AsRef<{}>", bound.1, bound.2),
-                         Into(l) => format!("{}: Into<Option<&'{} {}>>", bound.1, l, bound.2),
+                     .map(|bound| match bound.bound_type {
+                         IsA => format!("{}: IsA<{}>", bound.alias, bound.type_str),
+                         AsRef => format!("{}: AsRef<{}>", bound.alias, bound.type_str),
+                         Into(l) => format!("{}: Into<Option<&'{} {}>>",
+                                            bound.alias, l, bound.type_str),
                      }))
         .collect();
     format!("<{}>", strs.join(", "))

--- a/src/codegen/properties.rs
+++ b/src/codegen/properties.rs
@@ -84,8 +84,8 @@ pub fn bounds(bounds: &Bounds) -> String {
     use analysis::bounds::BoundType::*;
     if bounds.is_empty() { return String::new() }
     let strs: Vec<String> = bounds.iter()
-        .map(|bound| match bound.3 {
-            IsA => format!("{}: IsA<{}> + IsA<Object>", bound.1, bound.2),
+        .map(|bound| match bound.bound_type {
+            IsA => format!("{}: IsA<{}> + IsA<Object>", bound.alias, bound.type_str),
             _ => unreachable!(),
         })
         .collect();

--- a/src/codegen/properties.rs
+++ b/src/codegen/properties.rs
@@ -1,6 +1,6 @@
 use std::io::{Result, Write};
 
-use analysis::bounds::Bounds;
+use analysis::bounds::Bound;
 use analysis::properties::Property;
 use analysis::rust_type::{parameter_rust_type,rust_type};
 use chunk::Chunk;
@@ -55,16 +55,15 @@ fn declaration(env: &Env, prop: &Property) -> String {
         "".to_string()
     } else {
         let dir = library::ParameterDirection::In;
-        let param_type = match prop.bounds.get_parameter_alias_info(&prop.var_name) {
-            Some((t, _)) => {
-                bound = bounds(&prop.bounds);
-                if *prop.nullable {
-                    format!("Option<&{}>", t)
-                } else {
-                    format!("&{}", t)
-                }
+        let param_type = if let Some(Bound{alias, ref type_str, ..}) = prop.bound {
+            bound = format!("<{}: IsA<{}> + IsA<Object>>", alias, type_str);
+            if *prop.nullable {
+                format!("Option<&{}>", alias)
+            } else {
+                format!("&{}", alias)
             }
-            None => parameter_rust_type(env, prop.typ, dir, prop.nullable, prop.set_in_ref_mode)
+        } else {
+            parameter_rust_type(env, prop.typ, dir, prop.nullable, prop.set_in_ref_mode)
                 .into_string()
         };
         format!(", {}: {}", prop.var_name, param_type)
@@ -78,18 +77,6 @@ fn declaration(env: &Env, prop: &Property) -> String {
         "".to_string()
     };
     format!("fn {}{}(&self{}){}", prop.func_name, bound, set_param, return_str)
-}
-
-pub fn bounds(bounds: &Bounds) -> String {
-    use analysis::bounds::BoundType::*;
-    if bounds.is_empty() { return String::new() }
-    let strs: Vec<String> = bounds.iter()
-        .map(|bound| match bound.bound_type {
-            IsA => format!("{}: IsA<{}> + IsA<Object>", bound.alias, bound.type_str),
-            _ => unreachable!(),
-        })
-        .collect();
-    format!("<{}>", strs.join(", "))
 }
 
 fn body(prop: &Property) -> Chunk {


### PR DESCRIPTION
Closes #332 
Example change:
```diff
--- a/src/auto/container.rs
+++ b/src/auto/container.rs
@@ -90,7 +90,7 @@ pub trait ContainerExt {
 
     fn unset_focus_chain(&self);
 
-    fn set_property_child(&self, child: Option<&Widget>);
+    fn set_property_child<T: IsA<Widget> + IsA<Object>>(&self, child: Option<&T>);
 
     fn connect_add<F: Fn(&Self, &Widget) + 'static>(&self, f: F) -> u64;
```