### PR TITLE
Add support for correctly generating bitflag constants

### DIFF
--- a/src/codegen/sys/lib_.rs
+++ b/src/codegen/sys/lib_.rs
@@ -164,8 +164,14 @@ fn generate_constants(w: &mut Write, env: &Env, constants: &[Constant]) -> Resul
                 value = format!("{}GFALSE", prefix);
             }
         }
-        try!(writeln!(w, "{}pub const {}: {} = {};", comment,
-            constant.c_identifier, type_, value));
+
+        if let Some(_) = env.library.type_(constant.typ).maybe_ref_as::<Bitfield>() {
+            try!(writeln!(w, "{}pub const {}: {} = {2} {{ bits: {} }};", comment,
+                constant.c_identifier, type_, value));
+        } else {
+            try!(writeln!(w, "{}pub const {}: {} = {};", comment,
+                constant.c_identifier, type_, value));
+        }
     }
     if !constants.is_empty() {
         try!(writeln!(w, ""));


### PR DESCRIPTION
> This depends (and includes https://github.com/gtk-rs/gir/pull/335 )

In the GIR they are given with an integer value but we have to convert
them to the corresponding bitflags type.
