### PR TITLE
Create C string constants as *const c_char with trailing \0 instead of &'static str

### DIFF
--- a/src/codegen/sys/lib_.rs
+++ b/src/codegen/sys/lib_.rs
@@ -157,10 +157,11 @@ fn generate_constants(w: &mut Write, env: &Env, constants: &[Constant]) -> Resul
             type_ = "&'static str".into();
             value = format!("r##\"{}\"##", value)
         } else if type_ == "gboolean" {
+            let prefix = if env.config.library_name == "GLib" { "" } else { "glib::" };
             if value == "true" {
-                value = "glib::GTRUE".into();
+                value = format!("{}GTRUE", prefix);
             } else {
-                value = "glib::GFALSE".into();
+                value = format!("{}GFALSE", prefix);
             }
         }
         try!(writeln!(w, "{}pub const {}: {} = {};", comment,

--- a/src/codegen/sys/lib_.rs
+++ b/src/codegen/sys/lib_.rs
@@ -155,10 +155,13 @@ fn generate_constants(w: &mut Write, env: &Env, constants: &[Constant]) -> Resul
         let mut value = constant.value.clone();
         if type_ == "*mut c_char" {
             type_ = "&'static str".into();
-            value = format!("r##\"{}\"##", value);
-        } else if type_ == "Glyph" && env.config.library_name == "Pango"  {
-            //Fix single constant alias
-            type_ = "PangoGlyph".into();
+            value = format!("r##\"{}\"##", value)
+        } else if type_ == "gboolean" {
+            if value == "true" {
+                value = "glib::GTRUE".into();
+            } else {
+                value = "glib::GFALSE".into();
+            }
         }
         try!(writeln!(w, "{}pub const {}: {} = {};", comment,
             constant.c_identifier, type_, value));

--- a/src/codegen/sys/lib_.rs
+++ b/src/codegen/sys/lib_.rs
@@ -154,8 +154,8 @@ fn generate_constants(w: &mut Write, env: &Env, constants: &[Constant]) -> Resul
         }
         let mut value = constant.value.clone();
         if type_ == "*mut c_char" {
-            type_ = "&'static str".into();
-            value = format!("r##\"{}\"##", value)
+            type_ = "*const c_char".into();
+            value = format!("b\"{}\\0\" as *const u8 as *const c_char", escape_string(&value));
         } else if type_ == "gboolean" {
             let prefix = if env.config.library_name == "GLib" { "" } else { "glib::" };
             if value == "true" {
@@ -172,6 +172,20 @@ fn generate_constants(w: &mut Write, env: &Env, constants: &[Constant]) -> Resul
     }
 
     Ok(())
+}
+
+fn escape_string(s: &str) -> String {
+    let mut es = String::with_capacity(s.len() * 2);
+    let _ = s.chars().map(|c| {
+        match c {
+            '\'' | '\"' | '\\' => {
+                es.push('\\');
+                es.push(c)
+            }
+            _ => es.push(c),
+        }
+    }).count();
+    es
 }
 
 fn generate_enums(w: &mut Write, env: &Env, items: &[&Enumeration])


### PR DESCRIPTION
> This depends on (and includes) https://github.com/gtk-rs/gir/pull/335

This reverts part of 9defa38e7dd18c0818e2560b7534ebb9ea87e068

Reason for this change is that it allows to use the constants directly
for calling C functions without dynamic memory allocations, and still
allows to convert them to a &str without any copying by using CStr.