### PR TITLE
Generate *Ext traits by default and allow disabling them instead

### DIFF
--- a/src/analysis/object.rs
+++ b/src/analysis/object.rs
@@ -66,7 +66,7 @@ pub fn class(env: &Env, obj: &GObject, deps: &[library::TypeId]) -> Option<Info>
 
     let supertypes = supertypes::analyze(env, class_tid, &mut imports);
 
-    let mut has_children = obj.force_trait;
+    let mut has_children = obj.generate_trait;
 
     for child_tid in env.class_hierarchy.subtypes(class_tid) {
         let child_name = child_tid.full_name(&env.library);

--- a/src/analysis/object.rs
+++ b/src/analysis/object.rs
@@ -17,7 +17,7 @@ pub struct Info {
     pub c_type: String,
     pub get_type: String,
     pub supertypes: Vec<general::StatusedTypeId>,
-    pub has_children: bool,
+    pub generate_trait: bool,
     pub has_constructors: bool,
     pub has_methods: bool,
     pub has_functions: bool,
@@ -66,7 +66,7 @@ pub fn class(env: &Env, obj: &GObject, deps: &[library::TypeId]) -> Option<Info>
 
     let supertypes = supertypes::analyze(env, class_tid, &mut imports);
 
-    let mut has_children = obj.generate_trait;
+    let mut generate_trait = obj.generate_trait;
 
     for child_tid in env.class_hierarchy.subtypes(class_tid) {
         let child_name = child_tid.full_name(&env.library);
@@ -74,12 +74,12 @@ pub fn class(env: &Env, obj: &GObject, deps: &[library::TypeId]) -> Option<Info>
             .map(|o| o.status)
             .unwrap_or_default();
         if status.normal() {
-            has_children = true;
+            generate_trait = true;
             break;
         }
     }
 
-    if has_children {
+    if generate_trait {
         imports.add("glib::object::IsA", None);
     }
 
@@ -93,7 +93,7 @@ pub fn class(env: &Env, obj: &GObject, deps: &[library::TypeId]) -> Option<Info>
     special_functions::unhide(&mut functions, &specials, special_functions::Type::Copy);
     special_functions::analyze_imports(&specials, &mut imports);
 
-    let signals = signals::analyze(env, &klass.signals, class_tid, has_children,
+    let signals = signals::analyze(env, &klass.signals, class_tid, generate_trait,
                                    &mut trampolines, obj, &mut imports);
     let properties = properties::analyze(env, &klass.properties, class_tid, obj, &mut imports,
                                          &signatures, deps);
@@ -104,7 +104,7 @@ pub fn class(env: &Env, obj: &GObject, deps: &[library::TypeId]) -> Option<Info>
     let child_properties = child_properties::analyze(env, obj.child_properties.as_ref(), class_tid,
                                                      &mut imports);
 
-    if has_children && !properties.is_empty() {
+    if generate_trait && !properties.is_empty() {
         imports.add("glib", None);
     }
     //don't `use` yourself
@@ -125,7 +125,7 @@ pub fn class(env: &Env, obj: &GObject, deps: &[library::TypeId]) -> Option<Info>
     };
 
     // patch up trait methods in the symbol table
-    if has_children {
+    if generate_trait {
         let mut symbols = env.symbols.borrow_mut();
         for func in base.methods() {
             if let Some(symbol) = symbols.by_c_name_mut(&func.glib_name) {
@@ -143,7 +143,7 @@ pub fn class(env: &Env, obj: &GObject, deps: &[library::TypeId]) -> Option<Info>
         c_type: klass.c_type.clone(),
         get_type: klass.glib_get_type.clone(),
         supertypes: supertypes,
-        has_children: has_children,
+        generate_trait: generate_trait,
         has_constructors: has_constructors,
         has_methods: has_methods,
         has_functions: has_functions,
@@ -225,7 +225,7 @@ pub fn interface(env: &Env, obj: &GObject, deps: &[library::TypeId]) -> Option<I
         c_type: iface.c_type.clone(),
         get_type: iface.glib_get_type.clone(),
         supertypes: supertypes,
-        has_children: true,
+        generate_trait: true,
         has_methods: has_methods,
         has_functions: has_functions,
         signals: signals,

--- a/src/codegen/doc/mod.rs
+++ b/src/codegen/doc/mod.rs
@@ -91,7 +91,7 @@ fn create_object_doc(w: &mut Write, env: &Env, info: &analysis::object::Info) ->
     let symbols = env.symbols.borrow();
     let ty = TypeStruct::new(SType::Struct, &info.name);
     let ty_ext = TypeStruct::new(SType::Trait, &format!("{}Ext", info.name));
-    let has_trait = info.has_children;
+    let has_trait = info.generate_trait;
     let doc;
     let functions: &[Function];
 

--- a/src/codegen/object.rs
+++ b/src/codegen/object.rs
@@ -105,7 +105,7 @@ fn generate_inherent(analysis: &analysis::object::Info) -> bool {
 }
 
 fn generate_trait(analysis: &analysis::object::Info) -> bool {
-    analysis.generate_trait && (analysis.has_methods || !analysis.properties.is_empty() || !analysis.child_properties.is_empty() || !analysis.signals.is_empty())
+    analysis.generate_trait
 }
 
 pub fn generate_reexports(env: &Env, analysis: &analysis::object::Info, module_name: &str,

--- a/src/codegen/object.rs
+++ b/src/codegen/object.rs
@@ -101,11 +101,11 @@ pub fn generate(w: &mut Write, env: &Env, analysis: &analysis::object::Info) -> 
 }
 
 fn generate_inherent(analysis: &analysis::object::Info) -> bool {
-    analysis.has_constructors || analysis.has_functions || !analysis.generate_trait
+    analysis.has_constructors || analysis.has_functions || !generate_trait(analysis)
 }
 
 fn generate_trait(analysis: &analysis::object::Info) -> bool {
-    analysis.generate_trait
+    analysis.generate_trait && (analysis.has_methods || !analysis.properties.is_empty() || !analysis.child_properties.is_empty() || !analysis.signals.is_empty())
 }
 
 pub fn generate_reexports(env: &Env, analysis: &analysis::object::Info, module_name: &str,

--- a/src/codegen/object.rs
+++ b/src/codegen/object.rs
@@ -101,11 +101,11 @@ pub fn generate(w: &mut Write, env: &Env, analysis: &analysis::object::Info) -> 
 }
 
 fn generate_inherent(analysis: &analysis::object::Info) -> bool {
-    analysis.has_constructors || analysis.has_functions || !analysis.has_children
+    analysis.has_constructors || analysis.has_functions || !analysis.generate_trait
 }
 
 fn generate_trait(analysis: &analysis::object::Info) -> bool {
-    analysis.has_children
+    analysis.generate_trait
 }
 
 pub fn generate_reexports(env: &Env, analysis: &analysis::object::Info, module_name: &str,

--- a/src/codegen/object.rs
+++ b/src/codegen/object.rs
@@ -50,7 +50,7 @@ pub fn generate(w: &mut Write, env: &Env, analysis: &analysis::object::Info) -> 
         try!(writeln!(w, "}}"));
     }
 
-    try!(trait_impls::generate(w, &analysis.name, &analysis.functions, &analysis.specials));
+    try!(trait_impls::generate(w, &analysis.name, &analysis.functions, &analysis.specials, generate_trait(analysis)));
 
     if generate_trait(analysis) {
         try!(writeln!(w, ""));

--- a/src/codegen/record.rs
+++ b/src/codegen/record.rs
@@ -32,7 +32,7 @@ pub fn generate(w: &mut Write, env: &Env, analysis: &analysis::record::Info) -> 
         try!(writeln!(w, "}}"));
     }
 
-    try!(trait_impls::generate(w, &analysis.name, &analysis.functions, &analysis.specials));
+    try!(trait_impls::generate(w, &analysis.name, &analysis.functions, &analysis.specials, false));
 
     Ok(())
 }

--- a/src/codegen/trait_impls.rs
+++ b/src/codegen/trait_impls.rs
@@ -2,20 +2,20 @@ use std::io::{Result, Write};
 use analysis::functions::Info;
 use analysis::special_functions::{Infos, Type};
 
-pub fn generate(w: &mut Write, type_name: &str, functions: &[Info], specials: &Infos)
+pub fn generate(w: &mut Write, type_name: &str, functions: &[Info], specials: &Infos, in_trait: bool)
         -> Result<()> {
     for (type_, name) in specials.iter() {
         match *type_ {
             Type::Compare => {
                 if specials.get(&Type::Equal).is_none() {
-                    try!(generate_eq_compare(w, type_name, lookup(functions, name)));
+                    try!(generate_eq_compare(w, type_name, lookup(functions, name), in_trait));
                 }
-                try!(generate_ord(w, type_name, lookup(functions, name)));
+                try!(generate_ord(w, type_name, lookup(functions, name), in_trait));
             }
             Type::Equal => {
-                try!(generate_eq(w, type_name, lookup(functions, name)));
+                try!(generate_eq(w, type_name, lookup(functions, name), in_trait));
             }
-            Type::ToString => try!(generate_display(w, type_name, lookup(functions, name))),
+            Type::ToString => try!(generate_display(w, type_name, lookup(functions, name), in_trait)),
             _ => {}
         }
     }
@@ -28,17 +28,25 @@ fn lookup<'a>(functions: &'a [Info], name: &str) -> &'a Info {
         .unwrap()
 }
 
-fn generate_display(w: &mut Write, type_name: &str, func: &Info) -> Result<()> {
+fn generate_display(w: &mut Write, type_name: &str, func: &Info, in_trait: bool) -> Result<()> {
     use analysis::out_parameters::Mode;
+
+    let call = if in_trait {
+        format!("{type_name}Ext::{func_name}(self)",
+                type_name = type_name, func_name = func.name)
+    } else {
+        format!("self.{func_name}()",
+                func_name = func.name)
+    };
+
     let body = if let Mode::Throws(_) = func.outs.mode {
-        format!("if let Ok(val) = self.{}() {{
+        format!("if let Ok(val) = {} {{
             write!(f, \"{{}}\", val)
         }} else {{
             Err(fmt::Error)
-        }}", func.name)
+        }}", call)
     } else {
-        format!("write!(f, \"{{}}\", self.{func_name}())",
-                func_name = func.name)
+        format!("write!(f, \"{{}}\", {})", call)
     };
     writeln!(w, "
 impl fmt::Display for {type_name} {{
@@ -49,43 +57,67 @@ impl fmt::Display for {type_name} {{
 }}", type_name = type_name, body = body)
 }
 
-fn generate_eq(w: &mut Write, type_name: &str, func: &Info) -> Result<()> {
+fn generate_eq(w: &mut Write, type_name: &str, func: &Info, in_trait: bool) -> Result<()> {
+    let call = if in_trait {
+        format!("{type_name}Ext::{func_name}(self, other)",
+                type_name = type_name, func_name = func.name)
+    } else {
+        format!("self.{func_name}(other)",
+                func_name = func.name)
+    };
+
     writeln!(w, "
 impl PartialEq for {type_name} {{
     #[inline]
     fn eq(&self, other: &Self) -> bool {{
-        self.{func_name}(other)
+        {call}
     }}
 }}
 
-impl Eq for {type_name} {{}}", type_name = type_name, func_name = func.name)
+impl Eq for {type_name} {{}}", type_name = type_name, call = call)
 }
 
-fn generate_eq_compare(w: &mut Write, type_name: &str, func: &Info) -> Result<()> {
+fn generate_eq_compare(w: &mut Write, type_name: &str, func: &Info, in_trait: bool) -> Result<()> {
+    let call = if in_trait {
+        format!("{type_name}Ext::{func_name}(self, other)",
+                type_name = type_name, func_name = func.name)
+    } else {
+        format!("self.{func_name}(other)",
+                func_name = func.name)
+    };
+
     writeln!(w, "
 impl PartialEq for {type_name} {{
     #[inline]
     fn eq(&self, other: &Self) -> bool {{
-        self.{func_name}(other) == 0
+        {call} == 0
     }}
 }}
 
-impl Eq for {type_name} {{}}", type_name = type_name, func_name = func.name)
+impl Eq for {type_name} {{}}", type_name = type_name, call = call)
 }
 
-fn generate_ord(w: &mut Write, type_name: &str, func: &Info) -> Result<()> {
+fn generate_ord(w: &mut Write, type_name: &str, func: &Info, in_trait: bool) -> Result<()> {
+    let call = if in_trait {
+        format!("{type_name}Ext::{func_name}(self, other)",
+                type_name = type_name, func_name = func.name)
+    } else {
+        format!("self.{func_name}(other)",
+                func_name = func.name)
+    };
+
     writeln!(w, "
 impl PartialOrd for {type_name} {{
     #[inline]
     fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {{
-        self.{func_name}(other).partial_cmp(&0)
+        {call}.partial_cmp(&0)
     }}
 }}
 
 impl Ord for {type_name} {{
     #[inline]
     fn cmp(&self, other: &Self) -> cmp::Ordering {{
-        self.{func_name}(other).cmp(&0)
+        {call}.cmp(&0)
     }}
-}}", type_name = type_name, func_name = func.name)
+}}", type_name = type_name, call = call)
 }

--- a/src/config/gobjects.rs
+++ b/src/config/gobjects.rs
@@ -63,7 +63,7 @@ pub struct GObject {
     pub version: Option<Version>,
     pub cfg_condition: Option<String>,
     pub type_id: Option<TypeId>,
-    pub force_trait: bool,
+    pub generate_trait: bool,
     pub child_properties: Option<ChildProperties>,
 }
 
@@ -80,7 +80,7 @@ impl Default for GObject {
             version: None,
             cfg_condition: None,
             type_id: None,
-            force_trait: false,
+            generate_trait: true,
             child_properties: None,
         }
     }
@@ -121,9 +121,9 @@ fn parse_object(toml_object: &Value) -> GObject {
     let cfg_condition = toml_object.lookup("cfg_condition")
         .and_then(|v| v.as_str())
         .map(|s| s.to_owned());
-    let force_trait = toml_object.lookup("trait")
+    let generate_trait = toml_object.lookup("trait")
         .and_then(|v| v.as_bool())
-        .unwrap_or(false);
+        .unwrap_or(true);
     let child_properties = ChildProperties::parse(toml_object, &name);
 
     GObject {
@@ -137,7 +137,7 @@ fn parse_object(toml_object: &Value) -> GObject {
         version: version,
         cfg_condition: cfg_condition,
         type_id: None,
-        force_trait: force_trait,
+        generate_trait: generate_trait,
         child_properties: child_properties,
     }
 }


### PR DESCRIPTION
WIP: The configuration should probably be renamed to allow_no_trait or
similar instead.

Reason for this is that the general case is that subclasses of any
GObject are allowed, and in your own crate you don't generally know if
other crates or any other code is going to create subclasses. Only in
few cases a class is "final" and does not allow subclasses.


@EPashkin Any opinions on this one?