### PR TITLE
Add support for generating alias types

### DIFF
--- a/src/codegen/alias.rs
+++ b/src/codegen/alias.rs
@@ -1,0 +1,57 @@
+use analysis::namespaces;
+use analysis::rust_type::rust_type;
+use codegen::general;
+use config::gobjects::GObject;
+use env::Env;
+use file_saver;
+use library::*;
+use std::io::prelude::*;
+use std::io::Result;
+use std::path::Path;
+use traits::*;
+
+pub fn generate(env: &Env, root_path: &Path, mod_rs: &mut Vec<String>) {
+    let configs: Vec<&GObject> = env.config.objects.values()
+        .filter(|c| {
+            c.status.need_generate() &&
+                c.type_id.map_or(false, |tid| tid.ns_id == namespaces::MAIN)
+        })
+        .collect();
+    let mut has_any = false;
+    for config in &configs {
+        if let Type::Alias(_) = *env.library.type_(config.type_id.unwrap()) {
+            has_any = true;
+            break;
+        }
+    }
+
+    if !has_any {
+        return;
+    }
+
+    let path = root_path.join("alias.rs");
+    file_saver::save_to_file(path, env.config.make_backup, |w| {
+        try!(general::start_comments(w, &env.config));
+        try!(writeln!(w, ""));
+
+        if has_any {
+            mod_rs.push("\nmod alias;".into());
+        }
+        for config in &configs {
+            if let Type::Alias(ref alias) = *env.library.type_(config.type_id.unwrap()) {
+                mod_rs.push(format!("pub use self::alias::{};", alias.name));
+                try!(generate_alias(env, w, alias, config));
+            }
+        }
+
+        Ok(())
+    });
+}
+
+fn generate_alias(env: &Env, w: &mut Write, alias: &Alias, _: &GObject) -> Result<()> {
+    let typ = rust_type(env, alias.typ).into_string();
+    try!(writeln!(w, "pub type {} = {};", alias.name, typ));
+
+    Ok(())
+}
+

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -8,6 +8,7 @@ mod child_properties;
 mod doc;
 mod enums;
 mod flags;
+mod alias;
 mod function;
 mod function_body_chunk;
 mod general;
@@ -46,6 +47,7 @@ fn normal_generate(env: &Env) {
     records::generate(env, &root_path, &mut mod_rs);
     enums::generate(env, &root_path, &mut mod_rs);
     flags::generate(env, &root_path, &mut mod_rs);
+    alias::generate(env, &root_path, &mut mod_rs);
 
     generate_mod_rs(env, &root_path, &mod_rs, &traits);
 }


### PR DESCRIPTION
These come without any conversion traits implemented as they should be
directly compatible with the versions in the -sys crates.