### PR TITLE
Fully qualify the glib::object::Object for the IsA<_> constraints

### DIFF
--- a/src/analysis/object.rs
+++ b/src/analysis/object.rs
@@ -105,7 +105,7 @@ pub fn class(env: &Env, obj: &GObject, deps: &[library::TypeId]) -> Option<Info>
                                                      &mut imports);
 
     if has_children && !properties.is_empty() {
-        imports.add("Object", None);
+        imports.add("glib", None);
     }
     //don't `use` yourself
     imports.remove(&name);
@@ -197,7 +197,7 @@ pub fn interface(env: &Env, obj: &GObject, deps: &[library::TypeId]) -> Option<I
          iface.deprecated_version);
 
     if !properties.is_empty() {
-        imports.add("Object", None);
+        imports.add("glib", None);
     }
 
     //don't `use` yourself

--- a/src/analysis/properties.rs
+++ b/src/analysis/properties.rs
@@ -72,7 +72,7 @@ pub fn analyze(env: &Env, props: &[library::Property], type_tid: library::TypeId
                 imports.add("gobject_ffi", prop.version);
                 if prop.bound.is_some() {
                     imports.add("glib::object::IsA", prop.version);
-                    imports.add("Object", prop.version);
+                    imports.add("glib", prop.version);
                 }
             }
 

--- a/src/analysis/signals.rs
+++ b/src/analysis/signals.rs
@@ -58,7 +58,7 @@ fn analyze_signal(env: &Env, signal: &library::Signal, type_tid: library::TypeId
     if trampoline_name.is_ok() {
         imports.add_used_types(&used_types, version);
         if in_trait {
-            imports.add("Object", version);
+            imports.add("glib", version);
             imports.add("glib::object::Downcast", version);
         }
         imports.add("glib::signal::connect", version);

--- a/src/codegen/object.rs
+++ b/src/codegen/object.rs
@@ -73,7 +73,7 @@ pub fn generate(w: &mut Write, env: &Env, analysis: &analysis::object::Info) -> 
         let mut extra_isa: Vec<&'static str> = Vec::new();
         if !analysis.child_properties.is_empty() { extra_isa.push(" + IsA<Container>"); }
         if analysis.has_signals() || !analysis.properties.is_empty() {
-            extra_isa.push(" + IsA<Object>");
+            extra_isa.push(" + IsA<glib::object::Object>");
         }
         try!(write!(w, "impl<O: IsA<{}>{}> {0}Ext for O {{", analysis.name, extra_isa.join("")));
         for func_analysis in &analysis.methods() {

--- a/src/codegen/properties.rs
+++ b/src/codegen/properties.rs
@@ -56,7 +56,7 @@ fn declaration(env: &Env, prop: &Property) -> String {
     } else {
         let dir = library::ParameterDirection::In;
         let param_type = if let Some(Bound{alias, ref type_str, ..}) = prop.bound {
-            bound = format!("<{}: IsA<{}> + IsA<Object>>", alias, type_str);
+            bound = format!("<{}: IsA<{}> + IsA<glib::object::Object>>", alias, type_str);
             if *prop.nullable {
                 format!("Option<&{}>", alias)
             } else {


### PR DESCRIPTION
In crates like gtk or gstreamer, which have their own GtkObject and
GstObject, this otherwise will result in wrong bounds. Specifically the
one for GObject is missing, which is required for things like properties
and signals.