### PR TITLE
Generate functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ generate = ["Gtk.Widget", "Gtk.Window"]
 manual = ["Gtk.Button"]
 ```
 
-So in here, both `GtkWidget` and `GtkWindow` will be fully generated and functions/methods using `GtkButton` will be uncommented.
+So in here, both `GtkWidget` and `GtkWindow` will be fully generated and functions/methods using `GtkButton` will be uncommented. To generate code for all global functions, add `Gtk.*` to the `generate` array.
 
 Sometimes Gir understands the object definition incorrectly or the `.gir` file contains incomplete or wrong definition, to fix it, you can use the full object configuration:
 
@@ -141,6 +141,21 @@ status = "generate"
     # define starting version when member added
     version = "3.18"
 ```
+
+For global functions, the members can be configured by configuring the `Gtk.*` object:
+
+```toml
+[[object]]
+name = "Gtk.*"
+status = "generate"
+    [[object.member]]
+    name = "stock_list_ids"
+    # allows to ignore global functions
+    ignore = true
+```
+
+Note that you must not place `Gtk.*` into the `generate` array and
+additionally configure its members.
 
 ### Generation
 

--- a/src/analysis/functions.rs
+++ b/src/analysis/functions.rs
@@ -15,6 +15,7 @@ use library::{self, Nullable};
 use nameutil;
 use traits::*;
 use version::Version;
+use std::borrow::Borrow;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Visibility {
@@ -50,13 +51,14 @@ pub struct Info {
     pub doc_hidden: bool,
 }
 
-pub fn analyze(env: &Env, functions: &[library::Function], type_tid: library::TypeId,
+pub fn analyze<F: Borrow<library::Function>>(env: &Env, functions: &[F], type_tid: library::TypeId,
                obj: &config::gobjects::GObject, imports: &mut Imports,
                mut signatures: Option<&mut Signatures>,
                deps: Option<&[library::TypeId]>) -> Vec<Info> {
     let mut funcs = Vec::new();
 
     for func in functions {
+        let func = func.borrow();
         let configured_functions = obj.functions.matched(&func.name);
         if configured_functions.iter().any(|f| f.ignore) {
             continue;

--- a/src/analysis/imports.rs
+++ b/src/analysis/imports.rs
@@ -45,6 +45,7 @@ impl Imports {
 
     pub fn clean_glib(&mut self, env: &Env) {
         if env.namespaces.glib_ns_id != namespaces::MAIN { return; }
+        self.remove("glib");
         let glibs: Vec<(String, Option<Version>)> = self.map.iter().filter_map(|p| {
             let glib_offset = p.0.find("glib::");
             if let Some(glib_offset) = glib_offset {

--- a/src/analysis/out_parameters.rs
+++ b/src/analysis/out_parameters.rs
@@ -94,12 +94,13 @@ pub fn analyze(env: &Env, func: &Function,
 
 pub fn analyze_imports(env: &Env, func: &Function, imports: &mut Imports) {
     for par in &func.parameters {
-        if par.direction == ParameterDirection::Out && !par.caller_allocates {
+        if par.direction == ParameterDirection::Out {
             match *env.library.type_(par.typ) {
                 Type::Fundamental(..) |
                     Type::Bitfield(..) |
                     Type::Enumeration(..) => imports.add("std::mem", func.version),
-                _ => imports.add("std::ptr".into(), func.version),
+                _ if !par.caller_allocates => imports.add("std::ptr".into(), func.version),
+                _ => (),
             }
         }
     }

--- a/src/analysis/rust_type.rs
+++ b/src/analysis/rust_type.rs
@@ -98,6 +98,7 @@ fn rust_type_full(env: &Env, type_id: library::TypeId, nullable: Nullable, ref_m
                         ok("std::path::PathBuf")
                     }
                 }
+                Type if env.namespaces.glib_ns_id == library::MAIN_NAMESPACE => ok("types::Type"),
                 Type => ok("glib::types::Type"),
                 Unsupported => err("Unsupported"),
                 _ => err(&format!("Fundamental: {:?}", fund)),

--- a/src/codegen/alias.rs
+++ b/src/codegen/alias.rs
@@ -34,9 +34,7 @@ pub fn generate(env: &Env, root_path: &Path, mod_rs: &mut Vec<String>) {
         try!(general::start_comments(w, &env.config));
         try!(writeln!(w, ""));
 
-        if has_any {
-            mod_rs.push("\nmod alias;".into());
-        }
+        mod_rs.push("\nmod alias;".into());
         for config in &configs {
             if let Type::Alias(ref alias) = *env.library.type_(config.type_id.unwrap()) {
                 mod_rs.push(format!("pub use self::alias::{};", alias.name));

--- a/src/codegen/functions.rs
+++ b/src/codegen/functions.rs
@@ -1,0 +1,31 @@
+use std::path::Path;
+
+use env::Env;
+use file_saver;
+use codegen::general;
+use codegen::function;
+
+pub fn generate(env: &Env, root_path: &Path, mod_rs: &mut Vec<String>) {
+    info!("Generate global functions");
+
+    let functions = match env.analysis.global_functions {
+        Some(ref functions) => functions,
+        None => return,
+    };
+
+    let path = root_path.join("functions.rs");
+    file_saver::save_to_file(path, env.config.make_backup, |w| {
+        try!(general::start_comments(w, &env.config));
+        try!(general::uses(w, env, &functions.imports));
+
+        try!(writeln!(w, ""));
+
+        mod_rs.push("\npub mod functions;".into());
+
+        for func_analysis in &functions.functions {
+            try!(function::generate(w, env, &func_analysis, false, false, 0));
+        }
+
+        Ok(())
+    });
+}

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -11,6 +11,7 @@ mod flags;
 mod alias;
 mod function;
 mod function_body_chunk;
+mod functions;
 mod general;
 mod object;
 mod objects;
@@ -48,6 +49,7 @@ fn normal_generate(env: &Env) {
     enums::generate(env, &root_path, &mut mod_rs);
     flags::generate(env, &root_path, &mut mod_rs);
     alias::generate(env, &root_path, &mut mod_rs);
+    functions::generate(env, &root_path, &mut mod_rs);
 
     generate_mod_rs(env, &root_path, &mod_rs, &traits);
 }

--- a/src/config/gobjects.rs
+++ b/src/config/gobjects.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use std::str::FromStr;
 use toml::Value;
 
-use library::{Library, TypeId};
+use library::{Library, TypeId, MAIN_NAMESPACE};
 use config::error::TomlHelper;
 use config::parsable::{Parsable, Parse};
 use super::child_properties::ChildProperties;
@@ -167,9 +167,12 @@ fn parse_status_shorthand(objects: &mut GObjects, status: GStatus, toml: &Value)
 }
 
 pub fn resolve_type_ids(objects: &mut GObjects, library: &Library) {
+    let ns = library.namespace(MAIN_NAMESPACE);
+    let global_functions_name = format!("{}.*", ns.name);
+
     for (name, object) in objects.iter_mut() {
         let type_id = library.find_type(0, name);
-        if type_id.is_none() {
+        if type_id.is_none() && name != &global_functions_name {
             warn!("Configured object `{}` missing from the library", name);
         }
         object.type_id = type_id;


### PR DESCRIPTION
https://github.com/gtk-rs/gir/issues/295

All functions are now unconditionally generated unless "ignore=true" for them. None are re-exported automatically and would have to be added to e.g. src/lib.rs for re-exporting from auto::functions::$function_name.
Not sure if this is ideal. Reason for not re-exporting them automatically is that you usually want to group them into useful modules, e.g. in the case of GStreamer all "gst_parse_*" functions would be placed into a gst::parse module.

Any opinions?


Last commit is just some random cleanup that I happened to notice while reading the code again.