### PR TITLE
Don't prepend a comma before the first non-out parameter if the first…

### DIFF
--- a/src/codegen/function.rs
+++ b/src/codegen/function.rs
@@ -65,11 +65,13 @@ pub fn declaration(env: &Env, analysis: &analysis::functions::Info) -> String {
 
     let bounds = bounds(&analysis.bounds);
 
+    let mut skipped = 0;
     for (pos, par) in analysis.parameters.iter().enumerate() {
         if outs_as_return && analysis.outs.iter().any(|p| p.name==par.name) {
+            skipped += 1;
             continue;
         }
-        if pos > 0 { param_str.push_str(", ") }
+        if pos > skipped { param_str.push_str(", ") }
         let s = par.to_parameter(env, &analysis.bounds);
         param_str.push_str(&s);
     }


### PR DESCRIPTION
… one is an out parameter


We otherwise generate things like

```Rust
pub fn value_init_and_copy(, src: &glib::Value) -> glib::Value
```

Here the first parameter is an out parameter (that is converted to the return type).