### PR TITLE
Add support for array-length for parameters and return values

### DIFF
--- a/src/analysis/out_parameters.rs
+++ b/src/analysis/out_parameters.rs
@@ -39,10 +39,6 @@ impl Info {
     pub fn iter(&self) -> Iter<Parameter> {
         self.params.iter()
     }
-
-    pub fn len(&self) -> usize {
-        self.params.len()
-    }
 }
 
 pub fn analyze(env: &Env, func: &Function,

--- a/src/analysis/parameter.rs
+++ b/src/analysis/parameter.rs
@@ -20,6 +20,7 @@ pub struct Parameter {
     pub caller_allocates: bool,
     pub nullable: library::Nullable,
     pub allow_none: bool,
+    pub array_length: Option<u32>,
     pub is_error: bool,
 
     //analysis fields
@@ -84,6 +85,7 @@ pub fn analyze(env: &Env, par: &library::Parameter, configured_functions: &[&Fun
         caller_allocates: caller_allocates,
         nullable: nullable,
         allow_none: par.allow_none,
+        array_length: par.array_length,
         ref_mode: ref_mode,
         is_error: par.is_error,
         to_glib_extra: String::new(),

--- a/src/chunk/chunk.rs
+++ b/src/chunk/chunk.rs
@@ -15,7 +15,7 @@ pub enum Chunk {
     FfiCallParameter{par: parameter_ffi_call_in::Parameter},
     FfiCallOutParameter{par: parameter_ffi_call_out::Parameter},
     //TODO: separate without return_value::Info
-    FfiCallConversion{ret: return_value::Info, call: Box<Chunk>},
+    FfiCallConversion{ret: return_value::Info, array_length: Option<(String, String)>, call: Box<Chunk>},
     Let{name: String, is_mut: bool, value: Box<Chunk>, type_: Option<Box<Chunk>>},
     Uninitialized,
     UninitializedNamed{name: String},
@@ -23,7 +23,7 @@ pub enum Chunk {
     NullMutPtr,
     Custom(String),
     Tuple(Vec<Chunk>, TupleMode),
-    FromGlibConversion{mode: conversion_from_glib::Mode, value: Box<Chunk>},
+    FromGlibConversion{mode: conversion_from_glib::Mode, array_length: Option<(String, String)>, value: Box<Chunk>},
     OptionalReturn{condition: String, value: Box<Chunk>},
     ErrorResultReturn{value: Box<Chunk>},
     AssertInitializedAndInMainThread,

--- a/src/chunk/parameter_ffi_call_in.rs
+++ b/src/chunk/parameter_ffi_call_in.rs
@@ -9,13 +9,14 @@ pub struct Parameter {
     pub direction: library::ParameterDirection,
     pub transfer: library::Transfer,
     pub nullable: library::Nullable,
+    pub array_length: Option<(String, String)>,
     pub ref_mode: analysis::ref_mode::RefMode,
     pub to_glib_extra: String,
     pub is_into: bool,
 }
 
-impl<'a> From<&'a analysis::parameter::Parameter> for Parameter {
-    fn from(orig: &'a analysis::parameter::Parameter) -> Parameter {
+impl Parameter {
+    pub fn new(orig: &analysis::parameter::Parameter, array_length: Option<(String, String)>) -> Parameter {
         Parameter {
             name: orig.name.clone(),
             typ: orig.typ,
@@ -23,6 +24,7 @@ impl<'a> From<&'a analysis::parameter::Parameter> for Parameter {
             direction: orig.direction,
             transfer: orig.transfer,
             nullable: orig.nullable,
+            array_length: array_length,
             ref_mode: orig.ref_mode,
             to_glib_extra: orig.to_glib_extra.clone(),
             is_into: orig.is_into,

--- a/src/chunk/parameter_ffi_call_out.rs
+++ b/src/chunk/parameter_ffi_call_out.rs
@@ -7,15 +7,17 @@ pub struct Parameter {
     pub typ: library::TypeId,
     pub transfer: library::Transfer,
     pub caller_allocates: bool,
+    pub array_length: Option<(String, String)>,
     pub is_error: bool,
 }
 
-impl<'a> From<&'a analysis::parameter::Parameter> for Parameter {
-    fn from(orig: &'a analysis::parameter::Parameter) -> Parameter {
+impl Parameter {
+    pub fn new(orig: &analysis::parameter::Parameter, array_length: Option<(String, String)>) -> Parameter {
         Parameter {
             name: orig.name.clone(),
             typ: orig.typ,
             transfer: orig.transfer,
+            array_length: array_length,
             caller_allocates: orig.caller_allocates,
             is_error: orig.is_error,
         }

--- a/src/codegen/function.rs
+++ b/src/codegen/function.rs
@@ -131,7 +131,7 @@ pub fn body_chunk(env: &Env, analysis: &analysis::functions::Info) -> Chunk {
     let ret_array_length = if let Some(pos) = analysis.ret.parameter.as_ref().and_then(|p| p.array_length) {
         // The first parameter is &self in case of methods
         let pos_offset = if analysis.kind == library::FunctionKind::Method { 1 } else { 0 };
-        analysis.parameters.iter().nth((pos + pos_offset) as usize)
+        analysis.parameters.get((pos + pos_offset) as usize)
     } else {
         None
     };
@@ -148,7 +148,7 @@ pub fn body_chunk(env: &Env, analysis: &analysis::functions::Info) -> Chunk {
                 use analysis::out_parameters::Mode;
                 // The actual return value was inserted at position 0
                 let pos_offset = if analysis.outs.mode == Mode::Combined || analysis.outs.mode == Mode::Throws(true) { 1 } else { 0 };
-                analysis.parameters.iter().nth((pos + pos_offset) as usize)
+                analysis.parameters.get((pos + pos_offset) as usize)
             } else {
                 None
             };
@@ -158,7 +158,7 @@ pub fn body_chunk(env: &Env, analysis: &analysis::functions::Info) -> Chunk {
             let array_length = if let Some(pos) = par.array_length {
                 // The first parameter is &self in case of methods
                 let pos_offset = if analysis.kind == library::FunctionKind::Method { 1 } else { 0 };
-                analysis.parameters.iter().nth((pos + pos_offset) as usize)
+                analysis.parameters.get((pos + pos_offset) as usize)
             } else {
                 None
             };

--- a/src/codegen/function.rs
+++ b/src/codegen/function.rs
@@ -12,6 +12,7 @@ use super::parameter::ToParameter;
 use super::return_value::{out_parameters_as_return, ToReturnValue};
 use writer::primitives::tabs;
 use writer::ToCode;
+use library;
 
 pub fn generate(w: &mut Write, env: &Env, analysis: &analysis::functions::Info,
                 in_trait: bool, only_declaration: bool, indent: usize) -> Result<()> {
@@ -72,12 +73,24 @@ pub fn declaration(env: &Env, analysis: &analysis::functions::Info) -> String {
 
     let bounds = bounds(&analysis.bounds);
 
+    let array_lengths: Vec<_> = analysis.parameters.iter()
+                                                    .filter_map(|p| p.array_length)
+                                                    .collect();
+
     let mut skipped = 0;
     for (pos, par) in analysis.parameters.iter().enumerate() {
         if outs_as_return && analysis.outs.iter().any(|p| p.name==par.name) {
             skipped += 1;
             continue;
         }
+
+        // The first parameter is &self in case of methods
+        let pos_offset = if analysis.kind == library::FunctionKind::Method { 1 } else { 0 };
+        if pos >= pos_offset && array_lengths.contains(&((pos - pos_offset) as u32)) {
+            skipped += 1;
+            continue;
+        }
+
         if pos > skipped { param_str.push_str(", ") }
         let s = par.to_parameter(env, &analysis.bounds);
         param_str.push_str(&s);
@@ -115,17 +128,42 @@ pub fn body_chunk(env: &Env, analysis: &analysis::functions::Info) -> Chunk {
     }
 
     let outs_as_return = !analysis.outs.is_empty();
+    let ret_array_length = if let Some(pos) = analysis.ret.parameter.as_ref().and_then(|p| p.array_length) {
+        // The first parameter is &self in case of methods
+        let pos_offset = if analysis.kind == library::FunctionKind::Method { 1 } else { 0 };
+        analysis.parameters.iter().nth((pos + pos_offset) as usize)
+    } else {
+        None
+    };
+
     let mut builder = function_body_chunk::Builder::new();
     builder.glib_name(&analysis.glib_name)
         .assertion(analysis.assertion)
-        .ret(&analysis.ret)
+        .ret(env, &analysis.ret, ret_array_length)
         .outs_mode(analysis.outs.mode);
 
     for par in &analysis.parameters {
         if outs_as_return && analysis.outs.iter().any(|p| p.name==par.name) {
-            builder.out_parameter(env, par);
+            let array_length = if let Some(pos) = par.array_length {
+                use analysis::out_parameters::Mode;
+                // The actual return value was inserted at position 0
+                let pos_offset = if analysis.outs.mode == Mode::Combined || analysis.outs.mode == Mode::Throws(true) { 1 } else { 0 };
+                analysis.parameters.iter().nth((pos + pos_offset) as usize)
+            } else {
+                None
+            };
+
+            builder.out_parameter(env, par, array_length);
         } else {
-            builder.parameter(par);
+            let array_length = if let Some(pos) = par.array_length {
+                // The first parameter is &self in case of methods
+                let pos_offset = if analysis.kind == library::FunctionKind::Method { 1 } else { 0 };
+                analysis.parameters.iter().nth((pos + pos_offset) as usize)
+            } else {
+                None
+            };
+
+            builder.parameter(env, par, array_length);
         }
     }
 

--- a/src/codegen/function_body_chunk.rs
+++ b/src/codegen/function_body_chunk.rs
@@ -96,7 +96,7 @@ impl Builder {
         };
         let array_length = array_length.map(|p| (p.name.clone(), rust_type(env, p.typ).unwrap()));
         self.parameters.push(Parameter::Out {
-            parameter:  parameter_ffi_call_out::Parameter::new(parameter, array_length),
+            parameter: parameter_ffi_call_out::Parameter::new(parameter, array_length),
             mem_mode: mem_mode,
         });
         self.outs_as_return = true;

--- a/src/codegen/property_body.rs
+++ b/src/codegen/property_body.rs
@@ -98,6 +98,7 @@ impl Builder {
         };
         body.push(Chunk::FfiCallConversion {
             ret: return_info,
+            array_length: None,
             call: Box::new(ffi_call),
         });
 
@@ -157,6 +158,7 @@ impl Builder {
         };
         body.push(Chunk::FfiCallConversion {
             ret: return_info,
+            array_length: None,
             call: Box::new(ffi_call),
         });
 

--- a/src/codegen/return_value.rs
+++ b/src/codegen/return_value.rs
@@ -5,6 +5,7 @@ use library::{self, ParameterDirection};
 use analysis::conversion_type::ConversionType;
 use analysis::rust_type::parameter_rust_type;
 use traits::*;
+use nameutil;
 
 pub trait ToReturnValue {
     fn to_return_value(&self, env: &Env) -> String;
@@ -66,8 +67,9 @@ pub fn out_parameters_as_return(env: &Env, analysis: &analysis::functions::Info)
         // The actual return value is inserted with an empty name at position 0
         if !par.name.is_empty() {
             let pos_offset = if analysis.kind == library::FunctionKind::Method { 1 } else { 0 };
+            let mangled_par_name = nameutil::mangle_keywords(par.name.as_str());
             let param_pos = analysis.parameters.iter().enumerate()
-                                                      .filter_map(|(pos, orig_par)| if orig_par.name == par.name { Some(pos) } else { None })
+                                                      .filter_map(|(pos, orig_par)| if orig_par.name == mangled_par_name { Some(pos) } else { None } )
                                                       .next().unwrap();
             if param_pos >= pos_offset && array_lengths.contains(&((param_pos - pos_offset) as u32)) {
                 skip += 1;

--- a/src/codegen/translate_from_glib.rs
+++ b/src/codegen/translate_from_glib.rs
@@ -8,17 +8,17 @@ use library;
 use traits::*;
 
 pub trait TranslateFromGlib {
-    fn translate_from_glib_as_function(&self, env: &Env) -> (String, String);
+    fn translate_from_glib_as_function(&self, env: &Env, array_length: &Option<(String, String)>) -> (String, String);
 }
 
 impl TranslateFromGlib for Mode {
-    fn translate_from_glib_as_function(&self, env: &Env) -> (String, String) {
+    fn translate_from_glib_as_function(&self, env: &Env, array_length: &Option<(String, String)>) -> (String, String) {
         use analysis::conversion_type::ConversionType::*;
         match ConversionType::of(&env.library, self.typ) {
             Direct => (String::new(), String::new()),
             Scalar => ("from_glib(".into(), ")".into()),
             Pointer => {
-                let trans = from_glib_xxx(self.transfer);
+                let trans = from_glib_xxx(self.transfer, array_length);
                 match *env.type_(self.typ) {
                     library::Type::List(..) |
                         library::Type::SList(..) |
@@ -35,12 +35,12 @@ impl TranslateFromGlib for Mode {
 }
 
 impl TranslateFromGlib for analysis::return_value::Info {
-    fn translate_from_glib_as_function(&self, env: &Env) -> (String, String) {
+    fn translate_from_glib_as_function(&self, env: &Env, array_length: &Option<(String, String)>) -> (String, String) {
         match self.parameter {
             Some(ref par) => match self.base_tid {
                 Some(tid) => {
                     let rust_type = rust_type(env, tid);
-                    let from_glib_xxx = from_glib_xxx(par.transfer);
+                    let from_glib_xxx = from_glib_xxx(par.transfer, &None);
 
                     let prefix = if *par.nullable {
                         format!("Option::<{}>::{}", rust_type.into_string(), from_glib_xxx.0)
@@ -64,18 +64,22 @@ impl TranslateFromGlib for analysis::return_value::Info {
                         ("glib::error::BoolError::from_glib(".into(), format!(", \"{}\")", self.bool_return_is_error.as_ref().unwrap()))
                     }
                 }
-                None => Mode::from(par).translate_from_glib_as_function(env),
+                None => Mode::from(par).translate_from_glib_as_function(env, array_length),
             },
             None => (String::new(), ";".into())
         }
     }
 }
 
-fn from_glib_xxx(transfer: library::Transfer) -> (String, String) {
-    use library::Transfer::*;
-    match transfer {
-        None => ("from_glib_none(".into(), ")".into()),
-        Full => ("from_glib_full(".into(), ")".into()),
-        Container => ("from_glib_container(".into(), ")".into()),
+fn from_glib_xxx(transfer: library::Transfer, array_length: &Option<(String, String)>) -> (String, String) {
+    use library::Transfer;
+    match (transfer, array_length) {
+        (Transfer::None, &None) => ("from_glib_none(".into(), ")".into()),
+        (Transfer::Full, &None) => ("from_glib_full(".into(), ")".into()),
+        (Transfer::Container, &None) => ("from_glib_container(".into(), ")".into()),
+        (Transfer::None, &Some((ref array_length_name, _))) => ("from_glib_none_num(".into(), format!(", {} as usize)", array_length_name)),
+        (Transfer::Full, &Some((ref array_length_name, _))) => ("from_glib_full_num(".into(), format!(", {} as usize)", array_length_name)),
+        (Transfer::Container, &Some((ref array_length_name, _))) => ("from_glib_container_num(".into(), format!(", {} as usize)", array_length_name)),
     }
 }
+

--- a/src/codegen/translate_from_glib.rs
+++ b/src/codegen/translate_from_glib.rs
@@ -82,4 +82,3 @@ fn from_glib_xxx(transfer: library::Transfer, array_length: &Option<(String, Str
         (Transfer::Container, &Some((ref array_length_name, _))) => ("from_glib_container_num(".into(), format!(", {} as usize)", array_length_name)),
     }
 }
-

--- a/src/library.rs
+++ b/src/library.rs
@@ -261,6 +261,7 @@ pub struct Field {
     pub c_type: Option<String>,
     pub private: bool,
     pub bits: Option<u8>,
+    pub array_length: Option<u32>,
     pub doc: Option<String>,
 }
 
@@ -299,6 +300,7 @@ pub struct Parameter {
     pub caller_allocates: bool,
     pub nullable: Nullable,
     pub allow_none: bool,
+    pub array_length: Option<u32>,
     pub is_error: bool,
     pub doc: Option<String>,
 }

--- a/src/writer/to_code.rs
+++ b/src/writer/to_code.rs
@@ -41,9 +41,9 @@ impl ToCode for Chunk {
                 };
                 vec![s]
             }
-            FfiCallConversion{ref ret, ref call} => {
+            FfiCallConversion{ref ret, ref array_length, ref call} => {
                 let call_strings = call.to_code(env);
-                let (prefix, suffix) = ret.translate_from_glib_as_function(env);
+                let (prefix, suffix) = ret.translate_from_glib_as_function(env, array_length);
                 let s = format_block_one_line(&prefix, &suffix, &call_strings, "", "");
                 vec![s]
             }
@@ -78,9 +78,9 @@ impl ToCode for Chunk {
                 let s = format_block_one_line(prefix, suffix, &chs.to_code(env), "", ", ");
                 vec![s]
             }
-            FromGlibConversion{ref mode, ref value} => {
+            FromGlibConversion{ref mode, ref array_length, ref value} => {
                 let value_strings = value.to_code(env);
-                let (prefix, suffix) = mode.translate_from_glib_as_function(env);
+                let (prefix, suffix) = mode.translate_from_glib_as_function(env, array_length);
                 let s = format_block_one_line(&prefix, &suffix, &value_strings, "", "");
                 vec![s]
             }


### PR DESCRIPTION
https://github.com/gtk-rs/gir/issues/376


Only pointer arrays are currently supported, the translation trait is even called FromGlibPtrContainer. This should be changed really to also be able to handle all kinds of integer (incl. byte) arrays.