### PR TITLE
Implement Send/Sync configuration for objects/records

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,30 @@ status = "generate"
 Note that you must not place `Gtk.*` into the `generate` array and
 additionally configure its members.
 
+In various cases, GObjects or boxed types can be used from multiple threads
+and have certain concurrency guarantees. This can be configured with the
+`concurrency` setting at the top-level options or per object. It will
+automatically implement the `Send` and `Sync` traits for the resulting object
+and set appropriate trait bounds for signal callbacks. The default is `none`,
+and apart from that `send` and `send+sync` are supported.
+
+```toml
+[[object]]
+# object's fullname
+name = "Gtk.SomeClass"
+# can be also "manual" and "ignore" but it's simpler to just put the object in the same array
+status = "generate"
+# concurrency of the object, default is set in the top-level options or
+# otherwise "none". Valid values are "none", "send" and "send+sync"
+concurrency = "send+sync"
+```
+
+Note that `send` is only valid for types that are either not reference counted
+(i.e. `clone()` copies the object) or that are read-only (i.e. no API for
+mutating the object exists). `send+sync` is valid if the type can be sent to
+different threads and all API allows simultaneous calls from different threads
+due to internal locking via e.g. a mutex.
+
 ### Generation
 
 To generate the Rust-user API level, The command is very similar to the previous one. It's better to not put this output in the same directory as where the FFI files are. Just run:

--- a/src/analysis/info_base.rs
+++ b/src/analysis/info_base.rs
@@ -18,6 +18,7 @@ pub struct InfoBase {
     pub version: Option<Version>,
     pub deprecated_version: Option<Version>,
     pub cfg_condition: Option<String>,
+    pub concurrency: library::Concurrency,
 }
 
 impl InfoBase {

--- a/src/analysis/object.rs
+++ b/src/analysis/object.rs
@@ -177,6 +177,7 @@ pub fn class(env: &Env, obj: &GObject, deps: &[library::TypeId]) -> Option<Info>
         version: version,
         deprecated_version: deprecated_version,
         cfg_condition: obj.cfg_condition.clone(),
+        concurrency: obj.concurrency,
     };
 
     // patch up trait methods in the symbol table
@@ -295,6 +296,7 @@ pub fn interface(env: &Env, obj: &GObject, deps: &[library::TypeId]) -> Option<I
         version: version,
         deprecated_version: deprecated_version,
         cfg_condition: obj.cfg_condition.clone(),
+        concurrency: obj.concurrency,
     };
 
     let has_methods = !base.methods().is_empty();

--- a/src/analysis/record.rs
+++ b/src/analysis/record.rs
@@ -98,6 +98,7 @@ pub fn new(env: &Env, obj: &GObject) -> Option<Info> {
         version: version,
         deprecated_version: deprecated_version,
         cfg_condition: obj.cfg_condition.clone(),
+        concurrency: obj.concurrency,
     };
 
     let info = Info { base: base };

--- a/src/codegen/record.rs
+++ b/src/codegen/record.rs
@@ -1,6 +1,7 @@
 use std::io::{Result, Write};
 
 use analysis;
+use library;
 use analysis::special_functions::Type;
 use env::Env;
 use super::{function, general, trait_impls};
@@ -60,6 +61,25 @@ pub fn generate(w: &mut Write, env: &Env, analysis: &analysis::record::Info) -> 
         &analysis.specials,
         false,
     ));
+
+    if analysis.concurrency != library::Concurrency::None {
+        try!(writeln!(w, ""));
+    }
+
+    match analysis.concurrency {
+        library::Concurrency::Send |
+        library::Concurrency::SendSync => {
+            try!(writeln!(w, "unsafe impl Send for {} {{}}", analysis.name));
+        }
+        _ => (),
+    }
+
+    match analysis.concurrency {
+        library::Concurrency::SendSync => {
+            try!(writeln!(w, "unsafe impl Sync for {} {{}}", analysis.name));
+        }
+        _ => (),
+    }
 
     Ok(())
 }

--- a/src/codegen/signal.rs
+++ b/src/codegen/signal.rs
@@ -1,6 +1,7 @@
 use std::io::{Result, Write};
 
 use analysis;
+use library;
 use chunk::Chunk;
 use consts::TYPE_PARAMETERS_START;
 use env::Env;
@@ -18,12 +19,13 @@ pub fn generate(
     in_trait: bool,
     only_declaration: bool,
     indent: usize,
+    concurrency: library::Concurrency,
 ) -> Result<()> {
     let commented = analysis.trampoline_name.is_err();
     let comment_prefix = if commented { "//" } else { "" };
     let pub_prefix = if in_trait { "" } else { "pub " };
 
-    let function_type_string = function_type_string(env, analysis, trampolines);
+    let function_type_string = function_type_string(env, analysis, trampolines, concurrency);
     let declaration = declaration(analysis, &function_type_string);
     let suffix = if only_declaration { ";" } else { " {" };
 
@@ -79,6 +81,7 @@ fn function_type_string(
     env: &Env,
     analysis: &analysis::signals::Info,
     trampolines: &analysis::trampolines::Trampolines,
+    concurrency: library::Concurrency,
 ) -> Option<String> {
     if analysis.trampoline_name.is_err() {
         return None;
@@ -95,7 +98,12 @@ fn function_type_string(
         }
     };
 
-    let type_ = func_string(env, trampoline, Some((TYPE_PARAMETERS_START, "Self")));
+    let type_ = func_string(
+        env,
+        trampoline,
+        Some((TYPE_PARAMETERS_START, "Self")),
+        concurrency,
+    );
     Some(type_)
 }
 

--- a/src/codegen/trampoline.rs
+++ b/src/codegen/trampoline.rs
@@ -1,6 +1,7 @@
 use std::io::{Result, Write};
 
 use env::Env;
+use library;
 use analysis::bounds::{Bounds, BoundType};
 use analysis::ffi_type::ffi_type;
 use analysis::ref_mode::RefMode;
@@ -20,6 +21,7 @@ pub fn generate(
     analysis: &Trampoline,
     in_trait: bool,
     object_name: &str,
+    concurrency: library::Concurrency,
 ) -> Result<()> {
     try!(writeln!(w, ""));
     let (bounds, end) = if in_trait {
@@ -29,7 +31,7 @@ pub fn generate(
     };
 
     let params_str = trampoline_parameters(env, analysis);
-    let func_str = func_string(env, analysis, None);
+    let func_str = func_string(env, analysis, None, concurrency);
     let ret_str = trampoline_returns(env, analysis);
 
     try!(version_condition(w, env, analysis.version, false, 0));
@@ -64,11 +66,31 @@ pub fn func_string(
     env: &Env,
     analysis: &Trampoline,
     bound_replace: Option<(char, &str)>,
+    concurrency: library::Concurrency,
 ) -> String {
     let param_str = func_parameters(env, analysis, bound_replace);
     let return_str = func_returns(env, analysis);
 
-    format!("Fn({}){} + 'static", param_str, return_str)
+    let concurrency_str = match concurrency {
+        // If an object can be Send to other threads, this means that
+        // our callback will be called from whatever thread the object
+        // is sent to. But it will only be ever owned by a single thread
+        // at a time, so signals can only be emitted from one thread at
+        // a time and Sync is not needed
+        library::Concurrency::Send => " + Send",
+        // If an object is Sync, it can be shared between threads, and as
+        // such our callback can be called from arbitrary threads and needs
+        // to be Send *AND* Sync
+        library::Concurrency::SendSync => " + Send + Sync",
+        library::Concurrency::None => "",
+    };
+
+    format!(
+        "Fn({}){}{} + 'static",
+        param_str,
+        return_str,
+        concurrency_str
+    )
 }
 
 fn func_parameters(

--- a/src/library.rs
+++ b/src/library.rs
@@ -99,6 +99,32 @@ impl FromStr for FunctionKind {
     }
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Concurrency {
+    None,
+    Send,
+    SendSync,
+}
+
+impl FromStr for Concurrency {
+    type Err = String;
+    fn from_str(name: &str) -> Result<Concurrency, String> {
+        use self::Concurrency::*;
+        match name {
+            "none" => Ok(None),
+            "send" => Ok(Send),
+            "send+sync" => Ok(SendSync),
+            _ => Err("Unknown concurrency kind".into()),
+        }
+    }
+}
+
+impl Default for Concurrency {
+    fn default() -> Concurrency {
+        Concurrency::None
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Fundamental {
     None,


### PR DESCRIPTION
This allows configuring crate-wide and per object/record if an object is
supposed to be Send, Sync or Send + Sync. The marker traits will
automatically be implemented and signals callbacks on those objects will
get the appropriate trait bounds.

Note that it is still required to manually ensure that any signal of
parent or child types has at least the same trait bounds.

https://github.com/gtk-rs/gir/issues/379