### PR TITLE
Destroy

### DIFF
--- a/src/analysis/record_type.rs
+++ b/src/analysis/record_type.rs
@@ -12,14 +12,20 @@ impl RecordType {
         let mut has_free = false;
         let mut has_ref = false;
         let mut has_unref = false;
+        let mut has_destroy = false;
         for func in &record.functions {
             match &func.name[..] {
                 "copy" => has_copy = true,
                 "free" => has_free = true,
+                "destroy" => has_destroy = true,
                 "ref" => has_ref = true,
                 "unref" => has_unref = true,
                 _ => (),
             }
+        }
+
+        if has_destroy && has_copy {
+            has_free = true;
         }
 
         if has_copy && has_free {


### PR DESCRIPTION
It fixes a problem I encountered when generated the binding for the `Attribute` class in pango.

In the gir file:

```xml
<method name="destroy" c:identifier="pango_attribute_destroy">
  <doc xml:space="preserve">Destroy a #PangoAttribute and free all associated memory.</doc>
  <return-value transfer-ownership="none">
    <type name="none" c:type="void"/>
  </return-value>
  <parameters>
    <instance-parameter name="attr" transfer-ownership="none">
      <doc xml:space="preserve">a #PangoAttribute.</doc>
      <type name="Attribute" c:type="PangoAttribute*"/>
    </instance-parameter>
  </parameters>
</method>
```