### PR TITLE
Add SetValue/SetValueOptional bounds to property setters and import g…

### DIFF
--- a/src/analysis/object.rs
+++ b/src/analysis/object.rs
@@ -79,6 +79,7 @@ pub fn class(env: &Env, obj: &GObject, deps: &[library::TypeId]) -> Option<Info>
     let mut imports = Imports::new();
     imports.add("glib::translate::*", None);
     imports.add("ffi", None);
+    imports.add("gobject_ffi", None);
 
     let supertypes = supertypes::analyze(env, class_tid, &mut imports);
 
@@ -234,6 +235,7 @@ pub fn interface(env: &Env, obj: &GObject, deps: &[library::TypeId]) -> Option<I
     imports.add("glib::translate::*", None);
     imports.add("ffi", None);
     imports.add("glib::object::IsA", None);
+    imports.add("gobject_ffi", None);
 
     let supertypes = supertypes::analyze(env, iface_tid, &mut imports);
 

--- a/src/analysis/properties.rs
+++ b/src/analysis/properties.rs
@@ -72,7 +72,6 @@ pub fn analyze(
             }
             if type_string.is_ok() && prop.default_value.is_some() {
                 imports.add("glib::Value", prop.version);
-                imports.add("gobject_ffi", prop.version);
             }
 
             properties.push(prop);
@@ -83,11 +82,11 @@ pub fn analyze(
             }
             if type_string.is_ok() {
                 imports.add("glib::Value", prop.version);
-                imports.add("gobject_ffi", prop.version);
-                if prop.bound.is_some() {
-                    imports.add("glib::object::IsA", prop.version);
-                    imports.add("glib", prop.version);
-                }
+            }
+
+            if prop.bound.is_some() {
+                imports.add("glib", prop.version);
+                imports.add("glib::object::IsA", prop.version);
             }
 
             properties.push(prop);

--- a/src/codegen/properties.rs
+++ b/src/codegen/properties.rs
@@ -83,7 +83,16 @@ fn declaration(env: &Env, prop: &Property) -> String {
             ..
         }) = prop.bound
         {
-            bound = format!("<{}: IsA<{}> + IsA<glib::object::Object>>", alias, type_str);
+            let value_bound = if !prop.is_get {
+                if *prop.nullable {
+                    " + glib::value::SetValueOptional"
+                } else {
+                    " + glib::value::SetValue"
+                }
+            } else {
+                ""
+            };
+            bound = format!("<{}: IsA<{}> + IsA<glib::object::Object>{}>", alias, type_str, value_bound);
             if *prop.nullable {
                 format!("Option<&{}>", alias)
             } else {


### PR DESCRIPTION
…object_ffi

This is needed now as glib_wrapper!() implements the Value traits
instead of having generic implementations.

See https://github.com/gtk-rs/glib/pull/196