### PR TITLE
Unions: Remove feature-gate for stable rustc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,3 @@ git2 = { version = "0.6", default-features = false }
 
 [profile.release]
 codegen-units = 4
-
-[features]
-default = []
-use_unions = []

--- a/README.md
+++ b/README.md
@@ -309,11 +309,9 @@ It'll generate a `docs.md` if everything went fine. That's where all this crate'
 
 And now your crate should be completely documented as expected!
 
-## Nightly Rust Only Features
-
 ### Unions
 
-By default union generation is disabled except for some special cases due to unions not yet being a stable feature. However if you are using *nightly* rust, then you can enable union generation using `cargo run --release --features "use_unions"`.
+`gir` now has the ability to generate c-like unions using newly stabilised `union` in rustc 1.19. As such this means `gir` requires a minimum version rustc of 1.19
 
 Keep in mind that to access union members, you are required to use `unsafe` blocks, for example;
 

--- a/src/codegen/sys/lib_.rs
+++ b/src/codegen/sys/lib_.rs
@@ -343,7 +343,7 @@ fn generate_unions(w: &mut Write, env: &Env, items: &[&Union]) -> Result<()> {
             if lines.is_empty() {
                 try!(writeln!(
                     w,
-                    "{0}#[repr(C)]\n{0}#[derive(Copy,Clone)]\n{0}pub union {1}(c_void);\n",
+                    "{0}#[repr(C)]\n{0}pub union {1}(c_void);\n",
                     comment,
                     c_type
                 ));
@@ -631,12 +631,9 @@ fn generate_fields(env: &Env, struct_name: &str, fields: &[Field]) -> (Vec<Strin
             lines.push("\tpub priv_: gpointer,".to_owned());
         } else if let Some(ref c_type) = field.c_type {
             let name = mangle_keywords(&*field.name);
-            let mut c_type = ffi_type(env, field.typ, c_type);
+            let c_type = ffi_type(env, field.typ, c_type);
             if c_type.is_err() {
                 commented = true;
-            }
-            if is_gvalue && field.name == "data" {
-                c_type = Ok("[u64; 2]".to_owned());
             }
             lines.push(format!("\tpub {}: {},", name, c_type.into_string()));
         } else {

--- a/src/codegen/sys/lib_.rs
+++ b/src/codegen/sys/lib_.rs
@@ -343,16 +343,16 @@ fn generate_unions(w: &mut Write, env: &Env, items: &[&Union]) -> Result<()> {
             if lines.is_empty() {
                 try!(writeln!(
                     w,
-                    "{comment}#[repr(C)]\n{comment}pub union {name}(c_void);\n",
-                    comment = comment,
-                    name = c_type
+                    "{0}#[repr(C)]\n{0}#[derive(Copy,Clone)]\n{0}pub union {1}(c_void);\n",
+                    comment,
+                    c_type
                 ));
             } else {
                 try!(writeln!(
                     w,
-                    "{comment}#[repr(C)]\n{comment}pub union {name} {{",
-                    comment = comment,
-                    name = c_type
+                    "{0}#[repr(C)]\n{0}#[derive(Copy,Clone)]\n{0}pub union {1} {{",
+                    comment,
+                    c_type
                 ));
 
                 for line in lines {
@@ -498,7 +498,7 @@ fn generate_records(w: &mut Write, env: &Env, records: &[&Record]) -> Result<()>
         if lines.is_empty() {
             try!(writeln!(
                 w,
-                "{}#[repr(C)]\n{0}pub struct {}(c_void);\n",
+                "{0}#[repr(C)]\n{0}#[derive(Copy,Clone)]\n{0}pub struct {1}(u8);\n",
                 comment,
                 record.c_type
             ));

--- a/src/codegen/sys/lib_.rs
+++ b/src/codegen/sys/lib_.rs
@@ -317,36 +317,7 @@ fn generate_unions(w: &mut Write, env: &Env, items: &[&Union]) -> Result<()> {
 
     for item in items {
         if let Some(ref c_type) = item.c_type {
-            #[cfg(feature = "use_unions")]
-            {
-                let (lines, commented) = generate_fields(env, &item.name, &item.fields);
-
-                let comment = if commented { "//" } else { "" };
-                if lines.is_empty() {
-                    try!(writeln!(
-                        w,
-                        "{comment}#[repr(C)]\n{comment}pub union {name}(c_void);\n",
-                        comment = comment,
-                        name = c_type
-                    ));
-                } else {
-                    try!(writeln!(
-                        w,
-                        "{comment}#[repr(C)]\n{comment}pub union {name} {{",
-                        comment = comment,
-                        name = c_type
-                    ));
-
-                    for line in lines {
-                        try!(writeln!(w, "{}{}", comment, line));
-                    }
-                    try!(writeln!(w, "{}}}\n", comment));
-                }
-                if comment.is_empty() {
-                    try!(generate_debug_with_fields(w, name, &lines));
-                }
-            }
-            #[cfg(not(feature = "use_unions"))]
+           /* #[cfg(not(feature = "use_unions"))]
             {
                 // TODO: GLib/GObject special cases until we have proper union support in Rust
                 if env.config.library_name == "GLib" && c_type == "GMutex" {
@@ -365,19 +336,35 @@ fn generate_unions(w: &mut Write, env: &Env, items: &[&Union]) -> Result<()> {
                          pub struct {0}(*mut c_void);",
                         c_type
                     ));
-                } else {
-                    try!(writeln!(w, "pub type {} = c_void; // union", c_type));
+                }*/
+            let (lines, commented) = generate_fields(env, &item.name, &item.fields);
+
+            let comment = if commented { "//" } else { "" };
+            if lines.is_empty() {
+                try!(writeln!(
+                    w,
+                    "{comment}#[repr(C)]\n{comment}pub union {name}(c_void);\n",
+                    comment = comment,
+                    name = c_type
+                ));
+            } else {
+                try!(writeln!(
+                    w,
+                    "{comment}#[repr(C)]\n{comment}pub union {name} {{",
+                    comment = comment,
+                    name = c_type
+                ));
+
+                for line in lines {
+                    try!(writeln!(w, "{}{}", comment, line));
                 }
+                try!(writeln!(w, "{}}}\n", comment));
+            }
+            if comment.is_empty() {
+                try!(generate_debug_with_fields(w, name, &lines));
             }
         }
     }
-    #[cfg(not(feature = "use_unions"))]
-    {
-        if !items.is_empty() {
-            try!(writeln!(w, ""));
-        }
-    }
-
     Ok(())
 }
 
@@ -531,7 +518,8 @@ fn generate_records(w: &mut Write, env: &Env, records: &[&Record]) -> Result<()>
                 w,
                 "{}#[repr(C)]\n{}{0}pub struct {} {{",
                 comment,
-                if can_generate_fields_debug(&record.fields) { "#[derive(Debug)]\n" } else { "" },
+                if can_generate_fields_debug(&record.fields) { "#[derive(Copy,Clone,Debug)]\n" }
+                else { "" },
                 record.c_type
             ));
             for line in &lines {
@@ -590,43 +578,16 @@ fn generate_fields(env: &Env, struct_name: &str, fields: &[Field]) -> (Vec<Strin
             }
         };
 
-        // TODO: Special case for padding unions like used in GStreamer, see e.g.
-        // the padding in GstControlBinding
-        #[cfg(not(feature = "use_unions"))]
+        if !is_gweakref && !truncated && !is_ptr && is_bits &&
+            !is_union_special_case(&field.c_type)
         {
-            if is_union && !truncated {
-                if let Some(union_) = env.library.type_(field.typ).maybe_ref_as::<Union>() {
-                    for union_field in &union_.fields {
-                        if union_field.name.contains("reserved")
-                            || union_field.name.contains("padding")
-                        {
-                            if let Some(ref c_type) = union_field.c_type {
-                                let name = mangle_keywords(&*union_field.name);
-                                let c_type = ffi_type(env, union_field.typ, c_type);
-                                if c_type.is_err() {
-                                    commented = true;
-                                }
-                                lines.push(format!("\tpub {}: {},", name, c_type.into_string()));
-                                continue 'fields;
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        if !cfg!(feature = "use_unions") || (is_bits && !truncated) {
-            if !is_gweakref && !is_ghooklist && !truncated && !is_ptr && (is_union || is_bits)
-                && !is_union_special_case(&field.c_type)
-            {
-                warn!(
-                    "Field `{}::{}` not expressible in Rust, truncated",
-                    struct_name,
-                    field.name
-                );
-                lines.push("\t_truncated_record_marker: c_void,".to_owned());
-                truncated = true;
-            }
+            warn!(
+                "Field `{}::{}` not expressible in Rust, truncated",
+                struct_name,
+                field.name
+            );
+            lines.push("\t_truncated_record_marker: u8,".to_owned());
+            truncated = true;
         }
 
         if truncated {
@@ -665,7 +626,7 @@ fn generate_fields(env: &Env, struct_name: &str, fields: &[Field]) -> (Vec<Strin
                 lines.push("\tpub hook_size_and_setup: c_ulong,".to_owned());
             }
         // is_setup is ignored
-        } else if is_gweakref && !cfg!(feature = "use_unions") {
+        } else if is_gweakref {
             // union containing a single pointer
             lines.push("\tpub priv_: gpointer,".to_owned());
         } else if let Some(ref c_type) = field.c_type {
@@ -674,7 +635,7 @@ fn generate_fields(env: &Env, struct_name: &str, fields: &[Field]) -> (Vec<Strin
             if c_type.is_err() {
                 commented = true;
             }
-            if !cfg!(feature = "use_unions") && is_gvalue && field.name == "data" {
+            if is_gvalue && field.name == "data" {
                 c_type = Ok("[u64; 2]".to_owned());
             }
             lines.push(format!("\tpub {}: {},", name, c_type.into_string()));

--- a/src/codegen/sys/statics.rs
+++ b/src/codegen/sys/statics.rs
@@ -47,7 +47,7 @@ pub fn only_for_glib(w: &mut Write) -> Result<()> {
         "pub type gpointer = *mut c_void;",
         "",
         "#[repr(C)]",
-        "#[derive(Debug)]",
+        "#[derive(Copy,Clone,Debug)]",
         "pub struct Volatile<T>(T);",
         "",
     ];

--- a/src/codegen/sys/statics.rs
+++ b/src/codegen/sys/statics.rs
@@ -3,13 +3,8 @@ use std::io::{Result, Write};
 use super::super::general::write_vec;
 
 pub fn begin(w: &mut Write) -> Result<()> {
-    #[cfg(feature = "use_unions")]
-    let u = "#![feature(untagged_unions)]";
-    #[cfg(not(feature = "use_unions"))]
-    let u = "";
-
     let v = vec![
-        u,
+        "",
         "#![allow(non_camel_case_types, non_upper_case_globals)]",
         "",
         "extern crate libc;",

--- a/src/library.rs
+++ b/src/library.rs
@@ -287,7 +287,6 @@ pub struct Record {
     pub deprecated_version: Option<Version>,
     pub doc: Option<String>,
     pub doc_deprecated: Option<String>,
-    pub derive_copy: bool,
 }
 
 #[derive(Default, Debug)]
@@ -576,7 +575,6 @@ impl Type {
             deprecated_version: r.deprecated_version,
             doc: r.doc,
             doc_deprecated: r.doc_deprecated,
-            derive_copy: r.derive_copy,
         });
         library.add_type(ns_id, &format!("#{:?}", field_tids), typ)
     }

--- a/src/library.rs
+++ b/src/library.rs
@@ -287,6 +287,7 @@ pub struct Record {
     pub deprecated_version: Option<Version>,
     pub doc: Option<String>,
     pub doc_deprecated: Option<String>,
+    pub derive_copy: bool,
 }
 
 #[derive(Default, Debug)]
@@ -575,6 +576,7 @@ impl Type {
             deprecated_version: r.deprecated_version,
             doc: r.doc,
             doc_deprecated: r.doc_deprecated,
+            derive_copy: r.derive_copy,
         });
         library.add_type(ns_id, &format!("#{:?}", field_tids), typ)
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -285,14 +285,7 @@ impl Library {
                         let ctype = u.c_type.clone();
 
                         let type_id = {
-                            #[cfg(not(feature = "use_unions"))]
-                            {
-                                Type::union(self, u, INTERNAL_NAMESPACE)
-                            }
-                            #[cfg(feature = "use_unions")]
-                            {
-                                Type::union(self, u, ns_id)
-                            }
+                            Type::union(self, u, ns_id)
                         };
 
                         fields.push(Field {
@@ -340,7 +333,7 @@ impl Library {
         ns_id: u16,
         attrs: &Attributes,
     ) -> Result<()> {
-        if let Some(typ) = try!(self.read_record(parser, ns_id, attrs, None, None)) {
+        if let Some(typ) = try!(self.read_record(parser, ns_id, attrs, None, None, false)) {
             let name = typ.get_name().clone();
             self.add_type(ns_id, &name, typ);
         }
@@ -354,6 +347,7 @@ impl Library {
         attrs: &Attributes,
         parent_name_prefix: Option<&str>,
         parent_ctype_prefix: Option<&str>,
+        derive_copy: bool,
     ) -> Result<Option<Type>> {
         let mut record_name = try!(
             attrs
@@ -436,14 +430,7 @@ impl Library {
                             let ctype = u.c_type.clone();
 
                             let type_id = {
-                                #[cfg(not(feature = "use_unions"))]
-                                {
-                                    Type::union(self, u, INTERNAL_NAMESPACE)
-                                }
-                                #[cfg(feature = "use_unions")]
-                                {
-                                    Type::union(self, u, ns_id)
-                                }
+                                Type::union(self, u, ns_id)
                             };
 
                             fields.push(Field {
@@ -504,6 +491,7 @@ impl Library {
             deprecated_version: deprecated_version,
             doc: doc,
             doc_deprecated: doc_deprecated,
+            derive_copy: derive_copy,
         });
 
         Ok(Some(typ))
@@ -570,7 +558,8 @@ impl Library {
                             ns_id,
                             attrs,
                             parent_name_prefix,
-                            parent_ctype_prefix
+                            parent_ctype_prefix,
+                            true
                         )) {
                             Some(Type::Record(r)) => r,
                             _ => continue,
@@ -614,14 +603,7 @@ impl Library {
                         let ctype = r.c_type.clone();
 
                         let type_id = {
-                            #[cfg(not(feature = "use_unions"))]
-                            {
-                                Type::record(self, r, INTERNAL_NAMESPACE)
-                            }
-                            #[cfg(feature = "use_unions")]
-                            {
-                                Type::record(self, r, ns_id)
-                            }
+                            Type::record(self, r, ns_id)
                         };
 
                         fields.push(Field {

--- a/tests/sys/atk-sys/Cargo.toml
+++ b/tests/sys/atk-sys/Cargo.toml
@@ -1,9 +1,8 @@
-
 [build-dependencies]
 pkg-config = "0.3.7"
 
 [dependencies]
-bitflags = "0.8"
+bitflags = "1.0"
 libc = "0.2"
 
 [dependencies.glib-sys]
@@ -13,6 +12,7 @@ path = "../glib-sys"
 path = "../gobject-sys"
 
 [features]
+dox = []
 v2_10 = ["v2_9_4"]
 v2_12 = ["v2_10"]
 v2_14 = ["v2_12"]

--- a/tests/sys/gdk-pixbuf-sys/Cargo.toml
+++ b/tests/sys/gdk-pixbuf-sys/Cargo.toml
@@ -1,9 +1,8 @@
-
 [build-dependencies]
 pkg-config = "0.3.7"
 
 [dependencies]
-bitflags = "0.8"
+bitflags = "1.0"
 libc = "0.2"
 
 [dependencies.gio-sys]
@@ -16,9 +15,11 @@ path = "../glib-sys"
 path = "../gobject-sys"
 
 [features]
+dox = []
 v2_28 = []
 v2_30 = ["v2_28"]
 v2_32 = ["v2_30"]
+v2_36 = ["v2_32"]
 
 [lib]
 name = "gdk_pixbuf_sys"

--- a/tests/sys/gdk-sys/Cargo.toml
+++ b/tests/sys/gdk-sys/Cargo.toml
@@ -1,9 +1,8 @@
-
 [build-dependencies]
 pkg-config = "0.3.7"
 
 [dependencies]
-bitflags = "0.8"
+bitflags = "1.0"
 libc = "0.2"
 
 [dependencies.cairo-sys-rs]
@@ -25,10 +24,14 @@ path = "../gobject-sys"
 path = "../pango-sys"
 
 [features]
+dox = []
 v3_10 = ["v3_8"]
 v3_12 = ["v3_10"]
 v3_14 = ["v3_12"]
 v3_16 = ["v3_14"]
+v3_18 = ["v3_16"]
+v3_20 = ["v3_18"]
+v3_22 = ["v3_20"]
 v3_6 = []
 v3_8 = ["v3_6"]
 

--- a/tests/sys/gio-sys/Cargo.toml
+++ b/tests/sys/gio-sys/Cargo.toml
@@ -1,9 +1,8 @@
-
 [build-dependencies]
 pkg-config = "0.3.7"
 
 [dependencies]
-bitflags = "0.8"
+bitflags = "1.0"
 libc = "0.2"
 
 [dependencies.glib-sys]
@@ -13,12 +12,18 @@ path = "../glib-sys"
 path = "../gobject-sys"
 
 [features]
+dox = []
 v2_34 = []
 v2_36 = ["v2_34"]
 v2_38 = ["v2_36"]
 v2_40 = ["v2_38"]
 v2_42 = ["v2_40"]
 v2_44 = ["v2_42"]
+v2_46 = ["v2_44"]
+v2_48 = ["v2_46"]
+v2_50 = ["v2_48"]
+v2_52 = ["v2_50"]
+v2_54 = ["v2_52"]
 
 [lib]
 name = "gio_sys"

--- a/tests/sys/glib-sys/Cargo.toml
+++ b/tests/sys/glib-sys/Cargo.toml
@@ -1,17 +1,22 @@
-
 [build-dependencies]
 pkg-config = "0.3.7"
 
 [dependencies]
-bitflags = "0.8"
+bitflags = "1.0"
 libc = "0.2"
 
 [features]
+dox = []
 v2_34 = []
 v2_36 = ["v2_34"]
 v2_38 = ["v2_36"]
 v2_40 = ["v2_38"]
 v2_44 = ["v2_40"]
+v2_46 = ["v2_44"]
+v2_48 = ["v2_46"]
+v2_50 = ["v2_48"]
+v2_52 = ["v2_50"]
+v2_54 = ["v2_52"]
 
 [lib]
 name = "glib_sys"

--- a/tests/sys/gobject-sys/Cargo.toml
+++ b/tests/sys/gobject-sys/Cargo.toml
@@ -1,20 +1,22 @@
-
 [build-dependencies]
 pkg-config = "0.3.7"
 
 [dependencies]
-bitflags = "0.8"
+bitflags = "1.0"
 libc = "0.2"
 
 [dependencies.glib-sys]
 path = "../glib-sys"
 
 [features]
+dox = []
 v2_34 = []
 v2_36 = ["v2_34"]
 v2_38 = ["v2_36"]
 v2_42 = ["v2_38"]
 v2_44 = ["v2_42"]
+v2_46 = ["v2_44"]
+v2_54 = ["v2_46"]
 
 [lib]
 name = "gobject_sys"

--- a/tests/sys/gtk-sys/Cargo.toml
+++ b/tests/sys/gtk-sys/Cargo.toml
@@ -1,9 +1,8 @@
-
 [build-dependencies]
 pkg-config = "0.3.7"
 
 [dependencies]
-bitflags = "0.8"
+bitflags = "1.0"
 libc = "0.2"
 
 [dependencies.atk-sys]
@@ -31,10 +30,15 @@ path = "../gobject-sys"
 path = "../pango-sys"
 
 [features]
+dox = []
 v3_10 = ["v3_8"]
 v3_12 = ["v3_10"]
 v3_14 = ["v3_12"]
 v3_16 = ["v3_14"]
+v3_18 = ["v3_16"]
+v3_20 = ["v3_18"]
+v3_22 = ["v3_20"]
+v3_22_6 = ["v3_22"]
 v3_6 = []
 v3_8 = ["v3_6"]
 

--- a/tests/sys/pango-sys/Cargo.toml
+++ b/tests/sys/pango-sys/Cargo.toml
@@ -1,9 +1,8 @@
-
 [build-dependencies]
 pkg-config = "0.3.7"
 
 [dependencies]
-bitflags = "0.8"
+bitflags = "1.0"
 libc = "0.2"
 
 [dependencies.glib-sys]
@@ -13,11 +12,14 @@ path = "../glib-sys"
 path = "../gobject-sys"
 
 [features]
+dox = []
 v1_31 = []
 v1_32 = ["v1_31"]
 v1_32_4 = ["v1_32"]
 v1_34 = ["v1_32_4"]
 v1_36_7 = ["v1_34"]
+v1_38 = ["v1_36_7"]
+v1_42 = ["v1_38"]
 
 [lib]
 name = "pango_sys"

--- a/tests/sys/secret-sys/Cargo.toml
+++ b/tests/sys/secret-sys/Cargo.toml
@@ -1,9 +1,8 @@
-
 [build-dependencies]
 pkg-config = "0.3.7"
 
 [dependencies]
-bitflags = "0.8"
+bitflags = "1.0"
 libc = "0.2"
 
 [dependencies.gio-sys]
@@ -16,6 +15,7 @@ path = "../glib-sys"
 path = "../gobject-sys"
 
 [features]
+dox = []
 
 [lib]
 name = "secret_sys"


### PR DESCRIPTION
Removes all feature-gating of `union`, and now requires rust 1.19
Updates readme to reflect this.