### PR TITLE
Fix borrowed_box clippy warning in generated trampoline code

### DIFF
--- a/src/codegen/trampoline.rs
+++ b/src/codegen/trampoline.rs
@@ -53,7 +53,7 @@ pub fn generate(
         ));
     }
     try!(writeln!(w, "\tcallback_guard!();"));
-    try!(writeln!(w, "\tlet f: &Box_<{}> = transmute(f);", func_str));
+    try!(writeln!(w, "\tlet f: &&({}) = transmute(f);", func_str));
     try!(transformation_vars(w, analysis));
     let call = trampoline_call_func(env, analysis, in_trait);
     try!(writeln!(w, "\t{}", call));


### PR DESCRIPTION
https://github.com/rust-lang-nursery/rust-clippy/wiki#borrowed_box