### PR TITLE
Get rid of some clippy warnings

### DIFF
--- a/src/codegen/flags.rs
+++ b/src/codegen/flags.rs
@@ -99,6 +99,7 @@ fn generate_flags(
         let member_config = config.members.matched(&member.name);
         let version = member_config.iter().filter_map(|m| m.version).next();
         try!(version_condition(w, env, version, false, 2));
+        try!(writeln!(w, "\t\t#[cfg_attr(feature = \"cargo-clippy\", allow(unreadable_literal))]"));
         try!(writeln!(w, "\t\tconst {} = {};", name, val as u32));
         if let Some(cfg) =
             version_condition_string(env, cmp::max(flags.version, version), false, 0)

--- a/src/codegen/function.rs
+++ b/src/codegen/function.rs
@@ -61,6 +61,11 @@ pub fn generate(
         indent,
     ));
     try!(doc_hidden(w, analysis.doc_hidden, comment_prefix, indent));
+
+    if !commented && analysis.parameters.rust_parameters.len() > 7 {
+        try!(writeln!(w, "{}#[cfg_attr(feature = \"cargo-clippy\", allow(too_many_arguments))]", tabs(indent)));
+    }
+
     try!(writeln!(
         w,
         "{}{}{}{}{}",

--- a/src/codegen/object.rs
+++ b/src/codegen/object.rs
@@ -71,6 +71,15 @@ pub fn generate(w: &mut Write, env: &Env, analysis: &analysis::object::Info) -> 
         }
 
         try!(writeln!(w, "}}"));
+
+        if analysis.functions.iter().any(|f| !f.visibility.hidden() && f.name == "new" && f.parameters.rust_parameters.is_empty()) {
+            try!(writeln!(w, ""));
+            try!(writeln!(w, "impl Default for {} {{", analysis.name));
+            try!(writeln!(w, "    fn default() -> Self {{"));
+            try!(writeln!(w, "        Self::new()"));
+            try!(writeln!(w, "    }}"));
+            try!(writeln!(w, "}}"));
+        }
     }
 
     try!(trait_impls::generate(

--- a/src/codegen/record.rs
+++ b/src/codegen/record.rs
@@ -54,6 +54,15 @@ pub fn generate(w: &mut Write, env: &Env, analysis: &analysis::record::Info) -> 
         try!(writeln!(w, "}}"));
     }
 
+    if analysis.functions.iter().any(|f| !f.visibility.hidden() && f.name == "new" && f.parameters.rust_parameters.is_empty()) {
+        try!(writeln!(w, ""));
+        try!(writeln!(w, "impl Default for {} {{", analysis.name));
+        try!(writeln!(w, "    fn default() -> Self {{"));
+        try!(writeln!(w, "        Self::new()"));
+        try!(writeln!(w, "    }}"));
+        try!(writeln!(w, "}}"));
+    }
+
     try!(trait_impls::generate(
         w,
         &analysis.name,

--- a/src/codegen/trampoline.rs
+++ b/src/codegen/trampoline.rs
@@ -53,6 +53,7 @@ pub fn generate(
         ));
     }
     try!(writeln!(w, "\tcallback_guard!();"));
+    try!(writeln!(w, "\t#[cfg_attr(feature = \"cargo-clippy\", allow(transmute_ptr_to_ref))]"));
     try!(writeln!(w, "\tlet f: &&({}) = transmute(f);", func_str));
     try!(transformation_vars(w, analysis));
     let call = trampoline_call_func(env, analysis, in_trait);


### PR DESCRIPTION
This makes gstreamer-rs warning free with the default clippy configuration.