### PR TITLE
Support action signals

### DIFF
--- a/src/analysis/signals.rs
+++ b/src/analysis/signals.rs
@@ -10,12 +10,14 @@ use version::Version;
 
 #[derive(Debug)]
 pub struct Info {
+    pub object_name: String,
     pub connect_name: String,
     pub signal_name: String,
     pub trampoline_name: Result<String, Vec<String>>,
     pub version: Option<Version>,
     pub deprecated_version: Option<Version>,
     pub doc_hidden: bool,
+    pub is_action: bool,
 }
 
 pub fn analyze(
@@ -40,6 +42,7 @@ pub fn analyze(
 
         let info = analyze_signal(
             env,
+            obj,
             signal,
             type_tid,
             in_trait,
@@ -57,6 +60,7 @@ pub fn analyze(
 
 fn analyze_signal(
     env: &Env,
+    obj: &GObject,
     signal: &library::Signal,
     type_tid: library::TypeId,
     in_trait: bool,
@@ -98,12 +102,14 @@ fn analyze_signal(
     }
 
     let info = Info {
+        object_name: obj.name.clone(),
         connect_name: connect_name,
         signal_name: signal.name.clone(),
         trampoline_name: trampoline_name,
         version: version,
         deprecated_version: deprecated_version,
         doc_hidden: doc_hidden,
+        is_action: signal.is_action,
     };
     Some(info)
 }

--- a/src/codegen/signal.rs
+++ b/src/codegen/signal.rs
@@ -21,6 +21,16 @@ pub fn generate(
     indent: usize,
     concurrency: library::Concurrency,
 ) -> Result<()> {
+    // TODO: Add support for action signals.
+    // These work the other way around than normal signals: We are supposed to emit them from
+    // outside the object instead of connecting to it by using g_signal_emit*(). It basically is
+    // like a dynamic function call.
+    // The object itself is connected to the signal and waiting for us to emit it, to do something.
+    if analysis.is_action {
+        warn!("Ignoring action signal {}::{} - action signals are unsupported currently", analysis.object_name, analysis.signal_name);
+        return Ok(());
+    }
+
     let commented = analysis.trampoline_name.is_err();
     let comment_prefix = if commented { "//" } else { "" };
     let pub_prefix = if in_trait { "" } else { "pub " };

--- a/src/library.rs
+++ b/src/library.rs
@@ -364,6 +364,7 @@ pub struct Signal {
     pub deprecated_version: Option<Version>,
     pub doc: Option<String>,
     pub doc_deprecated: Option<String>,
+    pub is_action: bool,
 }
 
 #[derive(Default, Debug)]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1345,6 +1345,7 @@ impl Library {
         if let Some(v) = deprecated_version {
             self.register_version(ns_id, v);
         }
+        let is_action = to_bool(attrs.by_name("action").unwrap_or("0"));
 
         let mut params = Vec::new();
         let mut ret = None;
@@ -1394,6 +1395,7 @@ impl Library {
                 deprecated_version: deprecated_version,
                 doc: doc,
                 doc_deprecated: doc_deprecated,
+                is_action: is_action,
             })
         } else {
             bail!(mk_error!("Missing <return-value> element", parser))


### PR DESCRIPTION
These work the other way around than normal signals: We are supposed to
emit them from outside the object instead of connecting to it by using
g_signal_emit*(). It basically is like a dynamic function call.
The object itself is connected to the signal and waiting for us to emit
it, to do something.