### PR TITLE
Add configuration for concurrency per signal

### DIFF
--- a/src/analysis/signals.rs
+++ b/src/analysis/signals.rs
@@ -45,6 +45,7 @@ pub fn analyze(
             in_trait,
             &configured_signals,
             trampolines,
+            obj,
             imports,
         );
         if let Some(info) = info {
@@ -62,6 +63,7 @@ fn analyze_signal(
     in_trait: bool,
     configured_signals: &[&config::signals::Signal],
     trampolines: &mut trampolines::Trampolines,
+    obj: &GObject,
     imports: &mut Imports,
 ) -> Option<Info> {
     let mut used_types: Vec<String> = Vec::with_capacity(4);
@@ -81,6 +83,7 @@ fn analyze_signal(
         in_trait,
         configured_signals,
         trampolines,
+        obj,
         &mut used_types,
         version,
     );

--- a/src/analysis/trampolines.rs
+++ b/src/analysis/trampolines.rs
@@ -1,4 +1,5 @@
 use config;
+use config::gobjects::GObject;
 use env::Env;
 use library;
 use nameutil::signal_to_snake;
@@ -19,6 +20,7 @@ pub struct Trampoline {
     pub bounds: Bounds,
     pub version: Option<Version>,
     pub inhibit: bool,
+    pub concurrency: library::Concurrency,
 }
 
 pub type Trampolines = Vec<Trampoline>;
@@ -30,6 +32,7 @@ pub fn analyze(
     in_trait: bool,
     configured_signals: &[&config::signals::Signal],
     trampolines: &mut Trampolines,
+    obj: &GObject,
     used_types: &mut Vec<String>,
     version: Option<Version>,
 ) -> Result<String, Vec<String>> {
@@ -100,6 +103,12 @@ pub fn analyze(
         }
     }
 
+    let concurrency = configured_signals
+            .iter()
+            .map(|f| f.concurrency)
+            .next()
+            .unwrap_or(obj.concurrency);
+
     let ret = library::Parameter {
         nullable: ret_nullable,
         ..signal.ret.clone()
@@ -112,6 +121,7 @@ pub fn analyze(
         bounds: bounds,
         version: version,
         inhibit: inhibit,
+        concurrency: concurrency,
     };
     trampolines.push(trampoline);
     Ok(name)

--- a/src/codegen/object.rs
+++ b/src/codegen/object.rs
@@ -65,7 +65,6 @@ pub fn generate(w: &mut Write, env: &Env, analysis: &analysis::object::Info) -> 
                     false,
                     false,
                     1,
-                    analysis.concurrency,
                 ));
             }
         }
@@ -129,7 +128,6 @@ pub fn generate(w: &mut Write, env: &Env, analysis: &analysis::object::Info) -> 
                 true,
                 true,
                 1,
-                analysis.concurrency,
             ));
         }
         try!(writeln!(w, "}}"));
@@ -174,7 +172,6 @@ pub fn generate(w: &mut Write, env: &Env, analysis: &analysis::object::Info) -> 
                 true,
                 false,
                 1,
-                analysis.concurrency,
             ));
         }
         try!(writeln!(w, "}}"));
@@ -188,7 +185,6 @@ pub fn generate(w: &mut Write, env: &Env, analysis: &analysis::object::Info) -> 
                 trampoline,
                 generate_trait(analysis),
                 &analysis.name,
-                analysis.concurrency,
             ));
         }
     }

--- a/src/codegen/signal.rs
+++ b/src/codegen/signal.rs
@@ -1,7 +1,6 @@
 use std::io::{Result, Write};
 
 use analysis;
-use library;
 use chunk::Chunk;
 use consts::TYPE_PARAMETERS_START;
 use env::Env;
@@ -19,13 +18,12 @@ pub fn generate(
     in_trait: bool,
     only_declaration: bool,
     indent: usize,
-    concurrency: library::Concurrency,
 ) -> Result<()> {
     let commented = analysis.trampoline_name.is_err();
     let comment_prefix = if commented { "//" } else { "" };
     let pub_prefix = if in_trait { "" } else { "pub " };
 
-    let function_type_string = function_type_string(env, analysis, trampolines, concurrency);
+    let function_type_string = function_type_string(env, analysis, trampolines);
     let declaration = declaration(analysis, &function_type_string);
     let suffix = if only_declaration { ";" } else { " {" };
 
@@ -81,7 +79,6 @@ fn function_type_string(
     env: &Env,
     analysis: &analysis::signals::Info,
     trampolines: &analysis::trampolines::Trampolines,
-    concurrency: library::Concurrency,
 ) -> Option<String> {
     if analysis.trampoline_name.is_err() {
         return None;
@@ -102,7 +99,6 @@ fn function_type_string(
         env,
         trampoline,
         Some((TYPE_PARAMETERS_START, "Self")),
-        concurrency,
     );
     Some(type_)
 }

--- a/src/codegen/trampoline.rs
+++ b/src/codegen/trampoline.rs
@@ -21,7 +21,6 @@ pub fn generate(
     analysis: &Trampoline,
     in_trait: bool,
     object_name: &str,
-    concurrency: library::Concurrency,
 ) -> Result<()> {
     try!(writeln!(w, ""));
     let (bounds, end) = if in_trait {
@@ -31,7 +30,7 @@ pub fn generate(
     };
 
     let params_str = trampoline_parameters(env, analysis);
-    let func_str = func_string(env, analysis, None, concurrency);
+    let func_str = func_string(env, analysis, None);
     let ret_str = trampoline_returns(env, analysis);
 
     try!(version_condition(w, env, analysis.version, false, 0));
@@ -66,12 +65,11 @@ pub fn func_string(
     env: &Env,
     analysis: &Trampoline,
     bound_replace: Option<(char, &str)>,
-    concurrency: library::Concurrency,
 ) -> String {
     let param_str = func_parameters(env, analysis, bound_replace);
     let return_str = func_returns(env, analysis);
 
-    let concurrency_str = match concurrency {
+    let concurrency_str = match analysis.concurrency {
         // If an object can be Send to other threads, this means that
         // our callback will be called from whatever thread the object
         // is sent to. But it will only be ever owned by a single thread


### PR DESCRIPTION
When the object is Send+Sync it might still make sense to use Send only
for the signal. This is the case if the signal can be called only from a
single thread at a time.


I need this for GStreamer to make usage together with GTK a bit simpler.