### PR TITLE
Generate version conditions for Default implementation

### DIFF
--- a/src/codegen/general.rs
+++ b/src/codegen/general.rs
@@ -251,9 +251,17 @@ pub fn write_vec<T: Display>(w: &mut Write, v: &[T]) -> Result<()> {
     Ok(())
 }
 
-pub fn declare_default_from_new(w: &mut Write, name: &str, functions: &[analysis::functions::Info]) -> Result<()> {
-    if functions.iter().any(|f| !f.visibility.hidden() && f.name == "new" && f.parameters.rust_parameters.is_empty()) {
+pub fn declare_default_from_new(
+    w: &mut Write,
+    env: &Env,
+    name: &str,
+    functions: &[analysis::functions::Info],
+) -> Result<()> {
+    if let Some(func) = functions.iter().find(|f| {
+        !f.visibility.hidden() && f.name == "new" && f.parameters.rust_parameters.is_empty()
+    }) {
         try!(writeln!(w, ""));
+        try!(version_condition(w, env, func.version, false, 0));
         try!(writeln!(w, "impl Default for {} {{", name));
         try!(writeln!(w, "    fn default() -> Self {{"));
         try!(writeln!(w, "        Self::new()"));

--- a/src/codegen/object.rs
+++ b/src/codegen/object.rs
@@ -71,7 +71,12 @@ pub fn generate(w: &mut Write, env: &Env, analysis: &analysis::object::Info) -> 
 
         try!(writeln!(w, "}}"));
 
-        try!(general::declare_default_from_new(w, &analysis.name, &analysis.functions));
+        try!(general::declare_default_from_new(
+            w,
+            env,
+            &analysis.name,
+            &analysis.functions
+        ));
     }
 
     try!(trait_impls::generate(

--- a/src/codegen/record.rs
+++ b/src/codegen/record.rs
@@ -54,7 +54,12 @@ pub fn generate(w: &mut Write, env: &Env, analysis: &analysis::record::Info) -> 
         try!(writeln!(w, "}}"));
     }
 
-    try!(general::declare_default_from_new(w, &analysis.name, &analysis.functions));
+    try!(general::declare_default_from_new(
+        w,
+        env,
+        &analysis.name,
+        &analysis.functions
+    ));
 
     try!(trait_impls::generate(
         w,


### PR DESCRIPTION
Fix `Default` implementation for `PlacesSidebar` that have 
```
#[cfg(feature = "v3_10")]
     pub fn new() -> PlacesSidebar {
```

cc @sdroege 