### PR TITLE
Add configuration for explicitly setting the trait name

### DIFF
--- a/src/analysis/symbols.rs
+++ b/src/analysis/symbols.rs
@@ -25,9 +25,8 @@ impl Symbol {
         ret
     }
 
-    pub fn make_trait_method(&mut self) {
-        let name = self.owner_name.take();
-        self.owner_name = name.map(|s| format!("{}Ext", s));
+    pub fn make_trait_method(&mut self, trait_name: &str) {
+        self.owner_name = Some(trait_name.into());
     }
 }
 

--- a/src/codegen/doc/mod.rs
+++ b/src/codegen/doc/mod.rs
@@ -95,7 +95,7 @@ fn generate_doc(mut w: &mut Write, env: &Env) -> Result<()> {
 fn create_object_doc(w: &mut Write, env: &Env, info: &analysis::object::Info) -> Result<()> {
     let symbols = env.symbols.borrow();
     let ty = TypeStruct::new(SType::Struct, &info.name);
-    let ty_ext = TypeStruct::new(SType::Trait, &format!("{}Ext", info.name));
+    let ty_ext = TypeStruct::new(SType::Trait, &info.trait_name);
     let has_trait = info.generate_trait;
     let doc;
     let functions: &[Function];

--- a/src/codegen/record.rs
+++ b/src/codegen/record.rs
@@ -66,7 +66,7 @@ pub fn generate(w: &mut Write, env: &Env, analysis: &analysis::record::Info) -> 
         &analysis.name,
         &analysis.functions,
         &analysis.specials,
-        false,
+        None,
     ));
 
     if analysis.concurrency != library::Concurrency::None {

--- a/src/config/gobjects.rs
+++ b/src/config/gobjects.rs
@@ -68,6 +68,7 @@ pub struct GObject {
     pub cfg_condition: Option<String>,
     pub type_id: Option<TypeId>,
     pub generate_trait: bool,
+    pub trait_name: Option<String>,
     pub child_properties: Option<ChildProperties>,
     pub concurrency: library::Concurrency,
     pub ref_mode: Option<ref_mode::RefMode>,
@@ -87,6 +88,7 @@ impl Default for GObject {
             cfg_condition: None,
             type_id: None,
             generate_trait: true,
+            trait_name: None,
             child_properties: None,
             concurrency: Default::default(),
             ref_mode: None,
@@ -168,6 +170,10 @@ fn parse_object(toml_object: &Value, concurrency: library::Concurrency) -> GObje
         .lookup("trait")
         .and_then(|v| v.as_bool())
         .unwrap_or(true);
+    let trait_name = toml_object
+        .lookup("trait_name")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_owned());
     let concurrency = toml_object
         .lookup("concurrency")
         .and_then(|v| v.as_str())
@@ -197,6 +203,7 @@ fn parse_object(toml_object: &Value, concurrency: library::Concurrency) -> GObje
         cfg_condition: cfg_condition,
         type_id: None,
         generate_trait: generate_trait,
+        trait_name: trait_name,
         child_properties: child_properties,
         concurrency: concurrency,
         ref_mode: ref_mode,

--- a/src/config/gobjects.rs
+++ b/src/config/gobjects.rs
@@ -129,7 +129,7 @@ fn parse_object(toml_object: &Value, concurrency: library::Concurrency) -> GObje
     // Also checks for ChildProperties
     toml_object.check_unwanted(&["name", "status", "function", "signal", "member", "property",
                                  "module_name", "version", "concurrency", "ref_mode", "child_prop",
-                                 "child_name", "child_type"],
+                                 "child_name", "child_type", "trait", "trait_name", "cfg_condition"],
                                &format!("object {}", name));
 
     let status = match toml_object.lookup("status") {

--- a/src/config/signals.rs
+++ b/src/config/signals.rs
@@ -114,7 +114,7 @@ impl Signal {
             }
         };
         toml.check_unwanted(&["ignore", "inhibit", "version", "parameter", "return", "doc_hidden",
-                              "name", "pattern"],
+                              "name", "pattern", "concurrency"],
                             &format!("signal {}", object_name));
 
         let ignore = toml.lookup("ignore")


### PR DESCRIPTION
This is needed in cases where there are multiple types with the same
name in the type hierarchy, e.g. GObject and GstObject or GApplication
and GtkApplication.

See https://github.com/gtk-rs/glib/issues/211