### PR TITLE
Don't generate non-sys bindings for introspectable="0" functions/sign…

### DIFF
--- a/src/analysis/functions.rs
+++ b/src/analysis/functions.rs
@@ -68,7 +68,7 @@ pub fn analyze<F: Borrow<library::Function>>(
         if configured_functions.iter().any(|f| f.ignore) {
             continue;
         }
-        if env.is_totally_deprecated(func.deprecated_version) {
+        if env.is_totally_deprecated(func.deprecated_version) || !func.introspectable {
             continue;
         }
         let name = nameutil::mangle_keywords(&*func.name).into_owned();

--- a/src/analysis/properties.rs
+++ b/src/analysis/properties.rs
@@ -45,7 +45,7 @@ pub fn analyze(
             continue;
         }
 
-        if env.is_totally_deprecated(prop.deprecated_version) {
+        if env.is_totally_deprecated(prop.deprecated_version) || !prop.introspectable {
             continue;
         }
 

--- a/src/analysis/signals.rs
+++ b/src/analysis/signals.rs
@@ -34,7 +34,7 @@ pub fn analyze(
         if configured_signals.iter().any(|f| f.ignore) {
             continue;
         }
-        if env.is_totally_deprecated(signal.deprecated_version) {
+        if env.is_totally_deprecated(signal.deprecated_version) || !signal.introspectable {
             continue;
         }
 

--- a/src/library.rs
+++ b/src/library.rs
@@ -252,6 +252,7 @@ pub struct Member {
 pub struct Enumeration {
     pub name: String,
     pub c_type: String,
+    pub introspectable: bool,
     pub members: Vec<Member>,
     pub functions: Vec<Function>,
     pub version: Option<Version>,
@@ -266,6 +267,7 @@ pub struct Enumeration {
 pub struct Bitfield {
     pub name: String,
     pub c_type: String,
+    pub introspectable: bool,
     pub members: Vec<Member>,
     pub functions: Vec<Function>,
     pub version: Option<Version>,
@@ -280,6 +282,7 @@ pub struct Record {
     pub name: String,
     pub c_type: String,
     pub glib_get_type: Option<String>,
+    pub introspectable: bool,
     pub fields: Vec<Field>,
     pub functions: Vec<Function>,
     pub version: Option<Version>,
@@ -304,6 +307,7 @@ pub struct Union {
     pub name: String,
     pub c_type: Option<String>,
     pub glib_get_type: Option<String>,
+    pub introspectable: bool,
     pub fields: Vec<Field>,
     pub functions: Vec<Function>,
     pub doc: Option<String>,
@@ -319,6 +323,7 @@ pub struct Property {
     pub typ: TypeId,
     pub c_type: Option<String>,
     pub transfer: Transfer,
+    pub introspectable: bool,
     pub version: Option<Version>,
     pub deprecated_version: Option<Version>,
     pub doc: Option<String>,
@@ -346,6 +351,7 @@ pub struct Function {
     pub name: String,
     pub c_identifier: Option<String>,
     pub kind: FunctionKind,
+    pub introspectable: bool,
     pub parameters: Vec<Parameter>,
     pub ret: Parameter,
     pub throws: bool,
@@ -360,6 +366,7 @@ pub struct Signal {
     pub name: String,
     pub parameters: Vec<Parameter>,
     pub ret: Parameter,
+    pub introspectable: bool,
     pub version: Option<Version>,
     pub deprecated_version: Option<Version>,
     pub doc: Option<String>,
@@ -371,6 +378,7 @@ pub struct Interface {
     pub name: String,
     pub c_type: String,
     pub glib_get_type: String,
+    pub introspectable: bool,
     pub functions: Vec<Function>,
     pub signals: Vec<Signal>,
     pub properties: Vec<Property>,
@@ -385,6 +393,7 @@ pub struct Class {
     pub name: String,
     pub c_type: String,
     pub glib_get_type: String,
+    pub introspectable: bool,
     pub fields: Vec<Field>,
     pub functions: Vec<Function>,
     pub signals: Vec<Signal>,
@@ -556,19 +565,8 @@ impl Type {
     }
 
     pub fn record(library: &mut Library, r: Record, ns_id: u16) -> TypeId {
-        let fields = r.fields;
-        let field_tids: Vec<TypeId> = fields.iter().map(|f| f.typ).collect();
-        let typ = Type::Record(Record {
-            name: r.name,
-            c_type: r.c_type,
-            glib_get_type: r.glib_get_type,
-            fields: fields,
-            functions: r.functions,
-            version: r.version,
-            deprecated_version: r.deprecated_version,
-            doc: r.doc,
-            doc_deprecated: r.doc_deprecated,
-        });
+        let field_tids: Vec<TypeId> = r.fields.iter().map(|f| f.typ).collect();
+        let typ = Type::Record(r);
         library.add_type(ns_id, &format!("#{:?}", field_tids), typ)
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -217,6 +217,7 @@ impl Library {
                 .by_name("get-type")
                 .ok_or_else(|| mk_error!("Missing get-type attribute", parser))
         );
+        let introspectable = to_bool(attrs.by_name("introspectable").unwrap_or("1"));
         let version = try!(self.parse_version(parser, ns_id, attrs.by_name("version")));
         let deprecated_version = try!(self.parse_version(
             parser,
@@ -328,6 +329,7 @@ impl Library {
             name: class_name.into(),
             c_type: c_type.into(),
             glib_get_type: get_type.into(),
+            introspectable: introspectable,
             fields: fields,
             functions: fns,
             signals: signals,
@@ -378,6 +380,7 @@ impl Library {
             Some(s) => Some(s.to_string()),
             None => None,
         };
+        let introspectable = to_bool(attrs.by_name("introspectable").unwrap_or("1"));
         let version = try!(self.parse_version(parser, ns_id, attrs.by_name("version")));
         let deprecated_version = try!(self.parse_version(
             parser,
@@ -518,6 +521,7 @@ impl Library {
             name: record_name.into(),
             c_type: c_type.into(),
             glib_get_type: get_type.map(|s| s.into()),
+            introspectable: introspectable,
             fields: fields,
             functions: fns,
             version: version,
@@ -566,6 +570,7 @@ impl Library {
         let union_name = attrs.by_name("name").unwrap_or("");
         let c_type = attrs.by_name("type").unwrap_or("");
         let get_type = attrs.by_name("get-type").map(|s| s.into());
+        let introspectable = to_bool(attrs.by_name("introspectable").unwrap_or("1"));
 
         let mut fields = Vec::new();
         let mut fns = Vec::new();
@@ -674,6 +679,7 @@ impl Library {
             name: union_name.into(),
             c_type: Some(c_type.into()),
             glib_get_type: get_type,
+            introspectable: introspectable,
             fields: fields,
             functions: fns,
             doc: doc,
@@ -776,6 +782,7 @@ impl Library {
                 .by_name("get-type")
                 .ok_or_else(|| mk_error!("Missing get-type attribute", parser))
         );
+        let introspectable = to_bool(attrs.by_name("introspectable").unwrap_or("1"));
         let version = try!(self.parse_version(parser, ns_id, attrs.by_name("version")));
         let deprecated_version = try!(self.parse_version(
             parser,
@@ -835,6 +842,7 @@ impl Library {
             name: interface_name.into(),
             c_type: c_type.into(),
             glib_get_type: get_type.into(),
+            introspectable: introspectable,
             functions: fns,
             signals: signals,
             properties: properties,
@@ -859,6 +867,7 @@ impl Library {
                 .ok_or_else(|| mk_error!("Missing c:type attribute", parser))
         );
         let get_type = attrs.by_name("get-type").map(|s| s.into());
+        let introspectable = to_bool(attrs.by_name("introspectable").unwrap_or("1"));
         let version = try!(self.parse_version(parser, ns_id, attrs.by_name("version")));
         let deprecated_version = try!(self.parse_version(
             parser,
@@ -901,6 +910,7 @@ impl Library {
         let typ = Type::Bitfield(Bitfield {
             name: bitfield_name.into(),
             c_type: c_type.into(),
+            introspectable: introspectable,
             members: members,
             functions: fns,
             version: version,
@@ -930,6 +940,7 @@ impl Library {
                 .ok_or_else(|| mk_error!("Missing c:type attribute", parser))
         );
         let get_type = attrs.by_name("get-type").map(|s| s.into());
+        let introspectable = to_bool(attrs.by_name("introspectable").unwrap_or("1"));
         let version = try!(self.parse_version(parser, ns_id, attrs.by_name("version")));
         let deprecated_version = try!(self.parse_version(
             parser,
@@ -973,6 +984,7 @@ impl Library {
         let typ = Type::Enumeration(Enumeration {
             name: enum_name.into(),
             c_type: c_type.into(),
+            introspectable: introspectable,
             members: members,
             functions: fns,
             version: version,
@@ -1193,6 +1205,7 @@ impl Library {
             .or_else(|| attrs.by_name("type"));
         let kind = try!(FunctionKind::from_str(kind_str).map_err(|why| mk_error!(why, parser)));
         let is_method = kind == FunctionKind::Method;
+        let introspectable = to_bool(attrs.by_name("introspectable").unwrap_or("1"));
         let version = try!(self.parse_version(parser, ns_id, attrs.by_name("version")));
         let deprecated_version = try!(self.parse_version(
             parser,
@@ -1261,6 +1274,7 @@ impl Library {
             Ok(Function {
                 name: fn_name.into(),
                 c_identifier: c_identifier.map(|s| s.into()),
+                introspectable: introspectable,
                 kind: kind,
                 parameters: params,
                 ret: ret,
@@ -1325,6 +1339,7 @@ impl Library {
                 .by_name("name")
                 .ok_or_else(|| mk_error!("Missing signal name", parser))
         );
+        let introspectable = to_bool(attrs.by_name("introspectable").unwrap_or("1"));
         let version = match attrs.by_name("version") {
             Some(v) => Some(try!(v.parse().map_err(|why| mk_error!(why, parser)))),
             None => None,
@@ -1387,6 +1402,7 @@ impl Library {
         if let Some(ret) = ret {
             Ok(Signal {
                 name: signal_name.into(),
+                introspectable: introspectable,
                 parameters: params,
                 ret: ret,
                 version: version,
@@ -1566,6 +1582,7 @@ impl Library {
             Transfer::from_str(attrs.by_name("transfer-ownership").unwrap_or("none"))
                 .map_err(|why| mk_error!(why, parser))
         );
+        let introspectable = to_bool(attrs.by_name("introspectable").unwrap_or("1"));
         let version = match attrs.by_name("version") {
             Some(v) => Some(try!(v.parse().map_err(|why| mk_error!(why, parser)))),
             None => None,
@@ -1635,6 +1652,7 @@ impl Library {
                 transfer: transfer,
                 typ: tid,
                 c_type: c_type,
+                introspectable: introspectable,
                 version: version,
                 deprecated_version: deprecated_version,
                 doc: doc,


### PR DESCRIPTION
…als/properties

For classes, records, interfaces, bitfields, enums we ignore that for
now as those have to be explicitly enable in the configuration and
hopefully the user knows what they're doing.

https://github.com/gtk-rs/gir/issues/431