### PR TITLE
Fix generating docs for traits with custom name

### DIFF
--- a/src/codegen/doc/format.rs
+++ b/src/codegen/doc/format.rs
@@ -98,8 +98,8 @@ fn replace_c_types(entry: &str, symbols: &symbols::Info) -> String {
             caps.get(3).map(|m| m.as_str()).unwrap_or("")
         )
     });
-    let out = FUNCTION.replace_all(&out, |caps: &Captures| format!("`{}`", lookup(&caps[1])));
     let out = GDK_GTK.replace_all(&out, |caps: &Captures| format!("`{}`", lookup(&caps[0])));
+    let out = FUNCTION.replace_all(&out, |caps: &Captures| format!("`{}`", lookup(&caps[1])));
     let out = TAGS.replace_all(&out, "`$0`");
     SPACES.replace_all(&out, " ").into_owned()
 }

--- a/src/codegen/doc/mod.rs
+++ b/src/codegen/doc/mod.rs
@@ -39,7 +39,7 @@ impl_to_stripper_type!(Function, Fn);
 impl_to_stripper_type!(Class, Struct);
 
 pub fn generate(env: &Env) {
-    let path = env.config.target_path.join("docs.md");
+    let path = env.config.target_path.join("vendor.md");
     println!("Generating documentation {:?}", path);
     save_to_file(&path, env.config.make_backup, |w| generate_doc(w, env));
 }


### PR DESCRIPTION
Fix #435 


Also changed generated name to comply with https://github.com/gtk-rs/lgpl-docs names.