### PR TITLE
Make object version from config a higher priority

### DIFF
--- a/src/analysis/object.rs
+++ b/src/analysis/object.rs
@@ -147,7 +147,6 @@ pub fn class(env: &Env, obj: &GObject, deps: &[library::TypeId]) -> Option<Info>
         env,
         obj,
         &functions,
-        Some(&specials),
         klass.version,
         klass.deprecated_version,
     );
@@ -302,7 +301,6 @@ pub fn interface(env: &Env, obj: &GObject, deps: &[library::TypeId]) -> Option<I
         env,
         obj,
         &functions,
-        None,
         iface.version,
         iface.deprecated_version,
     );

--- a/src/analysis/record.rs
+++ b/src/analysis/record.rs
@@ -77,7 +77,6 @@ pub fn new(env: &Env, obj: &GObject) -> Option<Info> {
         env,
         obj,
         &functions,
-        None,
         record.version,
         record.deprecated_version,
     );


### PR DESCRIPTION
Change bad #444, just make gir use config version if it present
```
[[object]]
name = "GtkSource.Style"
status = "generate"
version = "2.0"
    [[object.function]]
    name = "copy"
    ignore = true
```
cc @GuillaumeGomez 