### PR TITLE
Borrow Boxed/Shared/Object/Interface arguments in signal trampolines

### DIFF
--- a/src/analysis/trampoline_parameters.rs
+++ b/src/analysis/trampoline_parameters.rs
@@ -119,7 +119,7 @@ pub fn analyze(
         library::Transfer::None,
         library::Nullable(false),
         RefMode::ByRef,
-        ConversionType::Pointer,
+        ConversionType::Borrow,
     );
     parameters.transformations.push(transform);
 
@@ -135,7 +135,14 @@ pub fn analyze(
             .next();
         let nullable = nullable_override.unwrap_or(par.nullable);
 
-        let conversion_type = ConversionType::of(&env.library, par.typ);
+        let conversion_type = {
+            match *env.library.type_(par.typ) {
+                library::Type::Record(..) |
+                library::Type::Interface(..) |
+                library::Type::Class(..) => ConversionType::Borrow,
+                _ => ConversionType::of(&env.library, par.typ),
+            }
+        };
 
         let new_name = configured_signals
             .matched_parameters(&name)

--- a/src/analysis/trampolines.rs
+++ b/src/analysis/trampolines.rs
@@ -81,7 +81,7 @@ pub fn analyze(
             library::Transfer::None,
             library::Nullable(false),
             ::analysis::ref_mode::RefMode::ByRef,
-            ConversionType::Pointer,
+            ConversionType::Borrow,
         );
         parameters.transformations.push(transform);
 


### PR DESCRIPTION
They are valid for the whole scope of the trampoline, obviously, and by
using from_glib_none() and passing them by reference we would in the
best case only do atomic reference counting but in the worst case
actually copy the data just to pass on a reference.