### PR TITLE
Use Path for shared library name extraction

### DIFF
--- a/src/codegen/sys/build.rs
+++ b/src/codegen/sys/build.rs
@@ -47,7 +47,12 @@ fn find() -> Result<(), Error> {
     let regex = Regex::new(r"^lib(.+)\.so.*$").expect("Regex failed");
     let shared_libs: Vec<_> = ns.shared_libs
         .iter()
-        .map(|s| regex.replace(s, "\"$1\""))
+        .map(|s| {
+            if !regex.is_match(s) {
+                panic!("A 'shared-library' in the GIR file doesn't match the following form: '^lib(.+)\\.so.*$'");
+            }
+            regex.replace(s, "\"$1\"")
+        })
         .collect();
 
     try!(writeln!(


### PR DESCRIPTION
First commit makes it panic when `shared-library` has a wrong form.
(Thought it'd be helpful to do so instead of generating uncompilable code.)

Second commit combines `Path` with `Regex` to extract the library name, which will support extraction from absolute paths and macOS `.dylib`s as well.

Sorry if I'm misunderstanding the intention of the present code...