### PR TITLE
Update to bitflags 1.0

### DIFF
--- a/src/codegen/flags.rs
+++ b/src/codegen/flags.rs
@@ -4,7 +4,6 @@ use config::gobjects::GObject;
 use env::Env;
 use file_saver;
 use library::*;
-use nameutil::strip_prefix_uppercase;
 use std::cmp;
 use std::io::prelude::*;
 use std::io::Result;
@@ -97,10 +96,7 @@ fn generate_flags(
             continue;
         }
 
-        let name = strip_prefix_uppercase(
-            &env.library.namespace(namespaces::MAIN).symbol_prefixes,
-            &member.c_identifier,
-        );
+        let name = member.name.to_uppercase();
         let val: i64 = member.value.parse().unwrap();
         let version = member_config.iter().filter_map(|m| m.version).next();
         try!(version_condition(w, env, version, false, 2));
@@ -110,7 +106,6 @@ fn generate_flags(
         {
             mod_rs.push(cfg);
         }
-        mod_rs.push(format!("pub use self::flags::{};", name));
     }
 
     try!(writeln!(

--- a/src/codegen/sys/cargo_toml.rs
+++ b/src/codegen/sys/cargo_toml.rs
@@ -68,7 +68,7 @@ fn fill_in(root: &mut Table, env: &Env) {
 
     {
         let deps = upsert_table(root, "dependencies");
-        set_string(deps, "bitflags", "0.9");
+        set_string(deps, "bitflags", "1.0");
         set_string(deps, "libc", "0.2");
     }
 

--- a/src/nameutil.rs
+++ b/src/nameutil.rs
@@ -14,25 +14,6 @@ pub fn split_namespace_name(name: &str) -> (Option<&str>, &str) {
     (ns, name)
 }
 
-/// Strip the longest of the prefixes from an upper-case name (`G_|FOO_BAR`)
-pub fn strip_prefix_uppercase<'a, S>(prefixes: &[S], name: &'a str) -> &'a str
-where
-    S: AsRef<str>,
-{
-    let mut cut = 0;
-    for prefix in prefixes {
-        let prefix = prefix.as_ref();
-        if prefix.len() + 1 <= cut {
-            continue;
-        }
-        let prefix_upper = format!("{}_", prefix.to_uppercase());
-        if name.starts_with(&prefix_upper) {
-            cut = prefix_upper.len()
-        }
-    }
-    &name[cut..]
-}
-
 /* unused :(
 pub fn strip_suffix<'a>(name: &'a str, suffix: &str) -> Option<&'a str> {
     if name.ends_with(suffix) {


### PR DESCRIPTION
This introduces various API changes, most importantly the flags types
work like enums now, e.g. you use SomeFlags::THE_VALUE instead of
THE_VALUE as a constant. For the -sys bindings, SOME_FLAGS_THE_VALUE
will still be exported as an alias (for closer C compatiblity), but the
non-sys bindings use the flags like enums now.

Fixes https://github.com/gtk-rs/gir/issues/468