### PR TITLE
Mark void pointers as gpointer

### DIFF
--- a/src/codegen/sys/ffi_type.rs
+++ b/src/codegen/sys/ffi_type.rs
@@ -92,7 +92,7 @@ fn ffi_inner(env: &Env, tid: library::TypeId, mut inner: String) -> Result {
                 Type => "GType",
                 Pointer => {
                     match &inner[..] {
-                        "void" => "c_void",
+                        "void" => "gpointer",
                         "tm" => return Err(TypeError::Unimplemented(inner)),  //TODO: try use time:Tm
                         _ => &*inner,
                     }


### PR DESCRIPTION
Otherwise the ABI is not properly respected as for some reason,
mem::size_of::<c_void>() returns 1 on a 64bits system. In the case
of GstVideoDecoder(Class), the ABI mistmatch because of the last
`void * padding[14]` field which is translated to
`pub padding: [c_void; 14]` which size was 14(bytes) instead of
112 (on 64bits systems).