### PR TITLE
Allow marking enums and bitflags as #[must_use]

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,12 +179,15 @@ child_type = "Gtk.MenuItem"
     doc_hidden = true
 ```
 
-For enumerations, you can configure the members:
+For enumerations and bitflags, you can configure the members and mark the type
+as `#[must_use]`:
 
 ```toml
 [[object]]
 name = "Gdk.EventType"
 status = "generate"
+# generates #[must_use] attribute for the type
+must_use = true
     [[object.member]]
     name = "2button_press"
     # allows to skip elements with bad names, other members with same value used instead

--- a/src/codegen/enums.rs
+++ b/src/codegen/enums.rs
@@ -128,6 +128,12 @@ fn generate_enum(env: &Env, w: &mut Write, enum_: &Enumeration, config: &GObject
         w,
         "#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]"
     ));
+    if config.must_use {
+        try!(writeln!(
+            w,
+            "#[must_use]"
+        ));
+    }
     try!(writeln!(w, "pub enum {} {{", enum_.name));
     for member in &members {
         try!(version_condition(w, env, member.version, false, 1));

--- a/src/codegen/flags.rs
+++ b/src/codegen/flags.rs
@@ -81,6 +81,12 @@ pub fn generate(env: &Env, root_path: &Path, mod_rs: &mut Vec<String>) {
 fn generate_flags(env: &Env, w: &mut Write, flags: &Bitfield, config: &GObject) -> Result<()> {
     try!(version_condition(w, env, flags.version, false, 0));
     try!(writeln!(w, "bitflags! {{"));
+    if config.must_use {
+        try!(writeln!(
+            w,
+            "    #[must_use]"
+        ));
+    }
     try!(writeln!(w, "    pub struct {}: u32 {{", flags.name));
     for member in &flags.members {
         let member_config = config.members.matched(&member.name);

--- a/src/config/gobjects.rs
+++ b/src/config/gobjects.rs
@@ -72,6 +72,7 @@ pub struct GObject {
     pub child_properties: Option<ChildProperties>,
     pub concurrency: library::Concurrency,
     pub ref_mode: Option<ref_mode::RefMode>,
+    pub must_use: bool,
 }
 
 impl Default for GObject {
@@ -92,6 +93,7 @@ impl Default for GObject {
             child_properties: None,
             concurrency: Default::default(),
             ref_mode: None,
+            must_use: false,
         }
     }
 }
@@ -145,6 +147,7 @@ fn parse_object(toml_object: &Value, concurrency: library::Concurrency) -> GObje
             "trait",
             "trait_name",
             "cfg_condition",
+            "must_use",
         ],
         &format!("object {}", name),
     );
@@ -201,6 +204,10 @@ fn parse_object(toml_object: &Value, concurrency: library::Concurrency) -> GObje
         .and_then(|v| v.as_str())
         .and_then(ref_mode_from_str);
     let child_properties = ChildProperties::parse(toml_object, &name);
+    let must_use = toml_object
+        .lookup("must_use")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
 
     if status != GStatus::Manual && ref_mode != None {
         warn!("ref_mode configuration used for non-manual object {}", name);
@@ -222,6 +229,7 @@ fn parse_object(toml_object: &Value, concurrency: library::Concurrency) -> GObje
         child_properties: child_properties,
         concurrency: concurrency,
         ref_mode: ref_mode,
+        must_use: must_use,
     }
 }
 


### PR DESCRIPTION
Useful for error/status types that the user must handle to not ignore
errors.