### PR TITLE
Generate enums in -sys crates as integer constants

### DIFF
--- a/src/codegen/enums.rs
+++ b/src/codegen/enums.rs
@@ -75,7 +75,6 @@ pub fn generate(env: &Env, root_path: &Path, mod_rs: &mut Vec<String>) {
             }
             try!(writeln!(w, "use glib::translate::*;"));
         }
-        try!(writeln!(w, "use std;"));
         try!(writeln!(w, ""));
 
         if has_any {
@@ -166,7 +165,7 @@ impl ToGlib for {name} {{
     }
     try!(writeln!(
         w,
-        "\t\t\t{}::__Unknown(value) => unsafe{{std::mem::transmute(value)}}",
+        "\t\t\t{}::__Unknown(value) => value",
         enum_.name
     ));
     try!(writeln!(
@@ -190,7 +189,7 @@ impl ToGlib for {name} {{
         "#[doc(hidden)]
 impl FromGlib<ffi::{ffi_name}> for {name} {{
     fn from_glib(value: ffi::{ffi_name}) -> Self {{
-        {assert}match value as i32 {{",
+        {assert}match value {{",
         name = enum_.name,
         ffi_name = enum_.c_type,
         assert = assert
@@ -231,7 +230,7 @@ impl FromGlib<ffi::{ffi_name}> for {name} {{
     }}
 
     fn code(self) -> i32 {{
-        self.to_glib() as i32
+        self.to_glib()
     }}
 
     fn from(code: i32) -> Option<Self> {{
@@ -302,11 +301,10 @@ impl FromGlib<ffi::{ffi_name}> for {name} {{
             w,
             "impl<'a> FromValue<'a> for {name} {{
     unsafe fn from_value(value: &Value) -> Self {{
-        from_glib(std::mem::transmute::<i32, ffi::{ffi_name}>(gobject_ffi::g_value_get_enum(value.to_glib_none().0)))
+        from_glib(gobject_ffi::g_value_get_enum(value.to_glib_none().0))
     }}
 }}",
             name = enum_.name,
-            ffi_name = enum_.c_type,
         ));
         try!(writeln!(w, ""));
 
@@ -315,7 +313,7 @@ impl FromGlib<ffi::{ffi_name}> for {name} {{
             w,
             "impl SetValue for {name} {{
     unsafe fn set_value(value: &mut Value, this: &Self) {{
-        gobject_ffi::g_value_set_enum(value.to_glib_none_mut().0, this.to_glib() as i32)
+        gobject_ffi::g_value_set_enum(value.to_glib_none_mut().0, this.to_glib())
     }}
 }}",
             name = enum_.name,


### PR DESCRIPTION
The C code might be extended by additional values without the bindings
being updated, which then is considered undefined behaviour on the Rust
side. As such we must use plain integers here.

The enums stay as enums in the non-sys crates and the conversion traits
ensure that the conversion from the integers to the actual enum values
is done correctly, while storing unknown values in a hidden enum
variant.

Fixes https://github.com/gtk-rs/gir/issues/480