### PR TITLE
Avoid to generate variable names which are keywords

### DIFF
--- a/src/analysis/functions.rs
+++ b/src/analysis/functions.rs
@@ -196,6 +196,11 @@ fn analyze_function(
             let mut output_params = vec![];
             if let Some(function) = find_function(env, &rust_finish_func_name) {
                 output_params.extend(function.parameters.clone());
+                for param in output_params.iter_mut() {
+                    if nameutil::needs_mangling(&param.name) {
+                        param.name = nameutil::mangle_keywords(&*param.name).into_owned();
+                    }
+                }
             }
             trampoline = Some(AsyncTrampoline {
                 is_method: func.kind == FunctionKind::Method,

--- a/src/nameutil.rs
+++ b/src/nameutil.rs
@@ -45,6 +45,10 @@ pub fn module_name(name: &str) -> String {
     mangle_keywords(name.to_snake()).into_owned()
 }
 
+pub fn needs_mangling(name: &str) -> bool {
+    KEYWORDS.contains_key(name)
+}
+
 // If the mangling happened, guaranteed to return Owned.
 pub fn mangle_keywords<'a, S: Into<Cow<'a, str>>>(name: S) -> Cow<'a, str> {
     let name = name.into();


### PR DESCRIPTION
Had the issue while adding new types to `gio`.

cc @EPashkin 