### PR TITLE
Remove unnecessary parentheses in async trampoline result

### DIFF
--- a/src/chunk/chunk.rs
+++ b/src/chunk/chunk.rs
@@ -86,5 +86,7 @@ pub fn chunks(ch: Chunk) -> Vec<Chunk> {
 pub enum TupleMode {
     Auto, // "", "1", "(1,2)"
     WithUnit, // "()", "1", "(1,2)"
+    #[deprecated]
+    #[allow(dead_code)]
     Simple,    // "()", "(1)", "(1,2)"
 }

--- a/src/codegen/function_body_chunk.rs
+++ b/src/codegen/function_body_chunk.rs
@@ -159,7 +159,7 @@ impl Builder {
                     }
                 }
             }).collect();
-        let result = Chunk::Tuple(result, TupleMode::Simple);
+        let result = Chunk::Tuple(result, TupleMode::WithUnit);
         let gio_crate_name = crate_name("Gio", env);
         let gobject_crate_name = crate_name("GObject", env);
         let glib_crate_name = crate_name("GLib", env);

--- a/src/writer/to_code.rs
+++ b/src/writer/to_code.rs
@@ -87,6 +87,7 @@ impl ToCode for Chunk {
             NullMutPtr => vec!["ptr::null_mut()".into()],
             Custom(ref string) => vec![string.clone()],
             Tuple(ref chs, mode) => {
+                #[allow(deprecated)]
                 let with_bracket = match mode {
                     TupleMode::Auto => chs.len() > 1,
                     TupleMode::WithUnit => chs.len() != 1,


### PR DESCRIPTION
cc @GuillaumeGomez, @sdroege 

Removes warning "unnecessary parentheses around function argument"
which appeared in nightly for gtk and gio.

```diff
--- a/src/auto/icon_info.rs
+++ b/src/auto/icon_info.rs
@@ -214,7 +214,7 @@ impl<O: IsA<IconInfo>> IconInfoExt for O {
             let mut error = ptr::null_mut();
             let mut was_symbolic = mem::uninitialized();
             let _ = ffi::gtk_icon_info_load_symbolic_finish(_source_object as *mut _, res, &mut was_symbolic, &mut error);
-            let result = if error.is_null() { Ok((from_glib(was_symbolic))) } else { Err(from_glib_full(error)) };
+            let result = if error.is_null() { Ok(from_glib(was_symbolic)) } else { Err(from_glib_full(error)) };
             let callback: Box<Box<T>> = Box::from_raw(user_data as *mut _);
             callback(result);
         }
```