### PR TITLE
 Fill missing c:type in fields in postprocessing phase.

### DIFF
--- a/src/codegen/sys/lib_.rs
+++ b/src/codegen/sys/lib_.rs
@@ -747,18 +747,6 @@ fn generate_fields(env: &Env, struct_name: &str, fields: &[Field]) -> (Vec<Strin
                     sig
                 ));
                 commented |= com;
-            } else if let Some(c_type) = env.library.type_(field.typ).get_glib_name() {
-                warn!(
-                    "Field `{}::{}` missing c:type assumed `{}`",
-                    struct_name,
-                    field.name,
-                    c_type
-                );
-                let c_type = ffi_type(env, field.typ, c_type);
-                if c_type.is_err() {
-                    commented = true;
-                }
-                lines.push(format!("\tpub {}: {},", name, c_type.into_string()));
             } else {
                 lines.push(format!(
                     "\tpub {}: [{:?} {}],",

--- a/src/library_postprocessing.rs
+++ b/src/library_postprocessing.rs
@@ -336,5 +336,4 @@ impl Library {
             }
         }
     }
-
 }


### PR DESCRIPTION
Reduce field related logic in code generation phase by moving it to library
postprocessing phase. ~~This PR also includes sockaddr which allows to
successfully generate bindings for Soup (which didn't work correctly
previously).~~

Tested with bindings hosted under gtk-rs in FFI and API mode.
