### PR TITLE
Allow non_snake_case to silence warnings in generated code.

### DIFF
--- a/src/codegen/sys/statics.rs
+++ b/src/codegen/sys/statics.rs
@@ -5,7 +5,7 @@ use super::super::general::write_vec;
 pub fn begin(w: &mut Write) -> Result<()> {
     let v = vec![
         "",
-        "#![allow(non_camel_case_types, non_upper_case_globals)]",
+        "#![allow(non_camel_case_types, non_upper_case_globals, non_snake_case)]",
         "",
         "extern crate libc;",
         "#[macro_use] extern crate bitflags;",


### PR DESCRIPTION
Useful especially in the case of WebKit crates.