### PR TITLE
Refactor imports.

### DIFF
--- a/src/analysis/imports.rs
+++ b/src/analysis/imports.rs
@@ -1,28 +1,66 @@
 use std::collections::btree_map::{BTreeMap, Iter};
 
-use env::Env;
+use library::Library;
+use nameutil::crate_name;
 use super::namespaces;
 use version::Version;
 
+/// Provides assistance in generating use declarations.
+///
+/// It takes into account that use declaration referring to names within the
+/// same crate will look differently. It also avoids generating spurious
+/// declarations referring to names from within the same module as the one we
+/// are generating code for.
 #[derive(Clone, Debug, Default)]
 pub struct Imports {
+    /// Name of the current crate.
+    crate_name: String,
+    /// Name defined within current module. It doesn't need use declaration.
+    ///
+    /// NOTE: Currently we don't need to support more than one such name.
+    defined: Option<String>,
     map: BTreeMap<String, Option<Version>>,
 }
 
 impl Imports {
-    pub fn new() -> Imports {
+    pub fn new(gir: &Library) -> Imports {
+        let crate_name = crate_name(&gir.namespace(namespaces::MAIN).name);
         Imports {
+            crate_name,
+            defined: None,
             map: BTreeMap::new(),
         }
     }
 
-    pub fn add(&mut self, name: &str, version: Option<Version>) {
-        let entry = self.map.entry(name.to_owned()).or_insert(version);
-        if version < *entry {
-            *entry = version;
+    pub fn with_defined(gir: &Library, name: &str) -> Imports {
+        let crate_name = crate_name(&gir.namespace(namespaces::MAIN).name);
+        Imports {
+            crate_name,
+            defined: Some(name.to_owned()),
+            map: BTreeMap::new(),
         }
     }
 
+    /// Declares that name should be available through its last path component.
+    ///
+    /// For example, if name is `X::Y::Z` then it will be available as `Z`.
+    pub fn add(&mut self, name: &str, version: Option<Version>) {
+        if let Some(ref defined) = self.defined {
+            if name == defined {
+                return
+            }
+        }
+        if let Some(name) = self.strip_crate_name(name) {
+            let entry = self.map.entry(name.to_owned()).or_insert(version);
+            if version < *entry {
+                *entry = version;
+            }
+        }
+    }
+
+    /// Declares that name should be available through its full path.
+    ///
+    /// For example, if name is `X::Y` then it will be available as `X::Y`.
     pub fn add_used_type(&mut self, used_type: &str, version: Option<Version>) {
         if let Some(i) = used_type.find("::") {
             if i == 0 {
@@ -41,33 +79,23 @@ impl Imports {
         }
     }
 
-    pub fn remove(&mut self, name: &str) {
-        self.map.remove(name);
-    }
-
-    pub fn clean_glib(&mut self, env: &Env) {
-        if env.namespaces.glib_ns_id != namespaces::MAIN {
-            return;
+    /// Tries to strip crate name prefix from given name.
+    ///
+    /// Returns `None` if name matches crate name exactly. Otherwise returns
+    /// name with crate name prefix stripped or full name if there was no match.
+    fn strip_crate_name<'a>(&self, name: &'a str) -> Option<&'a str> {
+        let prefix = &self.crate_name;
+        if !name.starts_with(prefix) {
+            return Some(name);
         }
-        self.remove("glib");
-        let glibs: Vec<(String, Option<Version>)> = self.map
-            .iter()
-            .filter_map(|p| {
-                let glib_offset = p.0.find("glib::");
-                if let Some(glib_offset) = glib_offset {
-                    if glib_offset == 0 {
-                        Some((p.0.clone(), *p.1))
-                    } else {
-                        None
-                    }
-                } else {
-                    None
-                }
-            })
-            .collect();
-        for p in glibs {
-            self.remove(&p.0);
-            self.add(&p.0[6..], p.1);
+        let rest = &name[prefix.len()..];
+        if rest.is_empty() {
+            None
+        } else if rest.starts_with("::") {
+            Some(&rest["::".len()..])
+        } else {
+            // It was false positive, return the whole name.
+            Some(name)
         }
     }
 

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -100,7 +100,7 @@ fn analyze_global_functions(env: &mut Env) {
         return;
     }
 
-    let mut imports = imports::Imports::new();
+    let mut imports = imports::Imports::new(&env.library);
     imports.add("glib::translate::*", None);
     imports.add("ffi", None);
 
@@ -114,8 +114,6 @@ fn analyze_global_functions(env: &mut Env) {
         None,
         None,
     );
-
-    imports.clean_glib(env);
 
     env.analysis.global_functions = Some(info_base::InfoBase {
         full_name: full_name,

--- a/src/analysis/object.rs
+++ b/src/analysis/object.rs
@@ -86,7 +86,7 @@ pub fn class(env: &Env, obj: &GObject, deps: &[library::TypeId]) -> Option<Info>
         None => return None,
     };
 
-    let mut imports = Imports::new();
+    let mut imports = Imports::with_defined(&env.library, &name);
     imports.add("glib::translate::*", None);
     imports.add("ffi", None);
     imports.add("glib_ffi", None);
@@ -185,11 +185,6 @@ pub fn class(env: &Env, obj: &GObject, deps: &[library::TypeId]) -> Option<Info>
         imports.add("glib::object::IsA", None);
     }
 
-    //don't `use` yourself
-    imports.remove(&name);
-
-    imports.clean_glib(env);
-
     let base = InfoBase {
         full_name: full_name,
         type_id: class_tid,
@@ -256,7 +251,7 @@ pub fn interface(env: &Env, obj: &GObject, deps: &[library::TypeId]) -> Option<I
         None => return None,
     };
 
-    let mut imports = Imports::new();
+    let mut imports = Imports::with_defined(&env.library, &name);
     imports.add("glib::translate::*", None);
     imports.add("ffi", None);
     imports.add("glib::object::IsA", None);
@@ -318,11 +313,6 @@ pub fn interface(env: &Env, obj: &GObject, deps: &[library::TypeId]) -> Option<I
     if !properties.is_empty() {
         imports.add("glib", None);
     }
-
-    //don't `use` yourself
-    imports.remove(&name);
-
-    imports.clean_glib(env);
 
     let base = InfoBase {
         full_name: full_name,

--- a/src/analysis/record.rs
+++ b/src/analysis/record.rs
@@ -52,7 +52,7 @@ pub fn new(env: &Env, obj: &GObject) -> Option<Info> {
         None => return None,
     };
 
-    let mut imports = Imports::new();
+    let mut imports = Imports::with_defined(&env.library, &name);
     imports.add("glib::translate::*", None);
     imports.add("ffi", None);
     imports.add("glib_ffi", None);
@@ -90,11 +90,6 @@ pub fn new(env: &Env, obj: &GObject) -> Option<Info> {
     };
 
     special_functions::analyze_imports(&specials, &mut imports);
-
-    //don't `use` yourself
-    imports.remove(&name);
-
-    imports.clean_glib(env);
 
     let base = InfoBase {
         full_name: full_name,


### PR DESCRIPTION
* Make Imports aware of current crate and names defined in module.
    
  This move responsibility for special handling of names defined within
  the same crate or module inside the Imports struct. Users of Imports
  merely declare what they use.

* Use Imports to generate use declarations in enum / flags codegen.
