### PR TITLE
record: use g_boxed_* if a get_type function exists

### DIFF
--- a/src/codegen/record.rs
+++ b/src/codegen/record.rs
@@ -24,17 +24,24 @@ pub fn generate(w: &mut Write, env: &Env, analysis: &analysis::record::Info) -> 
             unref_fn,
             &analysis.glib_get_type,
         ));
-    } else if let (Some(copy_fn), Some(free_fn)) = (
-        analysis.specials.get(&Type::Copy),
-        analysis.specials.get(&Type::Free),
-    ) {
+    } else if analysis.glib_get_type.is_some() {
         try!(general::define_boxed_type(
             w,
             &analysis.name,
             &type_.c_type,
-            copy_fn,
-            free_fn,
-            &analysis.glib_get_type,
+            None,
+            None,
+            analysis.glib_get_type.as_ref(),
+        ));
+    } else if analysis.specials.get(&Type::Copy).is_some() &&
+        analysis.specials.get(&Type::Free).is_some() {
+        try!(general::define_boxed_type(
+            w,
+            &analysis.name,
+            &type_.c_type,
+            analysis.specials.get(&Type::Copy),
+            analysis.specials.get(&Type::Free),
+            None,
         ));
     } else {
         panic!(


### PR DESCRIPTION
If a record has a get_type function, it is better to use
g_boxed_copy and g_boxed_free to make sure the appropriate
functions are called, for example:

struct Foo {};
foo_copy(void); // unrelated copy function
foo_free(void); // unrelated free function
foo_boxed_copy(Foo *);
foo_boxed_free(Foo *);
foo_get_type();

G_DEFINE_BOXED_TYPE (Foo, foo, foo_boxed_copy, foo_boxed_free)