### PR TITLE
Add support for async functions that have a non-trivial ..

### DIFF
--- a/src/analysis/out_parameters.rs
+++ b/src/analysis/out_parameters.rs
@@ -136,7 +136,7 @@ pub fn can_as_return(env: &Env, par: &Parameter) -> bool {
     }
 }
 
-fn use_function_return_for_result(env: &Env, ret: &Parameter) -> bool {
+pub fn use_function_return_for_result(env: &Env, ret: &Parameter) -> bool {
     if ret.typ == Default::default() {
         return false;
     }


### PR DESCRIPTION
return type of the finish() function

Fixes #535 

I've got a WIP patch for Gio here: https://github.com/MathieuDuponchelle/gio/commit/babfd3a287f4050227b681aa45946c4fc95482ac

I also fixed a bug in the same commit, where we would look up the wrong finish function in gio, because we looked it up by rust name, and there were multiple unrelated functions with that name (connect_finish, maybe others). It was a bit awkward to split up, just let me know if you'd rather I split it up!