### PR TITLE
Prioritize RecordType::Refcounted over other record types

### DIFF
--- a/src/analysis/record_type.rs
+++ b/src/analysis/record_type.rs
@@ -34,10 +34,10 @@ impl RecordType {
             has_free = true;
         }
 
-        if has_copy && has_free {
-            RecordType::Boxed
-        } else if has_ref && has_unref {
+        if has_ref && has_unref {
             RecordType::Refcounted
+        } else if has_copy && has_free {
+            RecordType::Boxed
         } else {
             RecordType::AutoBoxed
         }

--- a/src/analysis/ref_mode.rs
+++ b/src/analysis/ref_mode.rs
@@ -49,10 +49,10 @@ impl RefMode {
                 RefMode::None
             },
             Record(ref record) => if direction == library::ParameterDirection::In {
-                match RecordType::of(record) {
-                    RecordType::AutoBoxed => RefMode::ByRefMut,
-                    RecordType::Boxed => RefMode::ByRefMut,
-                    RecordType::Refcounted => RefMode::ByRef,
+                if let RecordType::Refcounted = RecordType::of(record) {
+                    RefMode::ByRef
+                } else {
+                    RefMode::ByRefMut
                 }
             } else {
                 RefMode::None


### PR DESCRIPTION
as only this record type is referenced without `mut`

cc @GuillaumeGomez, @sdroege 