### PR TITLE
config/gobject.rs: use AsciiExt so to_ascii_lowercase() will be found.

### DIFF
--- a/src/config/gobjects.rs
+++ b/src/config/gobjects.rs
@@ -1,3 +1,6 @@
+#[allow(unused_imports)]
+use std::ascii::AsciiExt;
+
 use std::collections::BTreeMap;
 use std::str::FromStr;
 use toml::Value;


### PR DESCRIPTION
This makes gir build on Rust 1.21.
