### PR TITLE
Use info instead of println in codegen.

### DIFF
--- a/src/codegen/doc/mod.rs
+++ b/src/codegen/doc/mod.rs
@@ -87,7 +87,7 @@ impl_function_like_type!(Function);
 impl_function_like_type!(Signal);
 
 pub fn generate(env: &Env) {
-    println!("Generating documentation {:?}", env.config.doc_target_path);
+    info!("Generating documentation {:?}", env.config.doc_target_path);
     save_to_file(&env.config.doc_target_path, env.config.make_backup, |w| generate_doc(w, env));
 }
 

--- a/src/codegen/sys/build.rs
+++ b/src/codegen/sys/build.rs
@@ -6,14 +6,14 @@ use file_saver::save_to_file;
 use regex::Regex;
 
 pub fn generate(env: &Env) {
-    println!(
-        "generating sys build script for {}",
+    info!(
+        "Generating sys build script for {}",
         env.config.library_name
     );
 
     let path = env.config.target_path.join("build.rs");
 
-    println!("Generating file {:?}", path);
+    info!("Generating file {:?}", path);
     save_to_file(
         &path,
         env.config.make_backup,

--- a/src/codegen/sys/cargo_toml.rs
+++ b/src/codegen/sys/cargo_toml.rs
@@ -10,8 +10,8 @@ use nameutil::crate_name;
 use version::Version;
 
 pub fn generate(env: &Env) {
-    println!(
-        "manipulating sys Cargo.toml for {}",
+    info!(
+        "Generatnig sys Cargo.toml for {}",
         env.config.library_name
     );
 

--- a/src/codegen/sys/lib_.rs
+++ b/src/codegen/sys/lib_.rs
@@ -16,11 +16,11 @@ use traits::*;
 use version::Version;
 
 pub fn generate(env: &Env) {
-    println!("generating sys for {}", env.config.library_name);
+    info!("Generating sys for {}", env.config.library_name);
 
     let path = env.config.target_path.join(file_name_sys("lib"));
 
-    println!("Generating file {:?}", path);
+    info!("Generating file {:?}", path);
     save_to_file(&path, env.config.make_backup, |w| generate_lib(w, env));
 }
 


### PR DESCRIPTION
The default log level is warn, thus this change also intentionally hides
those messages by default, avoiding excessive output when generating
code for multiple crates in succession.