### PR TITLE
Add docs links

### DIFF
--- a/src/codegen/doc/format.rs
+++ b/src/codegen/doc/format.rs
@@ -98,8 +98,14 @@ fn replace_c_types(entry: &str, symbols: &symbols::Info) -> String {
             caps.get(3).map(|m| m.as_str()).unwrap_or("")
         )
     });
-    let out = GDK_GTK.replace_all(&out, |caps: &Captures| format!("`{}`", lookup(&caps[0])));
-    let out = FUNCTION.replace_all(&out, |caps: &Captures| format!("`{}`", lookup(&caps[1])));
+    let out = GDK_GTK.replace_all(&out, |caps: &Captures| {
+        let full = lookup(&caps[0]);
+        format!("[`{0}`]({0})", full)
+    });
+    let out = FUNCTION.replace_all(&out, |caps: &Captures| {
+        let full = lookup(&caps[1]);
+        format!("[`{0}`]({0})", full)
+    });
     let out = TAGS.replace_all(&out, "`$0`");
     SPACES.replace_all(&out, " ").into_owned()
 }


### PR DESCRIPTION
Since https://github.com/rust-lang/rust/issues/43466 is in a good enough working state, I suppose we can now just link to types like this.

cc @EPashkin @sdroege 