### PR TITLE
Async exctraction

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![cfg_attr(feature = "cargo-clippy", allow(match_same_arms))]
 #![cfg_attr(feature = "cargo-clippy", allow(let_and_return))]
 #![cfg_attr(feature = "cargo-clippy", allow(too_many_arguments))]
+#![cfg_attr(feature = "cargo-clippy", allow(write_literal))]
 
 extern crate git2;
 #[macro_use]


### PR DESCRIPTION
also ignoring [last 10 clippy warnings](https://rust-lang-nursery.github.io/rust-clippy/v0.0.200/index.html#write_literal), since after removing "{}", you will need to quote all curly brackets and make code less readable.

cc @GuillaumeGomez, @sdroege, @antoyo 


```
warning: writing a literal with an empty format string
   --> src\codegen\enums.rs:216:9
    |
216 | /         "        }
217 | |     }
218 | | }
219 | | "
    | |_^
    |
    = help: for further information visit https://rust-lang-nursery.github.io/rust-clippy/v0.0.200/index.html#write_literal
```