### PR TITLE
Enum / Flags: generate user defined `derive`

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,18 @@ version = "3.12"
     version = "3.18"
 ```
 
+For enumerations and bitflags, you can also configure additional `#[derive()]`
+clauses optionally conditioned to a `cfg`.
+
+``` toml
+[[object]]
+name = "Gst.Format"
+status = "generate"
+    [[object.derive]]
+    name = "Serialize, Deserialize"
+    cfg_condition = "feature = \"ser_de\""
+```
+
 Gir auto-detects copy and free functions by looking up `type_name_copy` and `type_name_free` functions.
 If the relevant functions are not named that way, and the type is defined with `G_DEFINE_BOXED_TYPE`,
 `use_boxed_functions=true` can be used to call `g_boxed_copy` and `g_boxed_free` instead.

--- a/src/codegen/enums.rs
+++ b/src/codegen/enums.rs
@@ -1,7 +1,7 @@
 use analysis::imports::Imports;
 use analysis::namespaces;
 use case::CaseExt;
-use codegen::general::{self, cfg_deprecated, version_condition, version_condition_string};
+use codegen::general::{self, cfg_deprecated, derives, version_condition, version_condition_string};
 use config::gobjects::GObject;
 use env::Env;
 use file_saver;
@@ -123,6 +123,7 @@ fn generate_enum(env: &Env, w: &mut Write, enum_: &Enumeration, config: &GObject
             "#[must_use]"
         ));
     }
+    try!(derives(w, &config.derives, 0));
     try!(writeln!(w, "pub enum {} {{", enum_.name));
     for member in &members {
         try!(cfg_deprecated(w, env, member.deprecated_version, false, 1));

--- a/src/codegen/flags.rs
+++ b/src/codegen/flags.rs
@@ -1,6 +1,6 @@
 use analysis::imports::Imports;
 use analysis::namespaces;
-use codegen::general::{self, cfg_deprecated, version_condition, version_condition_string};
+use codegen::general::{self, cfg_deprecated, derives, version_condition, version_condition_string};
 use config::gobjects::GObject;
 use env::Env;
 use file_saver;
@@ -74,6 +74,7 @@ fn generate_flags(env: &Env, w: &mut Write, flags: &Bitfield, config: &GObject) 
             "    #[must_use]"
         ));
     }
+    try!(derives(w, &config.derives, 1));
     try!(writeln!(w, "    pub struct {}: u32 {{", flags.name));
     for member in &flags.members {
         let member_config = config.members.matched(&member.name);

--- a/src/codegen/general.rs
+++ b/src/codegen/general.rs
@@ -6,6 +6,7 @@ use analysis::general::StatusedTypeId;
 use analysis::imports::Imports;
 use analysis::namespaces;
 use config::Config;
+use config::derives::Derive;
 use env::Env;
 use gir_version::VERSION;
 use version::Version;
@@ -351,6 +352,25 @@ pub fn cfg_condition_string(
         }
         None => None,
     }
+}
+
+pub fn derives(
+    w: &mut Write,
+    derives: &[Derive],
+    indent: usize,
+) -> Result<()> {
+    for derive in derives {
+        let s = match &derive.cfg_condition {
+            Some(condition) => format!(
+                "#[cfg_attr({}, derive({}))]",
+                condition,
+                derive.name
+            ),
+            None => format!("#[derive({})]", derive.name),
+        };
+        try!(writeln!(w, "{}{}", tabs(indent), s));
+    }
+    Ok(())
 }
 
 pub fn doc_hidden(

--- a/src/config/derives.rs
+++ b/src/config/derives.rs
@@ -1,0 +1,39 @@
+use super::parsable::Parse;
+use toml::Value;
+use super::error::TomlHelper;
+
+#[derive(Clone, Debug)]
+pub struct Derive {
+    pub name: String,
+    pub cfg_condition: Option<String>,
+}
+
+impl Parse for Derive {
+    fn parse(toml: &Value, object_name: &str) -> Option<Derive> {
+        let name = match toml.lookup("name").and_then(|v| v.as_str()) {
+            Some(name) => name.to_owned(),
+            None => {
+                error!(
+                    "No 'name' given for derive for object {}",
+                    object_name
+                );
+                return None;
+            }
+        };
+        toml.check_unwanted(
+            &["name", "cfg_condition"],
+            &format!("derive {}", object_name),
+        );
+
+        let cfg_condition = toml.lookup("cfg_condition")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_owned());
+
+        Some(Derive {
+            name,
+            cfg_condition,
+        })
+    }
+}
+
+pub type Derives = Vec<Derive>;

--- a/src/config/gobjects.rs
+++ b/src/config/gobjects.rs
@@ -7,6 +7,7 @@ use library::{Library, TypeId, MAIN_NAMESPACE};
 use config::error::TomlHelper;
 use config::parsable::{Parsable, Parse};
 use super::child_properties::ChildProperties;
+use super::derives::Derives;
 use super::functions::Functions;
 use super::constants::Constants;
 use super::members::Members;
@@ -63,6 +64,7 @@ pub struct GObject {
     pub signals: Signals,
     pub members: Members,
     pub properties: Properties,
+    pub derives: Derives,
     pub status: GStatus,
     pub module_name: Option<String>,
     pub version: Option<Version>,
@@ -87,6 +89,7 @@ impl Default for GObject {
             signals: Signals::new(),
             members: Members::new(),
             properties: Properties::new(),
+            derives: Derives::new(),
             status: Default::default(),
             module_name: None,
             version: None,
@@ -159,6 +162,7 @@ fn parse_object(toml_object: &Value, concurrency: library::Concurrency) -> GObje
             "signal",
             "member",
             "property",
+            "derive",
             "module_name",
             "version",
             "concurrency",
@@ -199,6 +203,7 @@ fn parse_object(toml_object: &Value, concurrency: library::Concurrency) -> GObje
     };
     let members = Members::parse(toml_object.lookup("member"), &name);
     let properties = Properties::parse(toml_object.lookup("property"), &name);
+    let derives = Derives::parse(toml_object.lookup("derive"), &name);
     let module_name = toml_object
         .lookup("module_name")
         .and_then(|v| v.as_str())
@@ -257,6 +262,7 @@ fn parse_object(toml_object: &Value, concurrency: library::Concurrency) -> GObje
         signals,
         members,
         properties,
+        derives,
         status,
         module_name,
         version,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -15,6 +15,7 @@ pub mod signals;
 pub mod string_type;
 pub mod work_mode;
 pub mod constants;
+pub mod derives;
 
 pub use self::config::Config;
 pub use self::external_libraries::ExternalLibrary;

--- a/src/config/parsable.rs
+++ b/src/config/parsable.rs
@@ -1,4 +1,3 @@
-use super::ident::Ident;
 use toml::Value;
 
 pub trait Parse: Sized {
@@ -11,7 +10,7 @@ pub trait Parsable {
     fn parse(toml: Option<&Value>, object_name: &str) -> Vec<Self::Item>;
 }
 
-impl<T: Parse + AsRef<Ident>> Parsable for Vec<T> {
+impl<T: Parse> Parsable for Vec<T> {
     type Item = T;
 
     fn parse(toml: Option<&Value>, object_name: &str) -> Vec<Self::Item> {


### PR DESCRIPTION
Allow using API mode TOML config such as:

``` toml
[[object]]
name = "Gst.BufferFlags"
status = "generate"
    [[object.derive]]
    name = "Serialize, Deserialize"
    cfg_condition = "feature = \"ser_de\""

[[object]]
name = "Gst.Format"
status = "generate"
    [[object.derive]]
    name = "Serialize, Deserialize"
    cfg_condition = "feature = \"ser_de\""
```

to generate:

``` rust
 bitflags! {
     #[cfg_attr(feature = "ser_de", derive(Serialize, Deserialize))]
     pub struct BufferFlags: u32 {
         const LIVE = 16;
         [...]
     }
 }
```

and

``` rust
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "ser_de", derive(Serialize, Deserialize))]
 pub enum Format {
     Undefined,
     [...]
 }
```