### PR TITLE
Fix clippy warnings about passing short and Copy arguments by reference

### DIFF
--- a/src/analysis/functions.rs
+++ b/src/analysis/functions.rs
@@ -35,8 +35,8 @@ pub enum Visibility {
 }
 
 impl Visibility {
-    pub fn hidden(&self) -> bool {
-        *self == Visibility::Hidden
+    pub fn hidden(self) -> bool {
+        self == Visibility::Hidden
     }
 }
 

--- a/src/analysis/ref_mode.rs
+++ b/src/analysis/ref_mode.rs
@@ -84,9 +84,9 @@ impl RefMode {
         }
     }
 
-    pub fn is_ref(&self) -> bool {
+    pub fn is_ref(self) -> bool {
         use self::RefMode::*;
-        match *self {
+        match self {
             None => false,
             ByRef => true,
             ByRefMut => true,

--- a/src/config/gobjects.rs
+++ b/src/config/gobjects.rs
@@ -25,14 +25,14 @@ pub enum GStatus {
 }
 
 impl GStatus {
-    pub fn ignored(&self) -> bool {
-        self == &GStatus::Ignore
+    pub fn ignored(self) -> bool {
+        self == GStatus::Ignore
     }
-    pub fn need_generate(&self) -> bool {
-        self == &GStatus::Generate
+    pub fn need_generate(self) -> bool {
+        self == GStatus::Generate
     }
-    pub fn normal(&self) -> bool {
-        self == &GStatus::Generate || self == &GStatus::Manual
+    pub fn normal(self) -> bool {
+        self == GStatus::Generate || self == GStatus::Manual
     }
 }
 

--- a/src/library.rs
+++ b/src/library.rs
@@ -38,8 +38,8 @@ pub enum ParameterDirection {
 }
 
 impl ParameterDirection {
-    pub fn is_out(&self) -> bool {
-        self == &ParameterDirection::Out || self == &ParameterDirection::InOut
+    pub fn is_out(self) -> bool {
+        self == ParameterDirection::Out || self == ParameterDirection::InOut
     }
 }
 
@@ -249,9 +249,9 @@ pub struct TypeId {
 }
 
 impl TypeId {
-    pub fn full_name(&self, library: &Library) -> String {
+    pub fn full_name(self, library: &Library) -> String {
         let ns_name = &library.namespace(self.ns_id).name;
-        let type_ = &library.type_(*self);
+        let type_ = &library.type_(self);
         format!("{}.{}", ns_name, &type_.get_name())
     }
 

--- a/src/version.rs
+++ b/src/version.rs
@@ -9,18 +9,18 @@ pub enum Version {
 }
 
 impl Version {
-    pub fn to_cfg(&self) -> String {
+    pub fn to_cfg(self) -> String {
         use self::Version::*;
-        match *self {
+        match self {
             Full(major, minor, 0) => format!("feature = \"v{}_{}\"", major, minor),
             Full(major, minor, patch) => format!("feature = \"v{}_{}_{}\"", major, minor, patch),
             Short(major) => format!("feature = \"v{}\"", major),
         }
     }
 
-    pub fn to_feature(&self) -> String {
+    pub fn to_feature(self) -> String {
         use self::Version::*;
-        match *self {
+        match self {
             Full(major, minor, 0) => format!("v{}_{}", major, minor),
             Full(major, minor, patch) => format!("v{}_{}_{}", major, minor, patch),
             Short(major) => format!("v{}", major),


### PR DESCRIPTION
See https://rust-lang-nursery.github.io/rust-clippy/v0.0.209/index.html#trivially_copy_pass_by_ref