### PR TITLE
Remove adding callback_guard

### DIFF
--- a/src/codegen/function_body_chunk.rs
+++ b/src/codegen/function_body_chunk.rs
@@ -242,15 +242,11 @@ impl Builder {
             Param { name: "res".to_string(), typ: format!("*mut {}::GAsyncResult", gio_crate_name) },
             Param { name: "user_data".to_string(), typ: format!("{}::gpointer", glib_crate_name) },
         ];
-        let body = Chunk::Chunks(vec![
-            Chunk::Custom("callback_guard!();".into()),
-            Chunk::Chunks(body),
-        ]);
 
         chunks.push(Chunk::ExternCFunc {
             name: format!("{}<{}: {}>", trampoline.name, trampoline.bound_name, trampoline.callback_type),
             parameters,
-            body: Box::new(body),
+            body: Box::new(Chunk::Chunks(body)),
         });
         let chunk = Chunk::Let {
             name: "callback".to_string(),

--- a/src/codegen/trampoline.rs
+++ b/src/codegen/trampoline.rs
@@ -51,7 +51,6 @@ pub fn generate(
             object_name
         ));
     }
-    try!(writeln!(w, "\tcallback_guard!();"));
     try!(writeln!(w, "\tlet f: &&({}) = transmute(f);", func_str));
     try!(transformation_vars(w, analysis));
     let call = trampoline_call_func(env, analysis, in_trait);


### PR DESCRIPTION
Stable rust v1.27.0 landed, so I start removing callback guard

Part of https://github.com/gtk-rs/glib/pull/250 and https://github.com/gtk-rs/glib/issues/304
Previous attempt:  https://github.com/gtk-rs/gir/pull/547

cc @GuillaumeGomez, @sdroege 