### PR TITLE
Fix panic in generating `emit` for incomplete signal

### DIFF
--- a/src/codegen/signal.rs
+++ b/src/codegen/signal.rs
@@ -75,6 +75,11 @@ pub fn generate(
         }
     }
 
+    if function_type.is_none() {
+        // Signal incomplete, can't generate emit
+        return Ok(());
+    }
+
     if let Some(ref emit_name) = analysis.action_emit_name {
         try!(writeln!(w));
         if !in_trait || only_declaration {


### PR DESCRIPTION
Fix panic on GObject generation (see https://github.com/gtk-rs/gir/pull/620#issue-199102491).

cc @sdroege 