### PR TITLE
Bump pkg-config version

### DIFF
--- a/src/codegen/sys/cargo_toml.rs
+++ b/src/codegen/sys/cargo_toml.rs
@@ -76,7 +76,7 @@ fn fill_in(root: &mut Table, env: &Env) {
 
     {
         let build_deps = upsert_table(root, "build-dependencies");
-        set_string(build_deps, "pkg-config", "0.3.7");
+        set_string(build_deps, "pkg-config", "0.3.12");
     }
 
     {

--- a/tests/sys/atk-sys/Cargo.toml
+++ b/tests/sys/atk-sys/Cargo.toml
@@ -1,5 +1,5 @@
 [build-dependencies]
-pkg-config = "0.3.7"
+pkg-config = "0.3.12"
 
 [dependencies]
 bitflags = "1.0"

--- a/tests/sys/gdk-pixbuf-sys/Cargo.toml
+++ b/tests/sys/gdk-pixbuf-sys/Cargo.toml
@@ -1,5 +1,5 @@
 [build-dependencies]
-pkg-config = "0.3.7"
+pkg-config = "0.3.12"
 
 [dependencies]
 bitflags = "1.0"

--- a/tests/sys/gdk-sys/Cargo.toml
+++ b/tests/sys/gdk-sys/Cargo.toml
@@ -1,5 +1,5 @@
 [build-dependencies]
-pkg-config = "0.3.7"
+pkg-config = "0.3.12"
 
 [dependencies]
 bitflags = "1.0"

--- a/tests/sys/gio-sys/Cargo.toml
+++ b/tests/sys/gio-sys/Cargo.toml
@@ -1,5 +1,5 @@
 [build-dependencies]
-pkg-config = "0.3.7"
+pkg-config = "0.3.12"
 
 [dependencies]
 bitflags = "1.0"

--- a/tests/sys/glib-sys/Cargo.toml
+++ b/tests/sys/glib-sys/Cargo.toml
@@ -1,5 +1,5 @@
 [build-dependencies]
-pkg-config = "0.3.7"
+pkg-config = "0.3.12"
 
 [dependencies]
 bitflags = "1.0"

--- a/tests/sys/gobject-sys/Cargo.toml
+++ b/tests/sys/gobject-sys/Cargo.toml
@@ -1,5 +1,5 @@
 [build-dependencies]
-pkg-config = "0.3.7"
+pkg-config = "0.3.12"
 
 [dependencies]
 bitflags = "1.0"

--- a/tests/sys/gtk-sys/Cargo.toml
+++ b/tests/sys/gtk-sys/Cargo.toml
@@ -1,5 +1,5 @@
 [build-dependencies]
-pkg-config = "0.3.7"
+pkg-config = "0.3.12"
 
 [dependencies]
 bitflags = "1.0"

--- a/tests/sys/pango-sys/Cargo.toml
+++ b/tests/sys/pango-sys/Cargo.toml
@@ -1,5 +1,5 @@
 [build-dependencies]
-pkg-config = "0.3.7"
+pkg-config = "0.3.12"
 
 [dependencies]
 bitflags = "1.0"

--- a/tests/sys/secret-sys/Cargo.toml
+++ b/tests/sys/secret-sys/Cargo.toml
@@ -1,5 +1,5 @@
 [build-dependencies]
-pkg-config = "0.3.7"
+pkg-config = "0.3.12"
 
 [dependencies]
 bitflags = "1.0"


### PR DESCRIPTION
This [version](https://github.com/alexcrichton/pkg-config-rs/pull/70) adds support for MSVC builds.