### PR TITLE
Partial properties generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,6 +72,7 @@ dependencies = [
 name = "gir"
 version = "0.0.1"
 dependencies = [
+ "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "docopt 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "git2 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ build = "build.rs"
 exclude = ["Gir*.toml", "tests/**/*", "*.md"]
 
 [dependencies]
+bitflags = "1.0"
 docopt = "1.0"
 xml-rs = "0.8"
 toml = "0.4"

--- a/README.md
+++ b/README.md
@@ -189,6 +189,11 @@ cfg_condition = "mycond"
     name = "baseline-position"
     version = "3.10"
     ignore = true
+    [[object.property]]
+    name = "events"
+    # generate only `connect_property_events_notify`, without `get_property_events` and `set_property_events`
+    # supported values: "get", "set", "notify"
+    generate = ["notify"]
 ```
 
 Since there are no child properties in `.gir` files, it needs to be added for classes manually:

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -11,6 +11,7 @@ pub mod matchable;
 pub mod members;
 pub mod parsable;
 pub mod properties;
+pub mod property_generate_flags;
 pub mod signals;
 pub mod string_type;
 pub mod work_mode;
@@ -19,6 +20,8 @@ pub mod derives;
 
 pub use self::config::Config;
 pub use self::external_libraries::ExternalLibrary;
+pub use self::gobjects::GObject;
+pub use self::property_generate_flags::PropertyGenerateFlags;
 pub use self::work_mode::WorkMode;
 pub use self::child_properties::{ChildProperties, ChildProperty};
 pub use self::string_type::StringType;

--- a/src/config/property_generate_flags.rs
+++ b/src/config/property_generate_flags.rs
@@ -1,0 +1,91 @@
+use std::str::FromStr;
+use toml;
+
+use super::error::TomlHelper;
+
+bitflags! {
+    pub struct PropertyGenerateFlags: u32 {
+        const GET = 1;
+        const SET = 2;
+        const NOTIFY = 4;
+    }
+}
+
+impl FromStr for PropertyGenerateFlags {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "get" => Ok(PropertyGenerateFlags::GET),
+            "set" => Ok(PropertyGenerateFlags::SET),
+            "notify" => Ok(PropertyGenerateFlags::NOTIFY),
+            _ => Err(format!("Wrong property generate flag \"{}\"", s)),
+        }
+    }
+}
+
+impl PropertyGenerateFlags {
+    pub fn parse_flags(toml: &toml::Value, option: &str) -> Result<PropertyGenerateFlags, String> {
+        let array = toml.as_result_vec(option)?;
+        let mut val = PropertyGenerateFlags::empty();
+        for v in array {
+            let s = match v.as_str() {
+                Some(s) => s,
+                None => {
+                    return Err(format!(
+                        "Invalid `{}` value element, expected a string, found {}",
+                        option,
+                        v.type_str()
+                    ))
+                }
+            };
+            match PropertyGenerateFlags::from_str(s) {
+                Ok(v) => val |= v,
+                e @ Err(_) => return e,
+            }
+        }
+        Ok(val)
+    }
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use toml;
+
+    fn parse(val: &str) -> Result<PropertyGenerateFlags, String> {
+        let input = format!("generate={}", val);
+        let table: toml::Value = toml::from_str(&input).unwrap();
+        let value = table.lookup("generate").unwrap();
+        PropertyGenerateFlags::parse_flags(&value, "generate")
+    }
+
+    #[test]
+    fn parse_flags() {
+        assert_eq!(parse(r#"["get"]"#).unwrap(), PropertyGenerateFlags::GET);
+        assert_eq!(parse(r#"["set"]"#).unwrap(), PropertyGenerateFlags::SET);
+        assert_eq!(
+            parse(r#"["notify"]"#).unwrap(),
+            PropertyGenerateFlags::NOTIFY
+        );
+        assert_eq!(
+            parse(r#"["set","get"]"#).unwrap(),
+            PropertyGenerateFlags::GET | PropertyGenerateFlags::SET
+        );
+        assert_eq!(
+            parse(r#""get""#),
+            Err("Invalid `generate` value, expected a array, found string".into())
+        );
+        assert_eq!(
+            parse(r#"[true]"#),
+            Err("Invalid `generate` value element, expected a string, found boolean".into())
+        );
+        assert_eq!(
+            parse(r#"["bad"]"#),
+            Err("Wrong property generate flag \"bad\"".into())
+        );
+        assert_eq!(
+            parse(r#"["get", "bad"]"#),
+            Err("Wrong property generate flag \"bad\"".into())
+        );
+    }
+
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,8 @@
 #![cfg_attr(feature = "cargo-clippy", allow(too_many_arguments))]
 #![cfg_attr(feature = "cargo-clippy", allow(write_literal))]
 
+#[macro_use]
+extern crate bitflags;
 extern crate git2;
 #[macro_use]
 extern crate lazy_static;


### PR DESCRIPTION
Part of #639 and #510

cc @GuillaumeGomez, @sdroege 

IMHO needed other name instead "object.property.generate", maybe for `PropertyGenerateFlags` too.

WIP as I don't like current parser implementation and try to rework it.