### PR TITLE
Into wrapping

### DIFF
--- a/src/analysis/bounds.rs
+++ b/src/analysis/bounds.rs
@@ -80,20 +80,20 @@ impl Bound {
         type_id: TypeId,
         nullable: Nullable,
     ) -> Option<Bound> {
-        match Bounds::type_for(env, type_id, nullable) {
-            //TODO: match boxed_bound to BoundType::IsA(l)
-            Some(BoundType::Into(_, Some(boxed_bound))) => {
+        if let Some(bound_type) = Bounds::type_for(env, type_id, nullable) {
+            if bound_type.is_into() {
+                //TODO: match boxed_bound to BoundType::IsA(l)
                 let type_str = bounds_rust_type(env, type_id);
-                Some(Bound {
-                    bound_type: *boxed_bound.clone(),
+                return Some(Bound {
+                    bound_type,
                     parameter_name: var_name.to_owned(),
                     alias: TYPE_PARAMETERS_START,
                     type_str: type_str.into_string(),
                     info_for_next_type: false,
                 })
             }
-            _ => None,
         }
+        None
     }
 }
 


### PR DESCRIPTION
This code is currently a huge mess and generate stuff like:

```
fn set_property_cell_background<'a, P: Into<Option<&'a Option<&str>>>>(&self, cell_background: P) {
```

Which is pretty funny but not what I want. So my main question is:

Why does it generate two `Option` wrapping instead of one? (I assume the `Into` wrapping generates one over a type which already has one)

A bit of help would be very appreciated here (I think I did it completely wrong). :)

Once this part done, I'll just have to generate the `.into` call and we'll be good to go I think.