### PR TITLE
Fix adding `use IsA` for properties

### DIFF
--- a/src/analysis/bounds.rs
+++ b/src/analysis/bounds.rs
@@ -31,6 +31,14 @@ impl BoundType {
         }
     }
 
+    pub fn need_isa(&self) -> bool {
+        match *self {
+            BoundType::IsA(_) => true,
+            BoundType::Into(_, Some(ref bound_type)) if bound_type.need_isa() => true,
+            _ => false,
+        }
+    }
+
     fn with_lifetime(ty_: BoundType, lifetime: char) -> BoundType {
         match ty_ {
             BoundType::NoWrapper => unreachable!(),

--- a/src/analysis/properties.rs
+++ b/src/analysis/properties.rs
@@ -95,9 +95,11 @@ pub fn analyze(
                 imports.add("glib::Value", prop.version);
             }
 
-            if prop.bound.is_some() {
-                imports.add("glib", prop.version);
-                imports.add("glib::object::IsA", prop.version);
+            if let Some(ref bound, ..) = prop.bound {
+                if bound.bound_type.need_isa() {
+                    imports.add("glib", prop.version);
+                    imports.add("glib::object::IsA", prop.version);
+                }
             }
 
             properties.push(prop);


### PR DESCRIPTION
Fix generating https://github.com/sdroege/gstreamer-rs

Remove adding unused
```
use glib;
use glib::object::IsA;
```
to `gstreamer/src/auto/stream.rs`,
`gstreamer/src/auto/stream_collection.rs`,
`gstreamer-player/src/auto/player.rs` 

@sdroege Please check this.