### PR TITLE
Generate code using CStringHolder instead of String

### DIFF
--- a/src/analysis/child_properties.rs
+++ b/src/analysis/child_properties.rs
@@ -62,7 +62,7 @@ pub fn analyze(
 
     if !properties.is_empty() {
         imports.add("glib::object::IsA", None);
-        if let Some(s) = child_type.and_then(|typ| used_rust_type(env, typ).ok()) {
+        if let Some(s) = child_type.and_then(|typ| used_rust_type(env, typ, true).ok()) {
             imports.add_used_type(&s, None);
         }
     }
@@ -85,7 +85,7 @@ fn analyze_property(
 
         imports.add("glib::Value", None);
         imports.add("glib::StaticType", None);
-        if let Ok(s) = used_rust_type(env, typ) {
+        if let Ok(s) = used_rust_type(env, typ, false) {
             imports.add_used_type(&s, None);
         }
 

--- a/src/analysis/functions.rs
+++ b/src/analysis/functions.rs
@@ -254,7 +254,7 @@ fn analyze_function(
             "Wrong instance parameter in {}",
             func.c_identifier.as_ref().unwrap()
         );
-        if let Ok(s) = used_rust_type(env, par.typ) {
+        if let Ok(s) = used_rust_type(env, par.typ, !par.direction.is_out()) {
             used_types.push(s);
         }
         let (to_glib_extra, callback_info) = bounds.add_for_parameter(env, func, par, async);
@@ -334,12 +334,12 @@ fn analyze_function(
 
         if let Some(ref trampoline) = trampoline {
             for par in &trampoline.output_params {
-                if let Ok(s) = used_rust_type(env, par.typ) {
+                if let Ok(s) = used_rust_type(env, par.typ, false) {
                     used_types.push(s);
                 }
             }
             if let Some(ref par) = trampoline.ffi_ret {
-                if let Ok(s) = used_rust_type(env, par.typ) {
+                if let Ok(s) = used_rust_type(env, par.typ, false) {
                     used_types.push(s);
                 }
             }

--- a/src/analysis/properties.rs
+++ b/src/analysis/properties.rs
@@ -73,9 +73,8 @@ pub fn analyze(
         }
 
         let type_string = rust_type(env, prop.typ);
-        let used_type_string = used_rust_type(env, prop.typ);
         if let Some(prop) = getter {
-            if let Ok(ref s) = used_type_string {
+            if let Ok(ref s) = used_rust_type(env, prop.typ, false) {
                 imports.add_used_type(s, prop.version);
             }
             if type_string.is_ok() {
@@ -87,7 +86,7 @@ pub fn analyze(
             properties.push(prop);
         }
         if let Some(prop) = setter {
-            if let Ok(ref s) = used_type_string {
+            if let Ok(ref s) = used_rust_type(env, prop.typ, true) {
                 imports.add_used_type(s, prop.version);
             }
             if type_string.is_ok() {

--- a/src/analysis/return_value.rs
+++ b/src/analysis/return_value.rs
@@ -27,7 +27,7 @@ pub fn analyze(
     let mut parameter = if typ == Default::default() {
         None
     } else {
-        if let Ok(s) = used_rust_type(env, typ) {
+        if let Ok(s) = used_rust_type(env, typ, false) {
             used_types.push(s);
         }
         // Since GIRs are bad at specifying return value nullability, assume

--- a/src/analysis/rust_type.rs
+++ b/src/analysis/rust_type.rs
@@ -224,7 +224,7 @@ fn rust_type_full(
     rust_type
 }
 
-pub fn used_rust_type(env: &Env, type_id: library::TypeId) -> Result {
+pub fn used_rust_type(env: &Env, type_id: library::TypeId, is_in: bool) -> Result {
     use library::Type::*;
     match *env.library.type_(type_id) {
         Fundamental(library::Fundamental::Type) |
@@ -243,8 +243,10 @@ pub fn used_rust_type(env: &Env, type_id: library::TypeId) -> Result {
         Class(..) |
         Enumeration(..) |
         Interface(..) => rust_type(env, type_id),
-        List(inner_tid) | SList(inner_tid) | CArray(inner_tid) => used_rust_type(env, inner_tid),
+        //process inner types as return parameters
+        List(inner_tid) | SList(inner_tid) | CArray(inner_tid) => used_rust_type(env, inner_tid, false),
         Custom(..) => rust_type(env, type_id),
+        Fundamental(library::Fundamental::Utf8) if !is_in => Ok("::glib::GString".into()),
         _ => Err(TypeError::Ignored("Don't need use".to_owned())),
     }
 }

--- a/src/analysis/rust_type.rs
+++ b/src/analysis/rust_type.rs
@@ -98,7 +98,7 @@ fn rust_type_full(
                 Utf8 => if ref_mode.is_ref() {
                     ok("str")
                 } else {
-                    ok("String")
+                    ok("GString")
                 },
                 Filename => if ref_mode.is_ref() {
                     ok("std::path::Path")

--- a/src/analysis/supertypes.rs
+++ b/src/analysis/supertypes.rs
@@ -26,7 +26,7 @@ pub fn analyze(env: &Env, type_id: TypeId, imports: &mut Imports) -> Vec<Statuse
         });
 
         if !status.ignored() {
-            if let Ok(s) = used_rust_type(env, super_tid) {
+            if let Ok(s) = used_rust_type(env, super_tid, true) {
                 if super_tid.ns_id == namespaces::MAIN {
                     imports.add(&s, None);
                 } else {

--- a/src/analysis/trampoline_parameters.rs
+++ b/src/analysis/trampoline_parameters.rs
@@ -137,6 +137,7 @@ pub fn analyze(
 
         let conversion_type = {
             match *env.library.type_(par.typ) {
+                library::Type::Fundamental(library::Fundamental::Utf8) |
                 library::Type::Record(..) |
                 library::Type::Interface(..) |
                 library::Type::Class(..) => ConversionType::Borrow,

--- a/src/analysis/trampolines.rs
+++ b/src/analysis/trampolines.rs
@@ -98,7 +98,7 @@ pub fn analyze(
 
 
     for par in &parameters.rust_parameters {
-        if let Ok(s) = used_rust_type(env, par.typ) {
+        if let Ok(s) = used_rust_type(env, par.typ, false) {
             used_types.push(s);
         }
     }
@@ -111,7 +111,7 @@ pub fn analyze(
     let mut ret_nullable = signal.ret.nullable;
 
     if signal.ret.typ != Default::default() {
-        if let Ok(s) = used_rust_type(env, signal.ret.typ) {
+        if let Ok(s) = used_rust_type(env, signal.ret.typ, true) { //No GString
             used_types.push(s);
         }
         if let Some(s) = used_ffi_type(env, signal.ret.typ, &signal.ret.c_type) {

--- a/src/codegen/function.rs
+++ b/src/codegen/function.rs
@@ -152,7 +152,7 @@ pub fn declaration(env: &Env, analysis: &analysis::functions::Info) -> String {
             " -> Result<(), glib::error::BoolError>".into()
         }
     } else {
-        analysis.ret.to_return_value(env)
+        analysis.ret.to_return_value(env, false)
     };
     let mut param_str = String::with_capacity(100);
 

--- a/src/codegen/property_body.rs
+++ b/src/codegen/property_body.rs
@@ -121,7 +121,7 @@ impl Builder {
         let unwrap = if self.is_nullable {
             // This one is strictly speaking nullable, but
             // we represent that with an empty Vec instead
-            if self.type_ == "Vec<String>" {
+            if self.type_ == "Vec<GString>" {
                 ".unwrap()"
             } else {
                 ""

--- a/src/codegen/trampoline.rs
+++ b/src/codegen/trampoline.rs
@@ -167,7 +167,7 @@ fn func_returns(env: &Env, analysis: &Trampoline) -> String {
     } else if analysis.inhibit {
         " -> Inhibit".into()
     } else {
-        analysis.ret.to_return_value(env)
+        analysis.ret.to_return_value(env, true)
     }
 }
 


### PR DESCRIPTION
Generated code relying on CStringHolder should be more efficient because it
reduces the amount of string copies.
