### PR TITLE
Implement basics for subclassing

### DIFF
--- a/src/analysis/object.rs
+++ b/src/analysis/object.rs
@@ -17,6 +17,7 @@ pub struct Info {
     pub base: InfoBase,
     pub c_type: String,
     pub c_class_type: Option<String>,
+    pub rust_class_type: Option<String>,
     pub get_type: String,
     pub supertypes: Vec<general::StatusedTypeId>,
     pub generate_trait: bool,
@@ -207,6 +208,14 @@ pub fn class(env: &Env, obj: &GObject, deps: &[library::TypeId]) -> Option<Info>
         imports.add("glib::ObjectExt", None);
     }
 
+    let rust_class_type = if obj.subclassing {
+        let class_name = format!("{}Class", name);
+        imports.add(&class_name, None);
+        Some(class_name)
+    } else {
+        None
+    };
+
     let base = InfoBase {
         full_name,
         type_id: class_tid,
@@ -237,6 +246,7 @@ pub fn class(env: &Env, obj: &GObject, deps: &[library::TypeId]) -> Option<Info>
         base,
         c_type: klass.c_type.clone(),
         c_class_type: klass.c_class_type.clone(),
+        rust_class_type,
         get_type: klass.glib_get_type.clone(),
         supertypes,
         generate_trait,
@@ -363,6 +373,7 @@ pub fn interface(env: &Env, obj: &GObject, deps: &[library::TypeId]) -> Option<I
         base,
         c_type: iface.c_type.clone(),
         c_class_type: iface.c_class_type.clone(),
+        rust_class_type: None,
         get_type: iface.glib_get_type.clone(),
         supertypes,
         generate_trait: true,

--- a/src/codegen/general.rs
+++ b/src/codegen/general.rs
@@ -77,6 +77,7 @@ pub fn define_object_type(
     type_name: &str,
     glib_name: &str,
     glib_class_name: &Option<&str>,
+    rust_class_name: &Option<&str>,
     glib_func_name: &str,
     parents: &[StatusedTypeId],
 ) -> Result<()> {
@@ -105,25 +106,32 @@ pub fn define_object_type(
         }
     };
 
+    let rust_class_name = match rust_class_name {
+        None => String::new(),
+        Some(ref rust_class_name) => format!(", {}", rust_class_name),
+    };
+
     try!(writeln!(w));
     try!(writeln!(w, "glib_wrapper! {{"));
     if parents.is_empty() {
         try!(writeln!(
             w,
-            "\tpub struct {}(Object<ffi::{}{}{}>);",
+            "\tpub struct {}(Object<ffi::{}{}{}{}>);",
             type_name,
             glib_name,
             separator,
-            class_name
+            class_name,
+            rust_class_name
         ));
     } else if external_parents {
         try!(writeln!(
             w,
-            "\tpub struct {}(Object<ffi::{}{}{}>): [",
+            "\tpub struct {}(Object<ffi::{}{}{}{}>): [",
             type_name,
             glib_name,
             separator,
-            class_name
+            class_name,
+            rust_class_name
         ));
         for parent in parents {
             try!(writeln!(w, "\t\t{},", parent));
@@ -132,11 +140,12 @@ pub fn define_object_type(
     } else {
         try!(writeln!(
             w,
-            "\tpub struct {}(Object<ffi::{}{}{}>): {};",
+            "\tpub struct {}(Object<ffi::{}{}{}{}>): {};",
             type_name,
             glib_name,
             separator,
             class_name,
+            rust_class_name,
             parents.join(", ")
         ));
     }

--- a/src/codegen/object.rs
+++ b/src/codegen/object.rs
@@ -26,6 +26,7 @@ pub fn generate(
         &analysis.name,
         &analysis.c_type,
         &analysis.c_class_type.as_ref().map(|s| &s[..]),
+        &analysis.rust_class_type.as_ref().map(|s| &s[..]),
         &analysis.get_type,
         &analysis.supertypes,
     ));

--- a/src/config/gobjects.rs
+++ b/src/config/gobjects.rs
@@ -79,6 +79,7 @@ pub struct GObject {
     pub conversion_type: Option<conversion_type::ConversionType>,
     pub use_boxed_functions: bool,
     pub generate_display_trait: bool,
+    pub subclassing: bool,
 }
 
 impl Default for GObject {
@@ -105,6 +106,7 @@ impl Default for GObject {
             conversion_type: None,
             use_boxed_functions: false,
             generate_display_trait: true,
+            subclassing: false,
         }
     }
 }
@@ -187,6 +189,7 @@ fn parse_object(
             "must_use",
             "use_boxed_functions",
             "generate_display_trait",
+            "subclassing",
         ],
         &format!("object {}", name),
     );
@@ -265,6 +268,10 @@ fn parse_object(
         .lookup("generate_display_trait")
         .and_then(|v| v.as_bool())
         .unwrap_or(default_generate_display_trait);
+    let subclassing = toml_object
+        .lookup("subclassing")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
 
     if status != GStatus::Manual && ref_mode.is_some() {
         warn!("ref_mode configuration used for non-manual object {}", name);
@@ -296,6 +303,7 @@ fn parse_object(
         conversion_type,
         use_boxed_functions,
         generate_display_trait,
+        subclassing,
     }
 }
 


### PR DESCRIPTION
This passes the Rust class struct to glib_wrapper! if configured to do
so but still requires it to be manually implemented for the time being.

See https://github.com/gtk-rs/glib/pull/392