### PR TITLE
Remove now unneeded use statements for the glib_wrapper! macro

### DIFF
--- a/src/analysis/object.rs
+++ b/src/analysis/object.rs
@@ -91,10 +91,6 @@ pub fn class(env: &Env, obj: &GObject, deps: &[library::TypeId]) -> Option<Info>
     let mut imports = Imports::with_defined(&env.library, &name);
     imports.add("glib::translate::*", None);
     imports.add("ffi", None);
-    imports.add("glib_ffi", None);
-    imports.add("gobject_ffi", None);
-    imports.add("std::mem", None);
-    imports.add("std::ptr", None);
     if obj.generate_display_trait {
         imports.add("std::fmt", None);
     }
@@ -287,10 +283,6 @@ pub fn interface(env: &Env, obj: &GObject, deps: &[library::TypeId]) -> Option<I
     imports.add("glib::translate::*", None);
     imports.add("ffi", None);
     imports.add("glib::object::IsA", None);
-    imports.add("glib_ffi", None);
-    imports.add("gobject_ffi", None);
-    imports.add("std::mem", None);
-    imports.add("std::ptr", None);
     if obj.generate_display_trait {
         imports.add("std::fmt", None);
     }

--- a/src/analysis/out_parameters.rs
+++ b/src/analysis/out_parameters.rs
@@ -121,7 +121,12 @@ pub fn analyze_imports(env: &Env, func: &Function, imports: &mut Imports) {
                 {
                     imports.add("std::mem", func.version)
                 }
-                _ if !par.caller_allocates => imports.add("std::ptr", func.version),
+                _ if !par.caller_allocates => {
+                    match ConversionType::of(env, par.typ) {
+                        ConversionType::Direct | ConversionType::Scalar => (),
+                        _ => imports.add("std::ptr", func.version),
+                    }
+                }
                 _ => (),
             }
         }

--- a/src/analysis/record.rs
+++ b/src/analysis/record.rs
@@ -8,6 +8,7 @@ use nameutil::*;
 use super::*;
 use super::imports::Imports;
 use super::info_base::InfoBase;
+use super::record_type::RecordType;
 use traits::*;
 
 #[derive(Debug, Default)]
@@ -75,13 +76,13 @@ pub fn new(env: &Env, obj: &GObject) -> Option<Info> {
     let use_boxed_functions = obj.use_boxed_functions;
 
     let mut imports = Imports::with_defined(&env.library, &name);
-    imports.add("glib::translate::*", None);
     imports.add("ffi", None);
-    imports.add("glib_ffi", None);
-    imports.add("std::mem", None);
-    imports.add("std::ptr", None);
     if record.glib_get_type.is_some() {
-        imports.add("gobject_ffi", None);
+        if use_boxed_functions {
+            imports.add("gobject_ffi", None);
+        } else if let RecordType::AutoBoxed = RecordType::of(&record) {
+            imports.add("gobject_ffi", None);
+        }
     }
 
     let mut functions = functions::analyze(


### PR DESCRIPTION
See https://github.com/gtk-rs/glib/pull/398

This is not complete. There's still the `std::ptr` added from `src/analysis/out_parameters.rs:analyze_imports()`. It seems like the condition there is wrong but I don't know what it should be. It seems to be related to `src/codegen/function_body_chunk.rs:c_type_mem_mode_lib()`.

@EPashkin any ideas?