### PR TITLE
Various minor fixes

### DIFF
--- a/src/analysis/properties.rs
+++ b/src/analysis/properties.rs
@@ -273,7 +273,7 @@ fn analyze_property(
             if generate_trait {
                 imports.add("glib::object::Downcast", prop_version);
             }
-            imports.add("glib::signal::connect", prop_version);
+            imports.add("glib::signal::connect_raw", prop_version);
             imports.add("glib::signal::SignalHandlerId", prop_version);
             imports.add("std::mem::transmute", prop_version);
             imports.add("std::boxed::Box as Box_", prop_version);

--- a/src/analysis/signals.rs
+++ b/src/analysis/signals.rs
@@ -103,7 +103,7 @@ fn analyze_signal(
         if in_trait {
             imports.add("glib::object::Downcast", version);
         }
-        imports.add("glib::signal::connect", version);
+        imports.add("glib::signal::connect_raw", version);
         imports.add("glib::signal::SignalHandlerId", version);
         imports.add("std::mem::transmute", version);
         imports.add("std::boxed::Box as Box_", version);

--- a/src/codegen/child_properties.rs
+++ b/src/codegen/child_properties.rs
@@ -75,7 +75,7 @@ fn generate_func(
     ));
 
     if !only_declaration {
-        let body = body(env, prop, is_get).to_code(env);
+        let body = body(env, prop, in_trait, is_get).to_code(env);
         for s in body {
             try!(writeln!(w, "{}{}{}", tabs(indent), comment_prefix, s));
         }
@@ -119,11 +119,12 @@ fn declaration(env: &Env, prop: &ChildProperty, is_get: bool) -> String {
     )
 }
 
-fn body(env: &Env, prop: &ChildProperty, is_get: bool) -> Chunk {
+fn body(env: &Env, prop: &ChildProperty, in_trait: bool, is_get: bool) -> Chunk {
     let mut builder = property_body::Builder::new_for_child_property();
     let prop_name = nameutil::signal_to_snake(&*prop.name);
     builder
         .name(&prop.name)
+        .in_trait(in_trait)
         .var_name(&prop_name)
         .is_get(is_get)
         .is_ref(prop.set_in_ref_mode.is_ref())

--- a/src/codegen/object.rs
+++ b/src/codegen/object.rs
@@ -205,10 +205,9 @@ fn generate_trait(
     try!(writeln!(w, "}}"));
 
     try!(writeln!(w));
-    // FIXME remove 'static
     try!(write!(
         w,
-        "impl<O: 'static + IsA<{}>> {} for O {{",
+        "impl<O: IsA<{}>> {} for O {{",
         analysis.name,
         analysis.trait_name,
     ));

--- a/src/codegen/properties.rs
+++ b/src/codegen/properties.rs
@@ -67,7 +67,7 @@ fn generate_prop_func(
     ));
 
     if !only_declaration {
-        let body = body(env, prop).to_code(env);
+        let body = body(env, prop, in_trait).to_code(env);
         for s in body {
             try!(writeln!(w, "{}{}{}", tabs(indent), comment_prefix, s));
         }
@@ -167,10 +167,11 @@ fn declaration(env: &Env, prop: &Property) -> String {
     )
 }
 
-fn body(env: &Env, prop: &Property) -> Chunk {
+fn body(env: &Env, prop: &Property, in_trait: bool) -> Chunk {
     let mut builder = property_body::Builder::new();
     builder
         .name(&prop.name)
+        .in_trait(in_trait)
         .var_name(&prop.var_name)
         .is_get(prop.is_get)
         .is_ref(prop.set_in_ref_mode.is_ref())

--- a/src/codegen/property_body.rs
+++ b/src/codegen/property_body.rs
@@ -78,8 +78,7 @@ impl Builder {
         if self.is_child_property {
             params.push(Chunk::Custom("item.to_glib_none().0".into()));
         }
-        // FIXME
-        params.push(Chunk::Custom(format!("\"b{}\\0\".as_ptr() as *const _", self.name)));
+        params.push(Chunk::Custom(format!("b\"{}\\0\".as_ptr() as *const _", self.name)));
         params.push(Chunk::Custom("value.to_glib_none_mut().0".into()));
 
         let mut body = Vec::new();
@@ -137,8 +136,7 @@ impl Builder {
         if self.is_child_property {
             params.push(Chunk::Custom("item.to_glib_none().0".into()));
         }
-        // FIXME
-        params.push(Chunk::Custom(format!("\"b{}\\0\".as_ptr() as *const _", self.name)));
+        params.push(Chunk::Custom(format!("b\"{}\\0\".as_ptr() as *const _", self.name)));
         let ref_str = if self.is_ref { "" } else { "&" };
         params.push(Chunk::Custom(format!(
             "Value::from({}{}).to_glib_none().0",

--- a/src/codegen/property_body.rs
+++ b/src/codegen/property_body.rs
@@ -4,6 +4,7 @@ use chunk::Chunk;
 #[derive(Default)]
 pub struct Builder {
     name: String,
+    in_trait: bool,
     var_name: String,
     is_get: bool,
     is_child_property: bool,
@@ -28,6 +29,11 @@ impl Builder {
 
     pub fn name(&mut self, name: &str) -> &mut Builder {
         self.name = name.into();
+        self
+    }
+
+    pub fn in_trait(&mut self, value: bool) -> &mut Builder {
+        self.in_trait = value;
         self
     }
 
@@ -73,8 +79,13 @@ impl Builder {
     fn chunks_for_get(&self) -> Vec<Chunk> {
         let mut params = Vec::new();
 
-        let cast_target = if self.is_child_property { "ffi::GtkContainer" } else { "gobject_ffi::GObject" };
-        params.push(Chunk::Custom(format!("self.to_glib_none().0 as *mut {}", cast_target)));
+        if self.in_trait {
+            let cast_target = if self.is_child_property { "ffi::GtkContainer" } else { "gobject_ffi::GObject" };
+            params.push(Chunk::Custom(format!("self.to_glib_none().0 as *mut {}", cast_target)));
+        } else {
+            params.push(Chunk::Custom(String::from("self.to_glib_none().0")));
+        }
+
         if self.is_child_property {
             params.push(Chunk::Custom("item.to_glib_none().0".into()));
         }
@@ -131,8 +142,13 @@ impl Builder {
     fn chunks_for_set(&self) -> Vec<Chunk> {
         let mut params = Vec::new();
 
-        let cast_target = if self.is_child_property { "ffi::GtkContainer" } else { "gobject_ffi::GObject" };
-        params.push(Chunk::Custom(format!("self.to_glib_none().0 as *mut {}", cast_target)));
+        if self.in_trait {
+            let cast_target = if self.is_child_property { "ffi::GtkContainer" } else { "gobject_ffi::GObject" };
+            params.push(Chunk::Custom(format!("self.to_glib_none().0 as *mut {}", cast_target)));
+        } else {
+            params.push(Chunk::Custom(String::from("self.to_glib_none().0")));
+        }
+
         if self.is_child_property {
             params.push(Chunk::Custom("item.to_glib_none().0".into()));
         }

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -139,7 +139,7 @@ impl Config {
         let mut objects = toml.lookup("object")
             .map(|t| gobjects::parse_toml(t, concurrency, generate_display_trait))
             .unwrap_or_default();
-        gobjects::parse_status_shorthands(&mut objects, &toml, concurrency);
+        gobjects::parse_status_shorthands(&mut objects, &toml, concurrency, generate_display_trait);
 
         let external_libraries = try!(read_external_libraries(&toml));
 

--- a/src/config/gobjects.rs
+++ b/src/config/gobjects.rs
@@ -311,10 +311,11 @@ pub fn parse_status_shorthands(
     objects: &mut GObjects,
     toml: &Value,
     concurrency: library::Concurrency,
+    generate_display_trait: bool,
 ) {
     use self::GStatus::*;
     for &status in &[Manual, Generate, Comment, Ignore] {
-        parse_status_shorthand(objects, status, toml, concurrency);
+        parse_status_shorthand(objects, status, toml, concurrency, generate_display_trait);
     }
 }
 
@@ -323,6 +324,7 @@ fn parse_status_shorthand(
     status: GStatus,
     toml: &Value,
     concurrency: library::Concurrency,
+    generate_display_trait: bool,
 ) {
     let name = format!("options.{:?}", status).to_ascii_lowercase();
     if let Some(a) = toml.lookup(&name).map(|a| a.as_array().unwrap()) {
@@ -335,6 +337,7 @@ fn parse_status_shorthand(
                             name: name_.into(),
                             status,
                             concurrency,
+                            generate_display_trait,
                             ..Default::default()
                         },
                     );

--- a/src/writer/to_code.rs
+++ b/src/writer/to_code.rs
@@ -134,9 +134,8 @@ impl ToCode for Chunk {
                 ref trampoline,
                 in_trait,
             } => {
-                // FIXME \0 terminated string
                 let cast_str = if in_trait { " as *mut _" } else { "" };
-                let s1 = format!("connect(self.to_glib_none().0{}, \"{}\",", cast_str, signal);
+                let s1 = format!("connect_raw(self.to_glib_none().0{}, b\"{}\\0\".as_ptr() as *const _,", cast_str, signal);
                 let self_str = if in_trait { "::<Self>" } else { "" };
                 let s2 = format!(
                     "\ttransmute({}{} as usize), Box_::into_raw(f) as *mut _)",


### PR DESCRIPTION
commit bcfdfe6584cb9d934eb22ac150889a7d8b1c9924 (HEAD -> raw-strings)
Author: Sebastian Dröge <sebastian@centricular.com>
Date:   Sat Dec 8 10:58:23 2018 +0200

    Also generate display trait for shorthand types only if the global default says so

commit 6178a527b14e9f226db2b7f7758e23bf3cdc3488
Author: Sebastian Dröge <sebastian@centricular.com>
Date:   Sat Dec 8 10:48:03 2018 +0200

    Only insert casts in property getters/setters if we're generating them for a trait
    
    Otherwise compilation fails because type annotations would be needed.

commit 83a8280c1b9cbdedee5cc57323ca1f424f94383f
Author: Sebastian Dröge <sebastian@centricular.com>
Date:   Sat Dec 8 10:33:38 2018 +0200

    Use raw 0-terminated strings for connecting to signals and accessing properties
    
    Going through `s.to_glib_none().0` involves another allocation and copy.
