### PR TITLE
They weren't meant to be bit fields

### DIFF
--- a/src/analysis/types.rs
+++ b/src/analysis/types.rs
@@ -72,11 +72,6 @@ impl IsIncomplete for Alias {
 
 impl IsIncomplete for Field {
     fn is_incomplete(&self, lib: &Library) -> bool {
-        if self.bits.is_some() {
-            // Bitfields are unrepresentable in Rust,
-            // so from our perspective they are incomplete.
-            return true;
-        }
         if self.is_ptr() {
             // Pointers are always complete.
             return false;
@@ -91,7 +86,21 @@ impl<'a> IsIncomplete for &'a [Field] {
         if self.is_empty() {
             return true;
         }
-        self.iter().any(|f| f.is_incomplete(lib))
+
+        let mut is_bitfield = false;
+        for field in self.iter() {
+            if field.is_incomplete(lib) {
+                return true;
+            }
+            // Two consequitive bitfields are unrepresentable in Rust,
+            // so from our perspective they are incomplete.
+            if is_bitfield && field.bits.is_some() {
+                return true;
+            }
+            is_bitfield = field.bits.is_some();
+        }
+
+        false
     }
 }
 

--- a/src/codegen/sys/fields.rs
+++ b/src/codegen/sys/fields.rs
@@ -100,7 +100,15 @@ fn analyze_fields(env: &Env, unsafe_access: bool, fields: &[Field]) -> (Vec<Fiel
     let mut truncated = None;
     let mut infos = Vec::with_capacity(fields.len());
 
+    let mut is_bitfield = false;
     for field in fields {
+        // See IsIncomplete for &[Field].
+        if is_bitfield && field.bits.is_some() {
+            truncated = Some(format!("field {} has incomplete type", &field.name));
+            break;
+        }
+        is_bitfield = field.bits.is_some();
+
         let typ = match field_ffi_type(env, field) {
             e @ Err(..) => {
                 truncated = Some(e.into_string());


### PR DESCRIPTION
When bit field is not preceded by another bit field, generate the field
as if didn't specify bit width.

From Sys V ABI perspective two most important things about bit fields
are that they occupy storage unit appropriate for their declared type,
and that they might share it with other struct / union members.

When there are no other bit fields they could share storage with
they are laid out like fields without bit width specification.

Use this observation to generate definitions for additional types.