### PR TITLE
Remove special generation for enums with a single member

### DIFF
--- a/src/codegen/sys/lib_.rs
+++ b/src/codegen/sys/lib_.rs
@@ -291,19 +291,6 @@ fn generate_enums(w: &mut Write, env: &Env, items: &[&Enumeration]) -> Result<()
         if let Some(false) = config.map(|c| c.status.need_generate()) {
             continue;
         }
-        if item.members.len() == 1 {
-            try!(writeln!(w, "pub type {} = c_int;", item.name));
-            try!(writeln!(
-                w,
-                "pub const {}: {} = {};",
-                item.members[0].c_identifier,
-                item.name,
-                item.members[0].value
-            ));
-            try!(writeln!(w, "pub type {} = {};", item.c_type, item.name));
-            try!(writeln!(w));
-            continue;
-        }
         let mut vals: HashMap<String, (String, Option<Version>)> = HashMap::new();
         try!(writeln!(w, "pub type {} = c_int;", item.c_type));
         for member in &item.members {


### PR DESCRIPTION
The special case generates unqualified name in Rust, which crates
mismatch with version in C, since it is not present there.

Differences in sys codegen:

```diff
diff --git a/gdk-pixbuf-sys/src/lib.rs b/gdk-pixbuf-sys/src/lib.rs
index 1f814d8..45fc764 100644
--- a/gdk-pixbuf-sys/src/lib.rs
+++ b/gdk-pixbuf-sys/src/lib.rs
@@ -19,9 +19,8 @@ use libc::{c_int, c_char, c_uchar, c_float, c_uint, c_double,
 use glib::{gboolean, gconstpointer, gpointer, GType};

 // Enums
-pub type Colorspace = c_int;
-pub const GDK_COLORSPACE_RGB: Colorspace = 0;
-pub type GdkColorspace = Colorspace;
+pub type GdkColorspace = c_int;
+pub const GDK_COLORSPACE_RGB: GdkColorspace = 0;

 pub type GdkInterpType = c_int;
 pub const GDK_INTERP_NEAREST: GdkInterpType = 0;
diff --git a/gio-sys/src/lib.rs b/gio-sys/src/lib.rs
index f8f2373..02f4712 100644
--- a/gio-sys/src/lib.rs
+++ b/gio-sys/src/lib.rs
@@ -308,9 +308,8 @@ pub const G_TLS_AUTHENTICATION_NONE: GTlsAuthenticationMode = 0;
 pub const G_TLS_AUTHENTICATION_REQUESTED: GTlsAuthenticationMode = 1;
 pub const G_TLS_AUTHENTICATION_REQUIRED: GTlsAuthenticationMode = 2;

-pub type TlsCertificateRequestFlags = c_int;
-pub const G_TLS_CERTIFICATE_REQUEST_NONE: TlsCertificateRequestFlags = 0;
-pub type GTlsCertificateRequestFlags = TlsCertificateRequestFlags;
+pub type GTlsCertificateRequestFlags = c_int;
+pub const G_TLS_CERTIFICATE_REQUEST_NONE: GTlsCertificateRequestFlags = 0;

 pub type GTlsDatabaseLookupFlags = c_int;
 pub const G_TLS_DATABASE_LOOKUP_NONE: GTlsDatabaseLookupFlags = 0;
diff --git a/glib-sys/src/lib.rs b/glib-sys/src/lib.rs
index 3121235..41b9103 100644
--- a/glib-sys/src/lib.rs
+++ b/glib-sys/src/lib.rs
@@ -327,9 +327,8 @@ pub const G_TEST_RUN_SKIPPED: GTestResult = 1;
 pub const G_TEST_RUN_FAILURE: GTestResult = 2;
 pub const G_TEST_RUN_INCOMPLETE: GTestResult = 3;

-pub type ThreadError = c_int;
-pub const G_THREAD_ERROR_AGAIN: ThreadError = 0;
-pub type GThreadError = ThreadError;
+pub type GThreadError = c_int;
+pub const G_THREAD_ERROR_AGAIN: GThreadError = 0;

 pub type GTimeType = c_int;
 pub const G_TIME_TYPE_STANDARD: GTimeType = 0;
diff --git a/pango-sys/src/lib.rs b/pango-sys/src/lib.rs
index 77351de..26c4bac 100644
--- a/pango-sys/src/lib.rs
+++ b/pango-sys/src/lib.rs
@@ -252,9 +252,8 @@ pub const PANGO_STYLE_NORMAL: PangoStyle = 0;
 pub const PANGO_STYLE_OBLIQUE: PangoStyle = 1;
 pub const PANGO_STYLE_ITALIC: PangoStyle = 2;

-pub type TabAlign = c_int;
-pub const PANGO_TAB_LEFT: TabAlign = 0;
-pub type PangoTabAlign = TabAlign;
+pub type PangoTabAlign = c_int;
+pub const PANGO_TAB_LEFT: PangoTabAlign = 0;

 pub type PangoUnderline = c_int;
 pub const PANGO_UNDERLINE_NONE: PangoUnderline = 0;
```