### PR TITLE
Revert "They weren't meant to be bit fields"

### DIFF
--- a/src/analysis/types.rs
+++ b/src/analysis/types.rs
@@ -72,6 +72,11 @@ impl IsIncomplete for Alias {
 
 impl IsIncomplete for Field {
     fn is_incomplete(&self, lib: &Library) -> bool {
+        if self.bits.is_some() {
+            // Bitfields are unrepresentable in Rust,
+            // so from our perspective they are incomplete.
+            return true;
+        }
         if self.is_ptr() {
             // Pointers are always complete.
             return false;
@@ -86,21 +91,7 @@ impl<'a> IsIncomplete for &'a [Field] {
         if self.is_empty() {
             return true;
         }
-
-        let mut is_bitfield = false;
-        for field in self.iter() {
-            if field.is_incomplete(lib) {
-                return true;
-            }
-            // Two consequitive bitfields are unrepresentable in Rust,
-            // so from our perspective they are incomplete.
-            if is_bitfield && field.bits.is_some() {
-                return true;
-            }
-            is_bitfield = field.bits.is_some();
-        }
-
-        false
+        self.iter().any(|f| f.is_incomplete(lib))
     }
 }
 

--- a/src/codegen/sys/fields.rs
+++ b/src/codegen/sys/fields.rs
@@ -100,15 +100,7 @@ fn analyze_fields(env: &Env, unsafe_access: bool, fields: &[Field]) -> (Vec<Fiel
     let mut truncated = None;
     let mut infos = Vec::with_capacity(fields.len());
 
-    let mut is_bitfield = false;
     for field in fields {
-        // See IsIncomplete for &[Field].
-        if is_bitfield && field.bits.is_some() {
-            truncated = Some(format!("field {} has incomplete type", &field.name));
-            break;
-        }
-        is_bitfield = field.bits.is_some();
-
         let typ = match field_ffi_type(env, field) {
             e @ Err(..) => {
                 truncated = Some(e.into_string());


### PR DESCRIPTION
This reverts commit 69ecbe911e8b3491a8d98e20ba98c8232f5e398d.

We assumed those changed would be covered by new tests, but since neither
@sdroege  nor @GuillaumeGomez are interested in maintaining two test suites,
revert those changes at least until after migration to ctest is complete.