### PR TITLE
[WIP] Always generate IsA<T> bounds for classes even if they have no known …

### DIFF
--- a/src/analysis/bounds.rs
+++ b/src/analysis/bounds.rs
@@ -172,18 +172,8 @@ impl Bounds {
             Type::Fundamental(Fundamental::Filename) => Some(AsRef(None)),
             Type::Fundamental(Fundamental::OsString)=> Some(AsRef(None)),
             Type::Fundamental(Fundamental::Utf8) if *nullable => Some(Into(Some('_'), None)),
-            Type::Class(..) if !*nullable => {
-                if env.class_hierarchy.subtypes(type_id).next().is_some() {
-                    Some(IsA(None))
-                } else {
-                    None
-                }
-            }
-            Type::Class(..) => if env.class_hierarchy.subtypes(type_id).next().is_some() {
-                Some(Into(Some('_'), Some(Box::new(IsA(None)))))
-            } else {
-                Some(Into(Some('_'), None))
-            },
+            Type::Class(..) if !*nullable => Some(IsA(None)),
+            Type::Class(..) => Some(Into(Some('_'), Some(Box::new(IsA(None))))),
             Type::Interface(..) if !*nullable => Some(IsA(None)),
             Type::Interface(..) => Some(Into(Some('_'), Some(Box::new(IsA(None))))),
             Type::List(_) | Type::SList(_) | Type::CArray(_) => None,


### PR DESCRIPTION
…subclasses here

They might have subclasses in another crate!

----

TODO
* [ ] Properly detect final types (they have no public class or instance struct) and don't do it for them
* [ ] Generate typed `None` constants like `const NoneWidget: Option<Widget> = None;` for convenience

See https://github.com/gtk-rs/gir/pull/689#discussion_r246656283 for details.

