### PR TITLE
Implement configuration/detection for final types and use that inform…

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,8 +136,10 @@ name = "Gtk.SomeClass"
 status = "generate"
 # replace the parameter name for the child in child properties (instead "child")
 child_name = "item"
-# don't generate trait SomeClassExt for this object, but implement all functions in impl SomeClass
-trait = false
+# mark object as final type, i.e. one without any further subclasses. this
+# will not generate trait SomeClassExt for this object, but implement all
+# functions in impl SomeClass
+final_type = true
 # allow rename result file
 module_name = "soome_class"
 # override starting version

--- a/src/library.rs
+++ b/src/library.rs
@@ -466,6 +466,7 @@ pub struct Class {
     pub properties: Vec<Property>,
     pub parent: Option<TypeId>,
     pub implements: Vec<TypeId>,
+    pub final_type: bool,
     pub version: Option<Version>,
     pub deprecated_version: Option<Version>,
     pub doc: Option<String>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -94,7 +94,7 @@ fn do_main() -> Result<(), String> {
 
     {
         let _watcher = statistics.enter("Postprocessing");
-        library.postprocessing();
+        library.postprocessing(&cfg);
     }
 
     {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -198,6 +198,7 @@ impl Library {
             properties,
             parent,
             implements: impls,
+            final_type: false, // this will be set during postprocessing
             doc,
             version,
             deprecated_version,


### PR DESCRIPTION
…ation

Final types are those that can't have any further subclasses, and as
such we don't need to generate IsA<_> bounds or NONE_XXX constants and
also don't need to generate a trait for them.

This replaces the previous "trait" configuration with "final_type",
which has a slightly wider meaning.