### PR TITLE
Check for known subtypes when deciding if a type is a final type

### DIFF
--- a/src/library_postprocessing.rs
+++ b/src/library_postprocessing.rs
@@ -377,9 +377,22 @@ impl Library {
         }
     }
 
+    fn has_subtypes(&self, parent_tid: &TypeId) -> bool {
+        for (tid, _) in self.types() {
+            if let Type::Class(ref class) = *self.type_(tid) {
+                if class.parent.as_ref() == Some(parent_tid) {
+                    return true;
+                }
+            }
+        }
+
+        false
+    }
+
     fn mark_final_types(&mut self, config: &Config) {
         // Here we mark all class types as final types if configured so in the config or
-        // otherwise if there is no public class struct for the type.
+        // otherwise if there is no public class struct for the type and there are no
+        // known subtypes.
         //
         // Final types can't have any subclasses and we handle them slightly different
         // for that reason.
@@ -404,7 +417,7 @@ impl Library {
                         if *final_type {
                             final_types.push(tid);
                         }
-                    } else if klass.c_class_type.is_none() {
+                    } else if klass.c_class_type.is_none() && !self.has_subtypes(&tid) {
                         final_types.push(tid);
                     }
                 }


### PR DESCRIPTION
If there's a subtype we don't consider it a final type too. The class
struct might be private but inside the library there might be subtypes.

Subtypes in other libraries are nonetheless not possible if the class
struct is private.

----

I forgot to add that back yesterday. I don't think this changes any generated code except for `gstreamer-pbutils`