### PR TITLE
Few improvements on user callback generation

### DIFF
--- a/src/analysis/functions.rs
+++ b/src/analysis/functions.rs
@@ -867,6 +867,7 @@ fn analyze_callback(
                     0
                 },
                 destroy_index: 0,
+                nullable: par.nullable,
             }, match par.destroy_index {
                 Some(destroy_index) => Some(c_parameters[destroy_index].1),
                 None => None,

--- a/src/analysis/functions.rs
+++ b/src/analysis/functions.rs
@@ -388,8 +388,9 @@ fn analyze_function(
         match env.config.objects.get(&*full_name) {
             Some(obj) => {
                 match env.library.type_(type_tid) {
+                    // FIXME: Maybe check for interface and record here as well?
                     library::Type::Class(_) => obj.concurrency,
-                    _ => library::Concurrency::SendSync,
+                    _ => library::Concurrency::None,
                 }
             }
             None => library::Concurrency::SendSync,

--- a/src/analysis/functions.rs
+++ b/src/analysis/functions.rs
@@ -318,6 +318,14 @@ fn analyze_callbacks(
                                    func_name);
                         *commented = true;
                     }
+                    // We check if the user trampoline is there. If so, we change the destroy
+                    // nullable value if needed.
+                    for call in callbacks.iter() {
+                        if call.destroy_index == pos {
+                            callback.nullable = call.nullable;
+                            break
+                        }
+                    }
                     destroys.push(callback);
                     to_remove.push(pos);
                     continue;

--- a/src/analysis/functions.rs
+++ b/src/analysis/functions.rs
@@ -396,8 +396,9 @@ fn analyze_function(
         match env.config.objects.get(&*full_name) {
             Some(obj) => {
                 match env.library.type_(type_tid) {
-                    // FIXME: Maybe check for interface and record here as well?
-                    library::Type::Class(_) => obj.concurrency,
+                    library::Type::Class(_) |
+                    library::Type::Interface(_) |
+                    library::Type::Record(_) => obj.concurrency,
                     _ => library::Concurrency::None,
                 }
             }

--- a/src/analysis/rust_type.rs
+++ b/src/analysis/rust_type.rs
@@ -233,7 +233,9 @@ fn rust_type_full(
                 match rust_type(env, p.typ) {
                     Ok(x) => {
                         let is_fundamental = p.typ.is_fundamental_type(env);
-                        s.push(format!("{}{}", if is_fundamental { "" } else { "&" }, x));
+                        s.push(format!("{}{}",
+                                       if is_fundamental { "" } else { "&" },
+                                       if x != "GString" { x } else { "&str".to_owned() }));
                     }
                     e => {
                         err = true;

--- a/src/analysis/trampolines.rs
+++ b/src/analysis/trampolines.rs
@@ -31,6 +31,7 @@ pub struct Trampoline {
     /// It's used to group callbacks
     pub user_data_index: usize,
     pub destroy_index: usize,
+    pub nullable: library::Nullable,
 }
 
 pub type Trampolines = Vec<Trampoline>;
@@ -160,6 +161,7 @@ pub fn analyze(
         scope: library::ParameterScope::None,
         user_data_index: 0,
         destroy_index: 0,
+        nullable: library::Nullable(false),
     };
     trampolines.push(trampoline);
     Ok(name)

--- a/src/codegen/function_body_chunk.rs
+++ b/src/codegen/function_body_chunk.rs
@@ -264,7 +264,7 @@ impl Builder {
                                                       trampoline.name,
                                                       trampoline.bound_name)));
                 } else {
-                    chunks.push(Chunk::Custom(format!("let {0}_data: Option<{1}> = {0}.into();",
+                    chunks.push(Chunk::Custom(format!("let {0}_data: Option<{1}> = {0};",
                                                       trampoline.name,
                                                       trampoline.bound_name)));
                 }


### PR DESCRIPTION
Fixes #704.

This currently fixes two things:

* Remove the invalid indirection (`Box::<Option<X>>.as_ptr()` -> `&Box<Option<X>>` is not longer a thing)
* Added the missing `Option` <s>(yep, everything is an `Option` by default)</s> (it's now correctly handled everywhere)
* No more `GString` parameters: they're replaced with `&str` now
* Fix invalid Send/Sync bounds (by default, I was giving both of them :p)
* Fix invalid nullable "status" from destroy callbacks.

I intend to fix the other issues on this PR as well so please don't merge! :)