### PR TITLE
Fixup

### DIFF
--- a/src/analysis/function_parameters.rs
+++ b/src/analysis/function_parameters.rs
@@ -6,10 +6,11 @@ use env::Env;
 use library::{self, TypeId, ParameterScope};
 use nameutil;
 use super::conversion_type::ConversionType;
-use super::rust_type::rust_type;
-use super::ref_mode::RefMode;
 use super::out_parameters::can_as_return;
 use super::override_string_type::override_string_type_parameter;
+use super::rust_type::rust_type;
+use super::ref_mode::RefMode;
+use traits::MaybeRef;
 use traits::IntoString;
 
 //TODO: remove unused fields
@@ -248,8 +249,6 @@ pub fn analyze(
         let data_param_name = "user_data";
         let callback_param_name = "callback";
 
-        let mut nullable_into = false;
-
         if add_rust_parameter {
             let rust_par = RustParameter {
                 name: name.clone(),
@@ -262,6 +261,25 @@ pub fn analyze(
             ind_rust = None;
         }
 
+        let mut trans_nullable = false;
+        let type_ = env.type_(par.typ);
+        let to_glib_extra = if par.instance_parameter || !*nullable ||
+                               (!type_.is_interface() && !type_.is_class()) {
+            String::new()
+        } else {
+            trans_nullable = *nullable;
+            match type_.maybe_ref() {
+                Some(&library::Class { final_type, ..}) => {
+                    if final_type {
+                        String::new()
+                    } else {
+                        ".as_ref()".to_owned()
+                    }
+                }
+                None => String::new(),
+            }
+        };
+
         let transformation_type = match ConversionType::of(env, typ) {
             ConversionType::Direct => TransformationType::ToGlibDirect { name },
             ConversionType::Scalar => TransformationType::ToGlibScalar {
@@ -273,11 +291,11 @@ pub fn analyze(
                 instance_parameter: par.instance_parameter,
                 transfer,
                 ref_mode,
-                to_glib_extra: String::new(),
+                to_glib_extra,
                 explicit_target_type: String::new(),
                 pointer_cast: String::new(),
                 in_trait,
-                nullable: nullable_into,
+                nullable: trans_nullable,
             },
             ConversionType::Borrow => TransformationType::ToGlibBorrow,
             ConversionType::Unknown => TransformationType::ToGlibUnknown { name },

--- a/src/analysis/function_parameters.rs
+++ b/src/analysis/function_parameters.rs
@@ -10,7 +10,6 @@ use super::out_parameters::can_as_return;
 use super::override_string_type::override_string_type_parameter;
 use super::rust_type::rust_type;
 use super::ref_mode::RefMode;
-use traits::MaybeRef;
 use traits::IntoString;
 
 //TODO: remove unused fields
@@ -268,15 +267,10 @@ pub fn analyze(
             String::new()
         } else {
             trans_nullable = *nullable;
-            match type_.maybe_ref() {
-                Some(&library::Class { final_type, ..}) => {
-                    if final_type {
-                        String::new()
-                    } else {
-                        ".as_ref()".to_owned()
-                    }
-                }
-                None => String::new(),
+            if !type_.is_final_type() {
+                ".as_ref()".to_owned()
+            } else {
+                String::new()
             }
         };
 

--- a/src/codegen/function.rs
+++ b/src/codegen/function.rs
@@ -384,51 +384,51 @@ pub fn body_chunk_futures(env: &Env, analysis: &analysis::functions::Info) -> St
     }
 
     if env.config.library_name != "Gio" {
-        try!(writeln!(body, "    let cancellable = gio::Cancellable::new();"));
+        try!(writeln!(body, "\tlet cancellable = gio::Cancellable::new();"));
     } else {
-        try!(writeln!(body, "    let cancellable = Cancellable::new();"));
+        try!(writeln!(body, "\tlet cancellable = Cancellable::new();"));
     }
-    try!(writeln!(body, "    let send = Fragile::new(send);"));
+    try!(writeln!(body, "\tlet send = Fragile::new(send);"));
 
     if async_future.is_method {
-        try!(writeln!(body, "    let obj_clone = Fragile::new(obj.clone());"));
-        try!(writeln!(body, "    obj.{}(", analysis.name));
+        try!(writeln!(body, "\tlet obj_clone = Fragile::new(obj.clone());"));
+        try!(writeln!(body, "\tobj.{}(", analysis.name));
     } else if analysis.type_name.is_ok() {
-        try!(writeln!(body, "    Self::{}(", analysis.name));
+        try!(writeln!(body, "\tSelf::{}(", analysis.name));
     } else {
-        try!(writeln!(body, "    {}(", analysis.name));
+        try!(writeln!(body, "\t{}(", analysis.name));
     }
 
     // Skip the instance parameter
     for par in analysis.parameters.rust_parameters.iter().skip(skip) {
         if par.name == "cancellable" {
-            try!(writeln!(body, "         Some(&cancellable),"));
+            try!(writeln!(body, "\t\tSome(&cancellable),"));
         } else if par.name == "callback" {
             continue;
         } else {
             let c_par = &analysis.parameters.c_parameters[par.ind_c];
 
             if *c_par.nullable {
-                try!(writeln!(body, "         {}.as_ref().map(::std::borrow::Borrow::borrow),",
+                try!(writeln!(body, "\t\t{}.as_ref().map(::std::borrow::Borrow::borrow),",
                               par.name));
             } else if c_par.ref_mode != RefMode::None {
-                try!(writeln!(body, "         &{},", par.name));
+                try!(writeln!(body, "\t\t&{},", par.name));
             } else {
-                try!(writeln!(body, "         {},", par.name));
+                try!(writeln!(body, "\t\t{},", par.name));
             }
         }
     }
 
-    try!(writeln!(body, "         move |res| {{"));
+    try!(writeln!(body, "\t\tmove |res| {{"));
     if async_future.is_method {
-        try!(writeln!(body, "             let obj = obj_clone.into_inner();"));
-        try!(writeln!(body, "             let res = res.map(|v| (obj.clone(), v)).map_err(|v| (obj.clone(), v));"));
+        try!(writeln!(body, "\t\t\tlet obj = obj_clone.into_inner();"));
+        try!(writeln!(body, "\t\t\tlet res = res.map(|v| (obj.clone(), v)).map_err(|v| (obj.clone(), v));"));
     }
-    try!(writeln!(body, "             let _ = send.into_inner().send(res);"));
-    try!(writeln!(body, "         }},"));
-    try!(writeln!(body, "    );"));
+    try!(writeln!(body, "\t\t\tlet _ = send.into_inner().send(res);"));
+    try!(writeln!(body, "\t\t}},"));
+    try!(writeln!(body, "\t);"));
     try!(writeln!(body));
-    try!(writeln!(body, "    cancellable"));
+    try!(writeln!(body, "\tcancellable"));
     try!(writeln!(body, "}})"));
 
     Ok(body)

--- a/src/codegen/function_body_chunk.rs
+++ b/src/codegen/function_body_chunk.rs
@@ -322,7 +322,7 @@ impl Builder {
                                         Chunk::Custom(
                                             if !trampoline.scope.is_async() &&
                                                !trampoline.scope.is_call() {
-                                                format!("&({})", full_type)
+                                                format!("&{}", full_type)
                                             } else {
                                                 full_type.clone()
                                             }))),
@@ -383,7 +383,7 @@ impl Builder {
                         } else if trampoline.scope.is_call() {
                             format!("*mut {}", self.callbacks[0].bound_name)
                         } else {
-                            format!("&({})", self.callbacks[0].bound_name)
+                            format!("&{}", self.callbacks[0].bound_name)
                         }))),
                 }
             );

--- a/src/codegen/parameter.rs
+++ b/src/codegen/parameter.rs
@@ -25,6 +25,9 @@ impl ToParameter for CParameter {
                 Some((t, bound_type)) => {
                     match bound_type {
                         BoundType::NoWrapper => type_str = t.to_string(),
+                        BoundType::IsA(_) if *self.nullable => {
+                            type_str = format!("Option<&{}{}>", mut_str, t)
+                        }
                         BoundType::IsA(_) => {
                             type_str = format!("&{}{}", mut_str, t)
                         }

--- a/src/codegen/trampoline.rs
+++ b/src/codegen/trampoline.rs
@@ -142,7 +142,7 @@ fn func_parameter(
         Some((t, bound_type)) => match bound_type {
             BoundType::NoWrapper => unreachable!(),
             BoundType::IsA(_) => if *par.nullable {
-                format!("&Option<{}{}>", mut_str, t)
+                format!("Option<&{}{}>", mut_str, t)
             } else if let Some((from, to)) = bound_replace {
                 if from == t {
                     format!("&{}{}", mut_str, to)

--- a/src/codegen/translate_to_glib.rs
+++ b/src/codegen/translate_to_glib.rs
@@ -29,10 +29,10 @@ impl TranslateToGlib for TransformationType {
             } => {
                 let (left, right) = to_glib_xxx(transfer, ref_mode, explicit_target_type);
                 let to_glib_extra = if nullable && !to_glib_extra.is_empty() {
-                        format!(".map(|p| p{})", to_glib_extra)
-                    } else {
-                        to_glib_extra.clone()
-                    };
+                    format!(".map(|p| p{})", to_glib_extra)
+                } else {
+                    to_glib_extra.clone()
+                };
 
                 if instance_parameter {
                     format!("{}self{}{}{}", left, if in_trait { to_glib_extra } else { "".into() }, right, pointer_cast)

--- a/src/library.rs
+++ b/src/library.rs
@@ -813,6 +813,20 @@ impl Type {
             _ => false,
         }
     }
+
+    pub fn is_class(&self) -> bool {
+        match *self {
+            Type::Class(_) => true,
+            _ => false,
+        }
+    }
+
+    pub fn is_interface(&self) -> bool {
+        match *self {
+            Type::Interface(_) => true,
+            _ => false,
+        }
+    }
 }
 
 macro_rules! impl_maybe_ref {

--- a/src/library.rs
+++ b/src/library.rs
@@ -827,6 +827,13 @@ impl Type {
             _ => false,
         }
     }
+
+    pub fn is_final_type(&self) -> bool {
+        match *self {
+            Type::Class(Class { final_type, .. }) => final_type,
+            _ => false,
+        }
+    }
 }
 
 macro_rules! impl_maybe_ref {


### PR DESCRIPTION
Follow up of #724.

I still have an for the generation of `.map()`: I don't get how the rules work here. Why in some cases we do generate it and in other cases we don't?

It leads to errors such as:

```
error[E0283]: type annotations required: cannot resolve `gdk_pixbuf::Pixbuf: std::convert::AsRef<_>`
  --> src/auto/image.rs:78:84
   |
78 |             Widget::from_glib_none(ffi::gtk_image_new_from_pixbuf(pixbuf.map(|p| p.as_ref()).to_glib_none().0)).unsafe_cast()
   |                                                                                    ^^^^^^

error: aborting due to previous error
```