### PR TITLE
Allow nullable trampolines with scope="call"

### DIFF
--- a/src/codegen/function_body_chunk.rs
+++ b/src/codegen/function_body_chunk.rs
@@ -480,7 +480,7 @@ impl Builder {
             format!("::<{}>", bounds_names)
         };
         if !is_destroy {
-            if !trampoline.scope.is_call() && *trampoline.nullable {
+            if *trampoline.nullable {
                 chunks.push(Chunk::Custom(format!("let {0} = if {0}_data.is_some() {{ Some({0}_func{1} as _) }} else {{ None }};",
                                                   trampoline.name,
                                                   bounds_str)));


### PR DESCRIPTION
Part of https://github.com/gtk-rs/gdk/issues/287

changes only in gdk:
```diff
--- a/src/auto/seat.rs
+++ b/src/auto/seat.rs
@@ -91,7 +91,7 @@ impl Seat {
                 panic!("cannot get closure...")
             };
         }
-        let prepare_func = Some(prepare_func_func::<P> as _);
+        let prepare_func = if prepare_func_data.is_some() { Some(prepare_func_func::<P> as _) } else { None };
         let super_callback0: &Option<&mut dyn (FnMut(&Seat, &Window))> = &prepare_func_data;
         unsafe {
             from_glib(gdk_sys::gdk_seat_grab(self.to_glib_none().0, window.as_ref().to_glib_none().0, capabilities.to_glib(), owner_events.to_glib(), cursor.to_glib_none().0, event.to_glib_none().0, prepare_func, super_callback0 as *const _ as usize as *mut _))
```
```diff
--- a/src/auto/window.rs
+++ b/src/auto/window.rs
@@ -908,7 +908,7 @@ impl<O: IsA<Window>> WindowExt for O {
             };
             res.to_glib()
         }
-        let child_func = Some(child_func_func as _);
+        let child_func = if child_func_data.is_some() { Some(child_func_func as _) } else { None };
         let super_callback0: &Option<&mut dyn (FnMut(&Window) -> bool)> = &child_func_data;
         unsafe {
             gdk_sys::gdk_window_invalidate_maybe_recurse(self.as_ref().to_glib_none().0, region.to_glib_none().0, child_func, super_callback0 as *const _ as usize as *mut _);
```

@jangernert can you test this change just in case?

cc @GuillaumeGomez 