### PR TITLE
Force replacing '-' in crate name for `use`

### DIFF
--- a/src/codegen/sys/cargo_toml.rs
+++ b/src/codegen/sys/cargo_toml.rs
@@ -106,6 +106,7 @@ fn fill_in(root: &mut Table, env: &Env) {
 fn get_crate_name(config: &Config, root: &Table) -> String {
     if let Some(&Value::Table(ref lib)) = root.get("lib") {
         if let Some(&Value::String(ref lib_name)) = lib.get("name") {
+            //Converting don't needed as library target names cannot contain hyphens
             return lib_name.to_owned();
         }
     }

--- a/src/nameutil.rs
+++ b/src/nameutil.rs
@@ -55,7 +55,7 @@ pub fn file_name_sys(name: &str) -> String {
 
 /// Crate name with undescores for `use` statement
 pub fn crate_name(name: &str) -> String {
-    let name = name.to_snake();
+    let name = name.replace("-", "_").to_snake();
     let crate_name = if name.starts_with("g_") {
         format!("g{}", &name[2..])
     } else {


### PR DESCRIPTION
Refix #727 

cc @BrainBlasted

