### PR TITLE
library_postprocessing: Don't expect c:type for FixedArray

### DIFF
--- a/src/library_postprocessing.rs
+++ b/src/library_postprocessing.rs
@@ -316,6 +316,11 @@ impl Library {
                                 actions.push((tid, fid, Action::SetCType("void*".to_owned())));
                                 continue;
                             }
+                            if let Type::FixedArray(_, _, Some(ref c_type)) = *field_type {
+                                // fixed-size Arrays can only have inner c_type
+                                actions.push((tid, fid, Action::SetCType(c_type.clone())));
+                                continue;
+                            }
                             error!("Field `{}::{}` is missing c:type", name, &field.name);
                         }
                     },


### PR DESCRIPTION
As of https://gitlab.gnome.org/GNOME/gobject-introspection/commit/1f0965e379035be51ae96d5761358ec088fb3421,
fixed-size arrays are no longer generated with c:type, thus
we should not expect it of them.

Fixes https://github.com/gtk-rs/gir/issues/749