### PR TITLE
Port to futures 0.3

### DIFF
--- a/src/analysis/functions.rs
+++ b/src/analysis/functions.rs
@@ -581,7 +581,7 @@ fn analyze_function(
         imports.add("glib_sys", version);
         imports.add("gobject_sys", version);
         imports.add("std::ptr", version);
-        imports.add_with_constraint("futures_core", version, Some("futures"));
+        imports.add_with_constraint("futures::future", version, Some("futures"));
         imports.add_with_constraint("std::boxed::Box as Box_", version, Some("futures"));
 
         if let Some(ref trampoline) = trampoline {


### PR DESCRIPTION
While this requires nightly, the API is now stabilized and will become part of Rust 1.36. IMHO we should merge this now so that it can all get wider testing.