### PR TITLE
Generate builder for widgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,14 @@ manual = ["Gtk.Button"]
 
 So in here, both `GtkWidget` and `GtkWindow` will be fully generated and functions/methods using `GtkButton` will be uncommented. To generate code for all global functions, add `Gtk.*` to the `generate` array.
 
+To also generate a `Builder` struct for a widget, it needs to be added in the `generate_builders` array:
+
+```toml
+generate_builders = [
+    "Gtk.WindowBuilder",
+]
+```
+
 Sometimes Gir understands the object definition incorrectly or the `.gir` file contains an incomplete or wrong definition, to fix it, you can use the full object configuration:
 
 ```toml

--- a/src/analysis/object.rs
+++ b/src/analysis/object.rs
@@ -127,7 +127,7 @@ pub fn class(env: &Env, obj: &GObject, deps: &[library::TypeId]) -> Option<Info>
         obj,
         &mut imports,
     );
-    let (properties, builder_properties, notify_signals) = properties::analyze(
+    let (properties, mut builder_properties, notify_signals) = properties::analyze(
         env,
         &klass.properties,
         class_tid,
@@ -139,6 +139,29 @@ pub fn class(env: &Env, obj: &GObject, deps: &[library::TypeId]) -> Option<Info>
         deps,
         true,
     );
+
+    for &super_tid in env.class_hierarchy.supertypes(class_tid) {
+        let type_ = env.type_(super_tid);
+
+        let super_class: &library::Class = match type_.maybe_ref() {
+            Some(super_class) => super_class,
+            None => continue,
+        };
+
+        let (_, new_builder_properties, _) = properties::analyze(
+            env,
+            &super_class.properties,
+            super_tid,
+            !final_type,
+            &mut trampolines::Trampolines::with_capacity(0),
+            obj,
+            &mut imports,
+            &signatures,
+            deps,
+            true,
+        );
+        builder_properties.extend(new_builder_properties);
+    }
 
     let (version, deprecated_version) = info_base::versions(
         env,

--- a/src/analysis/object.rs
+++ b/src/analysis/object.rs
@@ -161,6 +161,12 @@ pub fn class(env: &Env, obj: &GObject, deps: &[library::TypeId]) -> Option<Info>
     // There's also no point in generating a trait for final types: there are no possible subtypes
     let generate_trait = !final_type && (has_signals || has_methods || !properties.is_empty() || !child_properties.is_empty());
 
+    if properties.iter().any(|property| property.construct || property.construct_only) {
+        imports.add("std::ffi::CString", None);
+        imports.add("glib::object::Cast", None);
+        imports.add("gtk::prelude::ToValue", None);
+    }
+
     if generate_trait {
         imports.add("glib::object::IsA", None);
     }

--- a/src/analysis/properties.rs
+++ b/src/analysis/properties.rs
@@ -1,4 +1,3 @@
-use analysis::bounds::Bound;
 use analysis::imports::Imports;
 use analysis::ref_mode::RefMode;
 use analysis::rust_type::*;
@@ -24,9 +23,6 @@ pub struct Property {
     pub set_in_ref_mode: RefMode,
     pub version: Option<Version>,
     pub deprecated_version: Option<Version>,
-    pub bound: Option<Bound>,
-    pub construct: bool,
-    pub construct_only: bool,
 }
 
 pub fn analyze(
@@ -39,9 +35,11 @@ pub fn analyze(
     imports: &mut Imports,
     signatures: &Signatures,
     deps: &[library::TypeId],
-) -> (Vec<Property>, Vec<signals::Info>) {
+    generate_builders: bool,
+) -> (Vec<Property>, Vec<Property>, Vec<signals::Info>) {
     let mut properties = Vec::new();
     let mut notify_signals = Vec::new();
+    let mut builder_properties = Vec::new();
 
     for prop in props {
         let configured_properties = obj.properties.matched(&prop.name);
@@ -53,7 +51,7 @@ pub fn analyze(
             continue;
         }
 
-        let (getter, setter, notify_signal) = analyze_property(
+        let (getter, setter, builder, notify_signal) = analyze_property(
             env,
             prop,
             type_tid,
@@ -64,7 +62,11 @@ pub fn analyze(
             imports,
             signatures,
             deps,
+            generate_builders,
         );
+        if let Some(builder) = builder {
+            builder_properties.push(builder);
+        }
 
         if let Some(notify_signal) = notify_signal {
             notify_signals.push(notify_signal);
@@ -96,18 +98,11 @@ pub fn analyze(
                 imports.add("glib::Value", prop.version);
             }
 
-            if let Some(ref bound, ..) = prop.bound {
-                if bound.bound_type.need_isa() {
-                    imports.add("glib::object::IsA", prop.version);
-                    imports.add("glib", prop.version);
-                }
-            }
-
             properties.push(prop);
         }
     }
 
-    (properties, notify_signals)
+    (properties, builder_properties, notify_signals)
 }
 
 fn analyze_property(
@@ -121,7 +116,8 @@ fn analyze_property(
     imports: &mut Imports,
     signatures: &Signatures,
     deps: &[library::TypeId],
-) -> (Option<Property>, Option<Property>, Option<signals::Info>) {
+    generate_builders: bool,
+) -> (Option<Property>, Option<Property>, Option<Property>, Option<signals::Info>) {
     let type_name = type_tid.full_name(&env.library);
     let name = prop.name.clone();
 
@@ -145,6 +141,7 @@ fn analyze_property(
     let check_get_func_name = format!("get_{}", name_for_func);
     let check_set_func_name = format!("set_{}", name_for_func);
 
+    let for_builder = (prop.construct_only || prop.construct || prop.writable) && generate_builders;
     let mut readable = prop.readable;
     let mut writable = if prop.construct_only {
         false
@@ -204,9 +201,6 @@ fn analyze_property(
             set_in_ref_mode,
             version: prop_version,
             deprecated_version: prop.deprecated_version,
-            bound: None,
-            construct: prop.construct,
-            construct_only: prop.construct_only,
         })
     } else {
         None
@@ -224,9 +218,6 @@ fn analyze_property(
             set_in_ref_mode,
             version: prop_version,
             deprecated_version: prop.deprecated_version,
-            bound: None,
-            construct: prop.construct,
-            construct_only: prop.construct_only,
         })
     } else {
         None
@@ -305,5 +296,25 @@ fn analyze_property(
         None
     };
 
-    (getter, setter, notify_signal)
+    let builder = if for_builder {
+        if let Ok(ref s) = used_rust_type(env, prop.typ, false) {
+            imports.add_used_type(s, prop.version);
+        }
+        Some(Property {
+            name: name.clone(),
+            var_name: String::new(),
+            typ: prop.typ,
+            is_get: false,
+            func_name: String::new(),
+            nullable,
+            get_out_ref_mode,
+            set_in_ref_mode,
+            version: prop_version,
+            deprecated_version: prop.deprecated_version,
+        })
+    } else {
+        None
+    };
+
+    (getter, setter, builder, notify_signal)
 }

--- a/src/analysis/properties.rs
+++ b/src/analysis/properties.rs
@@ -141,7 +141,8 @@ fn analyze_property(
     let check_get_func_name = format!("get_{}", name_for_func);
     let check_set_func_name = format!("set_{}", name_for_func);
 
-    let for_builder = (prop.construct_only || prop.construct || prop.writable) && generate_builders;
+    let for_builder = env.config.objects.get(&format!("{}Builder", obj.name)).is_some() &&
+        (prop.construct_only || prop.construct || prop.writable) && generate_builders;
     let mut readable = prop.readable;
     let mut writable = if prop.construct_only {
         false

--- a/src/analysis/properties.rs
+++ b/src/analysis/properties.rs
@@ -1,4 +1,5 @@
 use analysis::bounds::Bound;
+use analysis::function_parameters::TransformationType;
 use analysis::imports::Imports;
 use analysis::ref_mode::RefMode;
 use analysis::rust_type::*;
@@ -9,6 +10,7 @@ use config::{self, GObject, PropertyGenerateFlags};
 use env::Env;
 use library;
 use nameutil;
+use super::conversion_type::ConversionType;
 use traits::*;
 use version::Version;
 
@@ -16,6 +18,7 @@ use version::Version;
 pub struct Property {
     pub name: String,
     pub var_name: String,
+    pub c_type: Option<String>,
     pub typ: library::TypeId,
     pub is_get: bool,
     pub func_name: String,
@@ -25,6 +28,9 @@ pub struct Property {
     pub version: Option<Version>,
     pub deprecated_version: Option<Version>,
     pub bound: Option<Bound>,
+    pub construct: bool,
+    pub construct_only: bool,
+    pub transformation_type: TransformationType,
 }
 
 pub fn analyze(
@@ -189,10 +195,36 @@ fn analyze_property(
         set_in_ref_mode = RefMode::ByRef;
     }
     let nullable = library::Nullable(set_in_ref_mode.is_ref());
+
+    let transformation_type = {
+        let name = nameutil::mangle_keywords(nameutil::signal_to_snake(&name)).to_string();
+        match ConversionType::of(env, prop.typ) {
+            ConversionType::Direct => TransformationType::ToGlibDirect { name: name.clone() },
+            ConversionType::Scalar => TransformationType::ToGlibScalar {
+                name: name.clone(),
+                nullable,
+            },
+            ConversionType::Pointer => TransformationType::ToGlibPointer {
+                name: name.clone(),
+                instance_parameter: false,
+                transfer: library::Transfer::None,
+                ref_mode: set_in_ref_mode,
+                to_glib_extra: String::new(),
+                explicit_target_type: String::new(),
+                pointer_cast: String::new(),
+                in_trait: false,
+                nullable: false,
+            },
+            ConversionType::Borrow => TransformationType::ToGlibBorrow,
+            ConversionType::Unknown => TransformationType::ToGlibUnknown { name: name.clone() },
+        }
+    };
+
     let getter = if readable {
         Some(Property {
             name: name.clone(),
             var_name: String::new(),
+            c_type: prop.c_type.clone(),
             typ: prop.typ,
             is_get: true,
             func_name: get_func_name,
@@ -202,6 +234,9 @@ fn analyze_property(
             version: prop_version,
             deprecated_version: prop.deprecated_version,
             bound: None,
+            construct: prop.construct,
+            construct_only: prop.construct_only,
+            transformation_type: transformation_type.clone(),
         })
     } else {
         None
@@ -211,6 +246,7 @@ fn analyze_property(
         Some(Property {
             name: name.clone(),
             var_name,
+            c_type: prop.c_type.clone(),
             typ: prop.typ,
             is_get: false,
             func_name: set_func_name,
@@ -220,6 +256,9 @@ fn analyze_property(
             version: prop_version,
             deprecated_version: prop.deprecated_version,
             bound: None,
+            construct: prop.construct,
+            construct_only: prop.construct_only,
+            transformation_type,
         })
     } else {
         None

--- a/src/codegen/object.rs
+++ b/src/codegen/object.rs
@@ -113,7 +113,7 @@ pub fn generate(
     }
 
     // TODO: include parent properties.
-    if !analysis.builder_properties.is_empty() {
+    if env.config.objects.get(&format!("{}Builder", analysis.base.full_name)).is_some() && !analysis.builder_properties.is_empty() {
         generate_builder(w, env, analysis)?;
     }
 
@@ -201,7 +201,9 @@ pub struct {}Builder {{", analysis.name)?;
                 let name = nameutil::mangle_keywords(nameutil::signal_to_snake(&property.name));
                 version_condition(w, env, property.version, false, 1)?;
                 writeln!(w, "    {}: Option<{}>,", name, type_string)?;
-                let prefix = version_condition_string(env, property.version, false, 1).unwrap_or_default();
+                let prefix = version_condition_string(env, property.version, false, 1)
+                    .map(|version| format!("{}\n", version))
+                    .unwrap_or_default();
                 methods.push(format!("\n{prefix}    pub fn {name}(mut self, {name}: {param_type}) -> Self {{
         self.{name} = Some({name}{conversion});
         self

--- a/src/codegen/object.rs
+++ b/src/codegen/object.rs
@@ -113,7 +113,7 @@ pub fn generate(
     }
 
     // TODO: include parent properties.
-    if env.config.objects.get(&format!("{}Builder", analysis.base.full_name)).is_some() && !analysis.builder_properties.is_empty() {
+    if !analysis.builder_properties.is_empty() {
         generate_builder(w, env, analysis)?;
     }
 
@@ -179,6 +179,7 @@ pub fn generate(
     Ok(())
 }
 
+// TODO: instead create a Vec<> inside the Builder instead of Options.
 fn generate_builder(w: &mut Write, env: &Env, analysis: &analysis::object::Info) -> Result<()> {
     let mut methods = vec![];
     let mut properties = vec![];
@@ -238,7 +239,7 @@ impl {}Builder {{
         writeln!(w,
 "        if let Some(ref {property}) = self.{property} {{
             properties.push((\"{}\", {property}));
-        }}", property = name)?;
+        }}", property.name, property = name)?;
         if property.version.is_some() {
             writeln!(w, "        }}")?;
         }

--- a/src/codegen/properties.rs
+++ b/src/codegen/properties.rs
@@ -1,6 +1,5 @@
 use std::io::{Result, Write};
 
-use analysis::bounds::Bound;
 use analysis::properties::Property;
 use analysis::rust_type::{parameter_rust_type, rust_type};
 use chunk::Chunk;
@@ -75,59 +74,15 @@ fn generate_prop_func(
 }
 
 fn declaration(env: &Env, prop: &Property) -> String {
-    let mut bound = String::new();
+    let bound = String::new();
     let set_param = if prop.is_get {
         "".to_string()
     } else {
         let dir = library::ParameterDirection::In;
-        let param_type = if let Some(Bound {
-            alias,
-            ref type_str,
-            ref bound_type,
-            ..
-        }) = prop.bound
-        {
-            use library::Type::*;
-
-            let type_ = env.library.type_(prop.typ);
-            let bound_type = match *type_ {
-                Fundamental(_) => Some(bound_type.clone()),
-                _ => None,
-            };
-            match bound_type {
-                Some(_) => {
-                    let value_bound = if !prop.is_get {
-                        if *prop.nullable {
-                            " + glib::value::SetValueOptional"
-                        } else {
-                            " + glib::value::SetValue"
-                        }
-                    } else {
-                        ""
-                    };
-                    bound = format!(
-                        "<{}: IsA<{}>{}>",
-                        alias,
-                        type_str,
-                        value_bound
-                    );
-                    if *prop.nullable {
-                        format!("Option<&{}>", alias)
-                    } else {
-                        format!("&{}", alias)
-                    }
-                }
-                _ => {
-                    parameter_rust_type(env, prop.typ, dir, prop.nullable, prop.set_in_ref_mode,
-                                        library::ParameterScope::None)
-                        .into_string()
-                }
-            }
-        } else {
+        let param_type =
             parameter_rust_type(env, prop.typ, dir, prop.nullable, prop.set_in_ref_mode,
                                 library::ParameterScope::None)
-                .into_string()
-        };
+                .into_string();
         format!(", {}: {}", prop.var_name, param_type)
     };
     let return_str = if prop.is_get {

--- a/src/codegen/properties.rs
+++ b/src/codegen/properties.rs
@@ -74,11 +74,13 @@ fn generate_prop_func(
     Ok(())
 }
 
-pub fn property_type(env: &Env, prop: &Property) -> (String, String) {
+fn declaration(env: &Env, prop: &Property) -> String {
     let mut bound = String::new();
-    let dir = library::ParameterDirection::In;
-    let typ =
-        if let Some(Bound {
+    let set_param = if prop.is_get {
+        "".to_string()
+    } else {
+        let dir = library::ParameterDirection::In;
+        let param_type = if let Some(Bound {
             alias,
             ref type_str,
             ref bound_type,
@@ -126,16 +128,6 @@ pub fn property_type(env: &Env, prop: &Property) -> (String, String) {
                                 library::ParameterScope::None)
                 .into_string()
         };
-    (typ, bound)
-}
-
-fn declaration(env: &Env, prop: &Property) -> String {
-    let mut bound = String::new();
-    let set_param = if prop.is_get {
-        "".to_string()
-    } else {
-        let (param_type, new_bound) = property_type(env, prop);
-        bound = new_bound;
         format!(", {}: {}", prop.var_name, param_type)
     };
     let return_str = if prop.is_get {

--- a/src/codegen/properties.rs
+++ b/src/codegen/properties.rs
@@ -74,13 +74,11 @@ fn generate_prop_func(
     Ok(())
 }
 
-fn declaration(env: &Env, prop: &Property) -> String {
+pub fn property_type(env: &Env, prop: &Property) -> (String, String) {
     let mut bound = String::new();
-    let set_param = if prop.is_get {
-        "".to_string()
-    } else {
-        let dir = library::ParameterDirection::In;
-        let param_type = if let Some(Bound {
+    let dir = library::ParameterDirection::In;
+    let typ =
+        if let Some(Bound {
             alias,
             ref type_str,
             ref bound_type,
@@ -128,6 +126,16 @@ fn declaration(env: &Env, prop: &Property) -> String {
                                 library::ParameterScope::None)
                 .into_string()
         };
+    (typ, bound)
+}
+
+fn declaration(env: &Env, prop: &Property) -> String {
+    let mut bound = String::new();
+    let set_param = if prop.is_get {
+        "".to_string()
+    } else {
+        let (param_type, new_bound) = property_type(env, prop);
+        bound = new_bound;
         format!(", {}: {}", prop.var_name, param_type)
     };
     let return_str = if prop.is_get {

--- a/src/config/gobjects.rs
+++ b/src/config/gobjects.rs
@@ -20,6 +20,7 @@ use analysis::{ref_mode, conversion_type};
 pub enum GStatus {
     Manual, // already generated
     Generate,
+    Generate_Builders,
     Comment,
     Ignore,
 }
@@ -48,6 +49,7 @@ impl FromStr for GStatus {
         match s {
             "manual" => Ok(GStatus::Manual),
             "generate" => Ok(GStatus::Generate),
+            "generate_builders" => Ok(GStatus::Generate_Builders),
             "comment" => Ok(GStatus::Comment),
             "ignore" => Ok(GStatus::Ignore),
             e => Err(format!("Wrong object status: \"{}\"", e)),
@@ -349,7 +351,7 @@ pub fn parse_status_shorthands(
     generate_display_trait: bool,
 ) {
     use self::GStatus::*;
-    for &status in &[Manual, Generate, Comment, Ignore] {
+    for &status in &[Manual, Generate, Generate_Builders, Comment, Ignore] {
         parse_status_shorthand(objects, status, toml, concurrency, generate_display_trait);
     }
 }


### PR DESCRIPTION
The usage of the generated code looks like:
```rust
let button = LockButtonBuilder::new()
    .text_lock("Verrouiller")
    .text_unlock("Déverrouiller")
    .build();
```
This creates a `gtk::LockButton` and set the properties `text_lock` and `text_unlock` at the widget construction.

The generated code looks like:
```rust
#[cfg(any(feature = "builders", feature = "dox"))]
pub struct LockButtonBuilder {
    #[cfg(any(feature = "v3_14", feature = "dox"))]
    text_lock: Option<String>,
    #[cfg(any(feature = "v3_14", feature = "dox"))]
    text_unlock: Option<String>,
    // ...
}

#[cfg(any(feature = "builders", feature = "dox"))]
impl LockButtonBuilder {
    pub fn new() -> Self {
        Self {
            #[cfg(any(feature = "v3_14", feature = "dox"))]
            text_lock: None,
            #[cfg(any(feature = "v3_14", feature = "dox"))]
            text_unlock: None,
            #[cfg(any(feature = "v3_14", feature = "dox"))]
            tooltip_lock: None,
            #[cfg(any(feature = "v3_14", feature = "dox"))]
            tooltip_not_authorized: None,
            #[cfg(any(feature = "v3_14", feature = "dox"))]
            tooltip_unlock: None,
        }
    }
    pub fn build(self) -> LockButton {
        let mut n_properties = 0;
        let mut property_names: Vec<CString> = vec![];
        let mut names = vec![];
        let mut values = vec![];
        #[cfg(any(feature = "v3_14", feature = "dox"))]
        {
        if let Some(text_lock) = self.text_lock {
            property_names.push(CString::new("text-lock").unwrap());
            names.push(property_names[property_names.len() - 1].as_ptr());
            let property = text_lock.to_value();
            values.push(property.into_raw());
            n_properties += 1;
        }
        }
        #[cfg(any(feature = "v3_14", feature = "dox"))]
        {
        if let Some(text_unlock) = self.text_unlock {
            property_names.push(CString::new("text-unlock").unwrap());
            names.push(property_names[property_names.len() - 1].as_ptr());
            let property = text_unlock.to_value();
            values.push(property.into_raw());
            n_properties += 1;
        }
        }
        // ...
        unsafe {
            crate::Object::from_glib_none(gobject_sys::g_object_new_with_properties(
                LockButton::static_type().to_glib(), n_properties, names.as_mut_ptr(), values.as_ptr())
            as *mut _).downcast().expect("downcast")
        }
    }
    #[cfg(any(feature = "v3_14", feature = "dox"))]
    pub fn text_lock(mut self, text_lock: &str) -> Self {
        self.text_lock = Some(text_lock.to_string());
        self
    }
    #[cfg(any(feature = "v3_14", feature = "dox"))]
    pub fn text_unlock(mut self, text_unlock: &str) -> Self {
        self.text_unlock = Some(text_unlock.to_string());
        self
    }
    // ...
}
```