### PR TITLE
Improve gir errors a bit

### DIFF
--- a/src/xmlparser.rs
+++ b/src/xmlparser.rs
@@ -37,7 +37,11 @@ struct ErrorEmitter {
 impl ErrorEmitter {
     pub fn emit(&self, message: &str, position: TextPosition) -> String {
         let enriched = match self.path {
-            Some(ref path) => format!("{}:{}: {}", path.display(), position, message),
+            Some(ref path) => format!("{} at line {}:{}: {}",
+                                      path.display(),
+                                      position.row,
+                                      position.column,
+                                      message),
             None => format!("{} {}", position, message),
         };
         format!("GirXml: {}", enriched)


### PR DESCRIPTION
Part of #681.

cc @bochecha @EPashkin @sdroege 

Errors look like this now (not much changes but that's a start!):

```
GirXml: ../gir-files/GLib-2.0.gir at line 31840:10: <type> element is missing a name attribute
```