### PR TITLE
Builder setters accept references

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,10 +126,10 @@ manual = ["Gtk.Button"]
 
 So in here, both `GtkWidget` and `GtkWindow` will be fully generated and functions/methods using `GtkButton` will be uncommented. To generate code for all global functions, add `Gtk.*` to the `generate` array.
 
-To also generate a `Builder` struct for a widget, it needs to be added in the `generate_builders` array:
+To also generate a `Builder` struct for a widget, it needs to be added in the `builders` array:
 
 ```toml
-generate_builders = [
+builders = [
     "Gtk.WindowBuilder",
 ]
 ```

--- a/README.md
+++ b/README.md
@@ -126,12 +126,18 @@ manual = ["Gtk.Button"]
 
 So in here, both `GtkWidget` and `GtkWindow` will be fully generated and functions/methods using `GtkButton` will be uncommented. To generate code for all global functions, add `Gtk.*` to the `generate` array.
 
-To also generate a `Builder` struct for a widget, it needs to be added in the `builders` array:
+To also generate a `Builder` struct for a widget, it needs to be added in the `builders` array or set `generate_builder` flag in object configuration:
 
 ```toml
 builders = [
-    "Gtk.WindowBuilder",
+    "Gtk.AboutDialog",    # generated object name
+    "Gtk.WindowBuilder",  # or name with suffix Builder
 ]
+
+[[object]]
+name = "Gtk.TreeView"
+status = "generate"
+generate_builder = true
 ```
 
 Sometimes Gir understands the object definition incorrectly or the `.gir` file contains an incomplete or wrong definition, to fix it, you can use the full object configuration:
@@ -156,6 +162,8 @@ version = "3.12"
 cfg_condition = "mycond"
 # if you want to override default option Ex. for write your own Display implementation
 generate_display_trait = false
+# if you want to generate builder with name SomeClassBuilder
+generate_builder = true
     # define overrides for function
     [[object.function]]
     # filter functions from object

--- a/src/analysis/class_builder.rs
+++ b/src/analysis/class_builder.rs
@@ -17,11 +17,7 @@ pub fn analyze(
     obj: &GObject,
     imports: &mut Imports,
 ) -> Vec<Property> {
-    let generate_builders = env
-        .config
-        .objects
-        .contains_key(&format!("{}Builder", obj.name));
-    if !generate_builders {
+    if !obj.generate_builder {
         return Vec::new();
     }
 

--- a/src/case.rs
+++ b/src/case.rs
@@ -31,13 +31,11 @@ impl CaseExt for str {
                 true
             } else if c.is_lowercase() {
                 false
-            } else if c == '.' {
-                true
             } else {
                 upper
             };
 
-            if !upper && next_upper && c != '.' {
+            if !upper && next_upper {
                 s.push('_');
             } else if upper && !next_upper && upper_count >= 3 {
                 let n = s.len() - s.chars().next_back().unwrap().len_utf8();
@@ -96,10 +94,6 @@ mod tests {
             ("FooBarBaz", "foo_bar_baz"),
             ("aBcDe", "a_bc_de"),
             ("aXXbYYc", "a_xxb_yyc"),
-            ("options.GenerateBuilders", "options.generate_builders"),
-            ("options.Generate", "options.generate"),
-            ("options.Manual", "options.manual"),
-            ("options.Ignore", "options.ignore"),
         ];
 
         for &(input, expected) in &cases {

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -163,6 +163,7 @@ impl Config {
             .map(|t| gobjects::parse_toml(t, concurrency, generate_display_trait))
             .unwrap_or_default();
         gobjects::parse_status_shorthands(&mut objects, &toml, concurrency, generate_display_trait);
+        gobjects::parse_builders(&mut objects, &toml);
 
         let external_libraries = read_external_libraries(&toml)?;
 

--- a/src/config/gobjects.rs
+++ b/src/config/gobjects.rs
@@ -24,7 +24,6 @@ use toml::Value;
 pub enum GStatus {
     Manual,
     Generate,
-    Comment,
     Ignore,
 }
 
@@ -34,9 +33,6 @@ impl GStatus {
     }
     pub fn need_generate(self) -> bool {
         self == GStatus::Generate
-    }
-    pub fn normal(self) -> bool {
-        self == GStatus::Generate || self == GStatus::Manual
     }
 }
 
@@ -52,7 +48,6 @@ impl FromStr for GStatus {
         match s {
             "manual" => Ok(GStatus::Manual),
             "generate" => Ok(GStatus::Generate),
-            "comment" => Ok(GStatus::Comment),
             "ignore" => Ok(GStatus::Ignore),
             e => Err(format!("Wrong object status: \"{}\"", e)),
         }
@@ -368,7 +363,7 @@ pub fn parse_status_shorthands(
     generate_display_trait: bool,
 ) {
     use self::GStatus::*;
-    for &status in &[Manual, Generate, Comment, Ignore] {
+    for &status in &[Manual, Generate, Ignore] {
         parse_status_shorthand(objects, status, toml, concurrency, generate_display_trait);
     }
 }

--- a/src/config/gobjects.rs
+++ b/src/config/gobjects.rs
@@ -22,9 +22,9 @@ use toml::Value;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum GStatus {
-    Manual, // already generated
+    Manual,
     Generate,
-    GenerateBuilders,
+    Builders,
     Comment,
     Ignore,
 }
@@ -53,7 +53,7 @@ impl FromStr for GStatus {
         match s {
             "manual" => Ok(GStatus::Manual),
             "generate" => Ok(GStatus::Generate),
-            "generate_builders" => Ok(GStatus::GenerateBuilders),
+            "builders" => Ok(GStatus::Builders),
             "comment" => Ok(GStatus::Comment),
             "ignore" => Ok(GStatus::Ignore),
             e => Err(format!("Wrong object status: \"{}\"", e)),
@@ -362,7 +362,7 @@ pub fn parse_status_shorthands(
     generate_display_trait: bool,
 ) {
     use self::GStatus::*;
-    for &status in &[Manual, Generate, GenerateBuilders, Comment, Ignore] {
+    for &status in &[Manual, Generate, Builders, Comment, Ignore] {
         parse_status_shorthand(objects, status, toml, concurrency, generate_display_trait);
     }
 }

--- a/src/config/gobjects.rs
+++ b/src/config/gobjects.rs
@@ -9,7 +9,6 @@ use super::{
 };
 use crate::{
     analysis::{conversion_type, ref_mode},
-    case::CaseExt,
     config::{
         error::TomlHelper,
         parsable::{Parsable, Parse},
@@ -375,7 +374,7 @@ fn parse_status_shorthand(
     concurrency: library::Concurrency,
     generate_display_trait: bool,
 ) {
-    let name = format!("options.{:?}", status).to_snake();
+    let name = format!("options.{:?}", status).to_ascii_lowercase();
     if let Some(a) = toml.lookup(&name).map(|a| a.as_array().unwrap()) {
         for name_ in a.iter().map(|s| s.as_str().unwrap()) {
             match objects.get(name_) {


### PR DESCRIPTION
Close #763
Makes minor fixes after #757, #764

```diff
+++ b/src/auto/about_dialog.rs
@@ -505,8 +505,8 @@ impl AboutDialogBuilder {
         self
     }
 
-    pub fn logo(mut self, logo: gdk_pixbuf::Pixbuf) -> Self {
-        self.logo = Some(logo);
+    pub fn logo(mut self, logo: &gdk_pixbuf::Pixbuf) -> Self {
+        self.logo = Some(logo.clone());
         self
     }
```
Only changes classes parameters, vector functions remain unchanged
```rust
    pub fn artists(mut self, artists: Vec<String>) -> Self {
        self.artists = Some(artists);
        self
    }
```

cc @GuillaumeGomez , @sdroege , @antoyo 