### PR TITLE
Use complete pointer type for trampoline return

### DIFF
--- a/src/codegen/function_body_chunk.rs
+++ b/src/codegen/function_body_chunk.rs
@@ -613,12 +613,10 @@ impl Builder {
             body: Box::new(Chunk::Chunks(body)),
             return_value: if trampoline.ret.c_type != "void" {
                 let p = &trampoline.ret;
-                Some(if p.c_type == "gpointer" {
-                    "glib_sys::gpointer".to_string()
-                } else {
+                Some(
                     crate::analysis::ffi_type::ffi_type(env, p.typ, &p.c_type)
-                        .expect("failed to write c_type")
-                })
+                        .expect("failed to write c_type"),
+                )
             } else {
                 None
             },


### PR DESCRIPTION
`gpointer` mismatches with callback return type generated [here](https://github.com/gtk-rs/gir/blob/4618ddbc20ce0dd7799832faa9d5a961b1be4075/src/codegen/sys/functions.rs#L265).

Example: [GtkMapListModelMapFunc](https://developer.gnome.org/gtk4/unstable/gtk4-GtkMapListModel.html#GtkMapListModelMapFunc) in gtk4.

cc @GuillaumeGomez @sdroege