### PR TITLE
Rename trait instead hiding, because your minimum version 1.31 don't …

### DIFF
--- a/src/analysis/properties.rs
+++ b/src/analysis/properties.rs
@@ -227,8 +227,8 @@ fn analyze_property(
     };
 
     if !generate_trait && (writable || readable || notifiable) {
-        //Don't bring trait into scope to resolve conflict with OSTree::ObjectType
-        imports.add("glib::object::ObjectType as _", prop_version);
+        //To resolve a conflict with OSTree::ObjectType
+        imports.add("glib::object::ObjectType as ObjectType_", prop_version);
     }
 
     let notify_signal = if notifiable {

--- a/src/analysis/signals.rs
+++ b/src/analysis/signals.rs
@@ -102,8 +102,8 @@ fn analyze_signal(
         if in_trait {
             imports.add("glib::object::Cast", version);
         } else {
-            //Don't bring trait into scope to resolve conflict with OSTree::ObjectType
-            imports.add("glib::object::ObjectType as _", version);
+            //To resolve a conflict with OSTree::ObjectType
+            imports.add("glib::object::ObjectType as ObjectType_", version);
         }
         imports.add("glib::signal::connect_raw", version);
         imports.add("glib::signal::SignalHandlerId", version);


### PR DESCRIPTION
…support this

Part of #772

cc @GuillaumeGomez, @sdroege, @fkrull