### PR TITLE
Use Option<&T> instead of &Option<T> for signal callback parameters

### DIFF
--- a/src/analysis/rust_type.rs
+++ b/src/analysis/rust_type.rs
@@ -274,9 +274,17 @@ pub fn rust_type_full(
                         let y = rust_type(env, p.typ).unwrap_or_else(|_| String::new());
                         s.push(format!(
                             "{}{}",
-                            if is_fundamental { "" } else { "&" },
+                            if is_fundamental || *p.nullable {
+                                ""
+                            } else {
+                                "&"
+                            },
                             if y != "GString" {
-                                x
+                                if !is_fundamental && *p.nullable {
+                                    x.replace("Option<", "Option<&")
+                                } else {
+                                    x
+                                }
                             } else if *p.nullable {
                                 "Option<&str>".to_owned()
                             } else {

--- a/src/codegen/trampoline.rs
+++ b/src/codegen/trampoline.rs
@@ -160,7 +160,7 @@ fn func_parameter(
                 ref_mode,
                 library::ParameterScope::None,
             );
-            rust_type.into_string().replace("Option<&", "&Option<")
+            rust_type.into_string()
         }
     }
 }
@@ -246,7 +246,7 @@ fn trampoline_call_parameters(env: &Env, analysis: &Trampoline, in_trait: bool) 
                 continue;
             }
         };
-        let par_str = transformation.trampoline_from_glib(env, need_downcast);
+        let par_str = transformation.trampoline_from_glib(env, need_downcast, *par.nullable);
         parameter_strs.push(par_str);
         need_downcast = false; //Only downcast first parameter
     }


### PR DESCRIPTION
See https://github.com/gtk-rs/gir/issues/777

Next step is to do the same for callbacks passed to functions. That apparently does not even use the same machinery to find the correct type mappings between Rust and FFI types.

@GuillaumeGomez Any hint where to look and why you didn't use the `trampoline_from_glib` function?