### PR TITLE
Declare parameter to be mut if necessary

### DIFF
--- a/src/codegen/function.rs
+++ b/src/codegen/function.rs
@@ -59,7 +59,7 @@ pub fn generate(
         }
         Visibility::Hidden => return Ok(()),
     }
-    let declaration = declaration(env, analysis);
+    let declaration = declaration(env, analysis, only_declaration);
     let suffix = if only_declaration { ";" } else { " {" };
 
     writeln!(w)?;
@@ -88,7 +88,7 @@ pub fn generate(
     }
 
     if analysis.async_future.is_some() {
-        let declaration = declaration_futures(env, analysis);
+        let declaration = declaration_futures(env, analysis, only_declaration);
         let suffix = if only_declaration { ";" } else { " {" };
 
         writeln!(w)?;
@@ -132,7 +132,11 @@ pub fn generate(
     Ok(())
 }
 
-pub fn declaration(env: &Env, analysis: &analysis::functions::Info) -> String {
+pub fn declaration(
+    env: &Env,
+    analysis: &analysis::functions::Info,
+    only_declaration: bool,
+) -> String {
     let outs_as_return = !analysis.outs.is_empty();
     let return_str = if outs_as_return {
         out_parameters_as_return(env, analysis)
@@ -154,7 +158,7 @@ pub fn declaration(env: &Env, analysis: &analysis::functions::Info) -> String {
             param_str.push_str(", ")
         }
         let c_par = &analysis.parameters.c_parameters[par.ind_c];
-        let s = c_par.to_parameter(env, &analysis.bounds);
+        let s = c_par.to_parameter(env, &analysis.bounds, only_declaration);
         param_str.push_str(&s);
     }
 
@@ -164,7 +168,11 @@ pub fn declaration(env: &Env, analysis: &analysis::functions::Info) -> String {
     )
 }
 
-pub fn declaration_futures(env: &Env, analysis: &analysis::functions::Info) -> String {
+pub fn declaration_futures(
+    env: &Env,
+    analysis: &analysis::functions::Info,
+    only_declaration: bool,
+) -> String {
     let async_future = analysis.async_future.as_ref().unwrap();
 
     let return_str = format!(
@@ -194,7 +202,7 @@ pub fn declaration_futures(env: &Env, analysis: &analysis::functions::Info) -> S
             param_str.push_str(", ")
         }
 
-        let s = c_par.to_parameter(env, &analysis.bounds);
+        let s = c_par.to_parameter(env, &analysis.bounds, only_declaration);
         param_str.push_str(&s);
     }
 

--- a/src/codegen/parameter.rs
+++ b/src/codegen/parameter.rs
@@ -11,11 +11,11 @@ use crate::{
 };
 
 pub trait ToParameter {
-    fn to_parameter(&self, env: &Env, bounds: &Bounds) -> String;
+    fn to_parameter(&self, env: &Env, bounds: &Bounds, only_declaration: bool) -> String;
 }
 
 impl ToParameter for CParameter {
-    fn to_parameter(&self, env: &Env, bounds: &Bounds) -> String {
+    fn to_parameter(&self, env: &Env, bounds: &Bounds, only_declaration: bool) -> String {
         let mut_str = if self.ref_mode == RefMode::ByRefMut {
             "mut "
         } else {
@@ -50,11 +50,21 @@ impl ToParameter for CParameter {
                     }
                 }
             }
-            format_parameter(&self.name, &type_str)
+            let name_mod = if !only_declaration
+                && self.ref_mode == RefMode::ByRefMut
+                && !type_str.starts_with("&mut ")
+                && !type_str.starts_with("/*")
+            {
+                "mut "
+            } else {
+                ""
+            };
+
+            format_parameter(name_mod, &self.name, &type_str)
         }
     }
 }
 
-fn format_parameter(name: &str, type_str: &str) -> String {
-    format!("{}: {}", name, type_str)
+fn format_parameter(name_mod: &str, name: &str, type_str: &str) -> String {
+    format!("{}{}: {}", name_mod, name, type_str)
 }


### PR DESCRIPTION
Diff (gtk4):
```diff
diff --git a/src/auto/entry.rs b/src/auto/entry.rs
--- a/src/auto/entry.rs
+++ b/src/auto/entry.rs
@@ -647,7 +647,7 @@ impl<O: IsA<Entry>> EntryExt for O {
         }
     }
 
-    fn set_tabs(&self, tabs: Option<&mut pango::TabArray>) {
+    fn set_tabs(&self, mut tabs: Option<&mut pango::TabArray>) {
         unsafe {
             gtk_sys::gtk_entry_set_tabs(self.as_ref().to_glib_none().0, tabs.to_glib_none_mut().0);
         }
diff --git a/src/auto/text.rs b/src/auto/text.rs
--- a/src/auto/text.rs
+++ b/src/auto/text.rs
@@ -180,7 +180,7 @@ impl Text {
         }
     }
 
-    pub fn set_tabs(&self, tabs: Option<&mut pango::TabArray>) {
+    pub fn set_tabs(&self, mut tabs: Option<&mut pango::TabArray>) {
         unsafe {
             gtk_sys::gtk_text_set_tabs(self.to_glib_none().0, tabs.to_glib_none_mut().0);
         }
```

cc @EPashkin @sdroege