### PR TITLE
Add overriding for function trait for manual implemented functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,9 @@ generate_builder = true
     doc_hidden = true
     # disable length_of autodetection
     disable_length_detect = true
+    # write function docs to trait other than default "xxxExt",
+    # also works in [object.signal] and [object.property]
+    doc_trait_name = "SocketListenerExtManual"
         # override for parameter
         [[object.function.parameter]]
         # filter by name

--- a/src/config/functions.rs
+++ b/src/config/functions.rs
@@ -166,6 +166,7 @@ pub struct Function {
     pub doc_hidden: bool,
     pub is_windows_utf8: bool,
     pub disable_length_detect: bool,
+    pub doc_trait_name: Option<String>,
 }
 
 impl Parse for Function {
@@ -192,6 +193,7 @@ impl Parse for Function {
                 "is_windows_utf8",
                 "disable_length_detect",
                 "pattern",
+                "doc_trait_name",
             ],
             &format!("function {}", object_name),
         );
@@ -222,6 +224,10 @@ impl Parse for Function {
             .lookup("disable_length_detect")
             .and_then(Value::as_bool)
             .unwrap_or(false);
+        let doc_trait_name = toml
+            .lookup("doc_trait_name")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned);
 
         Some(Function {
             ident,
@@ -233,6 +239,7 @@ impl Parse for Function {
             doc_hidden,
             is_windows_utf8,
             disable_length_detect,
+            doc_trait_name,
         })
     }
 }

--- a/src/config/properties.rs
+++ b/src/config/properties.rs
@@ -14,6 +14,7 @@ pub struct Property {
     pub ignore: bool,
     pub version: Option<Version>,
     pub generate: Option<PropertyGenerateFlags>,
+    pub doc_trait_name: Option<String>,
 }
 
 impl Parse for Property {
@@ -30,7 +31,14 @@ impl Parse for Property {
         };
 
         toml.check_unwanted(
-            &["ignore", "version", "name", "pattern", "generate"],
+            &[
+                "ignore",
+                "version",
+                "name",
+                "pattern",
+                "generate",
+                "doc_trait_name",
+            ],
             &format!("property {}", object_name),
         );
 
@@ -47,12 +55,17 @@ impl Parse for Property {
                 .map_err(|e| error!("{} for object {}", e, object_name))
                 .ok()
         });
+        let doc_trait_name = toml
+            .lookup("doc_trait_name")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned);
 
         Some(Property {
             ident,
             ignore,
             version,
             generate,
+            doc_trait_name,
         })
     }
 }

--- a/src/config/signals.rs
+++ b/src/config/signals.rs
@@ -107,6 +107,7 @@ pub struct Signal {
     pub ret: Return,
     pub concurrency: library::Concurrency,
     pub doc_hidden: bool,
+    pub doc_trait_name: Option<String>,
 }
 
 impl Signal {
@@ -136,6 +137,7 @@ impl Signal {
                 "name",
                 "pattern",
                 "concurrency",
+                "doc_trait_name",
             ],
             &format!("signal {}", object_name),
         );
@@ -166,6 +168,10 @@ impl Signal {
             .lookup("doc_hidden")
             .and_then(Value::as_bool)
             .unwrap_or(false);
+        let doc_trait_name = toml
+            .lookup("doc_trait_name")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned);
 
         Some(Signal {
             ident,
@@ -176,6 +182,7 @@ impl Signal {
             ret,
             concurrency,
             doc_hidden,
+            doc_trait_name,
         })
     }
 }


### PR DESCRIPTION
Fix https://github.com/gtk-rs/gir/issues/797

@GuillaumeGomez, not sure that it right way, but it works

test for gio:
```diff
+++ b/Gir.toml
@@ -664,11 +664,13 @@ manual_traits = ["SocketListenerExtManual"]
     name = "accept_socket_async"
     # finish function misses nullable return annotation
     ignore = true
+    doc_trait_name = "SocketListenerExtManual"
 
     [[object.function]]
     name = "accept_async"
     # finish function misses nullable return annotation
     ignore = true
+    doc_trait_name = "SocketListenerExtManual"
 
 [[object]]
 name = "Gio.Subprocess"
```