### PR TITLE
Parse "doc-deprecated" tag in alias

### DIFF
--- a/src/library.rs
+++ b/src/library.rs
@@ -335,6 +335,7 @@ pub struct Alias {
     pub typ: TypeId,
     pub target_c_type: String,
     pub doc: Option<String>,
+    pub doc_deprecated: Option<String>,
 }
 
 #[derive(Debug)]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -766,6 +766,7 @@ impl Library {
 
         let mut inner = None;
         let mut doc = None;
+        let mut doc_deprecated = None;
 
         parser.elements(|parser, elem| match elem.name() {
             "source-position" => parser.ignore_element(),
@@ -785,6 +786,7 @@ impl Library {
                 Ok(())
             }
             "doc" => parser.text().map(|t| doc = Some(t)),
+            "doc-deprecated" => parser.text().map(|t| doc_deprecated = Some(t)),
             "attribute" => parser.ignore_element(),
             _ => Err(parser.unexpected_element(elem)),
         })?;
@@ -796,6 +798,7 @@ impl Library {
                 typ,
                 target_c_type: c_type,
                 doc,
+                doc_deprecated,
             });
             self.add_type(ns_id, alias_name, typ);
             Ok(())


### PR DESCRIPTION
Fix #803 

@GuillaumeGomez seems that in doc mode aliases are not processed at all