### PR TITLE
Migrate property getters to new signature for `Value::get`

### DIFF
--- a/src/codegen/property_body.rs
+++ b/src/codegen/property_body.rs
@@ -138,7 +138,10 @@ impl Builder {
         } else {
             ".unwrap()"
         };
-        body.push(Chunk::Custom(format!("value.get(){}", unwrap)));
+        body.push(Chunk::Custom(format!(
+            "value.get().expect(\"Return Value for property `{}` getter\"){}",
+            self.name, unwrap,
+        )));
 
         let unsafe_ = Chunk::Unsafe(body);
 

--- a/src/codegen/signal.rs
+++ b/src/codegen/signal.rs
@@ -138,11 +138,19 @@ pub fn generate(
             )?;
 
             if trampoline.ret.typ != Default::default() {
-                if trampoline.ret.nullable == library::Nullable(true) {
-                    writeln!(w, "{}res.unwrap().get()", tabs(indent + 1),)?;
+                let unwrap = if trampoline.ret.nullable == library::Nullable(true) {
+                    ""
                 } else {
-                    writeln!(w, "{}res.unwrap().get().unwrap()", tabs(indent + 1),)?;
-                }
+                    ".unwrap()"
+                };
+
+                writeln!(
+                    w,
+                    "{}res.unwrap().get().expect(\"Return Value for `{}`\"){}",
+                    tabs(indent + 1),
+                    emit_name,
+                    unwrap,
+                )?;
             }
             writeln!(w, "{}}}", tabs(indent))?;
         }


### PR DESCRIPTION
... in consequence of https://github.com/gtk-rs/glib/pull/513