### PR TITLE
Remove dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: xenial
+dist: bionic
 language: rust
 rust:
 - nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: bionic
+dist: xenial
 language: rust
 rust:
 - nightly
@@ -8,7 +8,6 @@ addons:
     packages:
     - libgtk-3-dev
     - libssh2-1-dev
-    - libgit2-dev
 script:
   - test "$TRAVIS_RUST_VERSION" == "nightly" || rustup component add rustfmt clippy
   - test "$TRAVIS_RUST_VERSION" == "nightly" || cargo clippy --release

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ addons:
     packages:
     - libgtk-3-dev
     - libssh2-1-dev
+    - libgit2-dev
 script:
   - test "$TRAVIS_RUST_VERSION" == "nightly" || rustup component add rustfmt clippy
   - test "$TRAVIS_RUST_VERSION" == "nightly" || cargo clippy --release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,17 +42,6 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "docopt"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
- "strsim 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "env_logger"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -62,6 +51,14 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "getopts"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-width 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -79,8 +76,8 @@ name = "gir"
 version = "0.0.1"
 dependencies = [
  "bitflags 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "docopt 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "getopts 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "git2 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hprof 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -222,25 +219,9 @@ version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "quick-error"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "quote"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "proc-macro2 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "regex"
@@ -267,39 +248,11 @@ source = "git+https://github.com/GuillaumeGomez/rustdoc-stripper#1c7c652e4aa3eb1
 name = "serde"
 version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "serde_derive 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "serde_derive"
-version = "1.0.101"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "proc-macro2 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "smallvec"
 version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "strsim"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "syn"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "proc-macro2 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "termcolor"
@@ -343,8 +296,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.0"
+name = "unicode-width"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -415,8 +368,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)" = "4fc9a35e1f4290eb9e5fc54ba6cf40671ed2a2514c3eeb2b2a908dda2ea5a1be"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 "checksum clock_ticks 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c49a90f58e73ac5f41ed0ac249861ceb5f0976db35fabc2b9c2c856916042d63"
-"checksum docopt 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7f525a586d310c87df72ebcd98009e57f1cc030c8c268305287a476beb653969"
 "checksum env_logger 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "39ecdb7dd54465526f0a56d666e3b2dd5f3a218665a030b6e4ad9e70fa95d8fa"
+"checksum getopts 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)" = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
 "checksum getrandom 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "473a1265acc8ff1e808cd0a1af8cee3c2ee5200916058a2ca113c29f2d903571"
 "checksum git2 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "39f27186fbb5ec67ece9a56990292bc5aed3c3fc51b9b07b0b52446b1dfb4a82"
 "checksum hprof 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "17b42e67c01ef27237e424783538a0bc45721ecd53438fab5c3f8bbf5dfd8516"
@@ -435,23 +388,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bcef43580c035376c0705c42792c294b66974abbfd2789b511784023f71f3273"
 "checksum percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 "checksum pkg-config 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)" = "72d5370d90f49f70bd033c3d75e87fc529fbfff9d6f7cccef07d6170079d91ea"
-"checksum proc-macro2 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "90cf5f418035b98e655e9cdb225047638296b862b42411c4e45bb88d700f7fc0"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
-"checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
 "checksum regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dc220bd33bdce8f093101afe22a037b8eb0e5af33592e6a9caafff0d4cb81cbd"
 "checksum regex-syntax 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "11a7e20d1cce64ef2fed88b66d347f88bd9babb82845b2b858f3edbf59a4f716"
 "checksum rustdoc-stripper 0.1.10 (git+https://github.com/GuillaumeGomez/rustdoc-stripper)" = "<none>"
 "checksum serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)" = "9796c9b7ba2ffe7a9ce53c2287dfc48080f4b2b362fcc245a259b3a7201119dd"
-"checksum serde_derive 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)" = "4b133a43a1ecd55d4086bd5b4dc6c1751c68b1bfbeba7a5040442022c7e7c02e"
 "checksum smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ab606a9c5e214920bb66c458cd7be8ef094f813f20fe77a54cc7dbfff220d4b7"
-"checksum strsim 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "032c03039aae92b350aad2e3779c352e104d919cb192ba2fabbd7b831ce4f0f6"
-"checksum syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "66850e97125af79138385e9b88339cbcd037e3f28ceab8c5ad98e64f0f1f80bf"
 "checksum termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "96d6098003bde162e4277c70665bd87c326f5a0c3f3fbfb285787fa482d54e6e"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum toml 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c7aabe75941d914b72bf3e5d3932ed92ce0664d49d8432305a8b547c37227724"
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
 "checksum unicode-normalization 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "141339a08b982d942be2ca06ff8b076563cbe223d1befd5450716790d44e2426"
-"checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
+"checksum unicode-width 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7007dbd421b92cc6e28410fe7362e2e0a2503394908f417b68ec8d1c364c4e20"
 "checksum url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "75b414f6c464c879d7f9babf951f23bc3743fb7313c081b2e6ca719067ea9d61"
 "checksum vcpkg 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "33dd455d0f96e90a75803cfeb7f948768c08d70a6de9a8d2362461935698bf95"
 "checksum wasi 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b89c3ce4ce14bdc6fb6beaf9ec7928ca331de5df7e5ea278375642a2f478570d"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,15 +9,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atty"
-version = "0.2.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "bitflags"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -46,11 +37,7 @@ name = "env_logger"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "humantime 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -107,14 +94,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "clock_ticks 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "humantime"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -219,11 +198,6 @@ version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "quick-error"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "regex"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -253,14 +227,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "smallvec"
 version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "termcolor"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "wincolor 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "thread_local"
@@ -321,49 +287,12 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "winapi"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "wincolor"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "xml-rs"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
 "checksum aho-corasick 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "58fb5e95d83b38284460a5fda7d6470aa0b8844d283a0b614b8535e880800d2d"
-"checksum atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "1803c647a3ec87095e7ae7acfca019e98de5ec9a7d01343f611cf3152ed71a90"
 "checksum bitflags 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8a606a02debe2813760609f57a64a2ffd27d9fdf5b2f133eaca0b248dd92cdd2"
 "checksum cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)" = "4fc9a35e1f4290eb9e5fc54ba6cf40671ed2a2514c3eeb2b2a908dda2ea5a1be"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
@@ -373,7 +302,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum getrandom 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "473a1265acc8ff1e808cd0a1af8cee3c2ee5200916058a2ca113c29f2d903571"
 "checksum git2 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "39f27186fbb5ec67ece9a56990292bc5aed3c3fc51b9b07b0b52446b1dfb4a82"
 "checksum hprof 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "17b42e67c01ef27237e424783538a0bc45721ecd53438fab5c3f8bbf5dfd8516"
-"checksum humantime 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
 "checksum idna 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9"
 "checksum jobserver 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "f2b1d42ef453b30b7387e113da1c83ab1605d90c5b4e0eb8e96d016ed3b8c160"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
@@ -388,13 +316,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bcef43580c035376c0705c42792c294b66974abbfd2789b511784023f71f3273"
 "checksum percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 "checksum pkg-config 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)" = "72d5370d90f49f70bd033c3d75e87fc529fbfff9d6f7cccef07d6170079d91ea"
-"checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
 "checksum regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dc220bd33bdce8f093101afe22a037b8eb0e5af33592e6a9caafff0d4cb81cbd"
 "checksum regex-syntax 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "11a7e20d1cce64ef2fed88b66d347f88bd9babb82845b2b858f3edbf59a4f716"
 "checksum rustdoc-stripper 0.1.10 (git+https://github.com/GuillaumeGomez/rustdoc-stripper)" = "<none>"
 "checksum serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)" = "9796c9b7ba2ffe7a9ce53c2287dfc48080f4b2b362fcc245a259b3a7201119dd"
 "checksum smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ab606a9c5e214920bb66c458cd7be8ef094f813f20fe77a54cc7dbfff220d4b7"
-"checksum termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "96d6098003bde162e4277c70665bd87c326f5a0c3f3fbfb285787fa482d54e6e"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum toml 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c7aabe75941d914b72bf3e5d3932ed92ce0664d49d8432305a8b547c37227724"
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
@@ -403,9 +329,4 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "75b414f6c464c879d7f9babf951f23bc3743fb7313c081b2e6ca719067ea9d61"
 "checksum vcpkg 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "33dd455d0f96e90a75803cfeb7f948768c08d70a6de9a8d2362461935698bf95"
 "checksum wasi 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b89c3ce4ce14bdc6fb6beaf9ec7928ca331de5df7e5ea278375642a2f478570d"
-"checksum winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
-"checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-"checksum winapi-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7168bab6e1daee33b4557efd0e95d5ca70a03706d39fa5f3fe7a236f584b03c9"
-"checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-"checksum wincolor 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "96f5016b18804d24db43cebf3c77269e7569b8954a8464501c216cc5e070eaa9"
 "checksum xml-rs 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "541b12c998c5b56aa2b4e6f18f03664eef9a4fd0a246a55594efae6cc2d964b5"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,15 +14,6 @@ version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "cc"
-version = "1.0.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "jobserver 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -49,23 +40,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "getrandom"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasi 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "gir"
 version = "0.0.1"
 dependencies = [
  "bitflags 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "getopts 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "git2 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hprof 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -73,18 +53,6 @@ dependencies = [
  "rustdoc-stripper 0.1.10 (git+https://github.com/GuillaumeGomez/rustdoc-stripper)",
  "toml 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "xml-rs 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "git2"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bitflags 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
- "libgit2-sys 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -97,56 +65,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "idna"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-normalization 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "jobserver"
-version = "0.1.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "getrandom 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "libc"
-version = "0.2.62"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "libgit2-sys"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
- "libz-sys 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "pkg-config 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "libz-sys"
-version = "1.0.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
- "pkg-config 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "vcpkg 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "linked-hash-map"
@@ -170,31 +91,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "matches"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "memchr"
 version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "num_cpus"
-version = "1.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "percent-encoding"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "pkg-config"
-version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -224,11 +122,6 @@ version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "smallvec"
-version = "0.6.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "thread_local"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -246,44 +139,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-bidi"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "unicode-normalization"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "unicode-width"
 version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "url"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "idna 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "vcpkg"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "wasi"
-version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -294,39 +151,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [metadata]
 "checksum aho-corasick 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "58fb5e95d83b38284460a5fda7d6470aa0b8844d283a0b614b8535e880800d2d"
 "checksum bitflags 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8a606a02debe2813760609f57a64a2ffd27d9fdf5b2f133eaca0b248dd92cdd2"
-"checksum cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)" = "4fc9a35e1f4290eb9e5fc54ba6cf40671ed2a2514c3eeb2b2a908dda2ea5a1be"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 "checksum clock_ticks 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c49a90f58e73ac5f41ed0ac249861ceb5f0976db35fabc2b9c2c856916042d63"
 "checksum env_logger 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "39ecdb7dd54465526f0a56d666e3b2dd5f3a218665a030b6e4ad9e70fa95d8fa"
 "checksum getopts 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)" = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
-"checksum getrandom 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "473a1265acc8ff1e808cd0a1af8cee3c2ee5200916058a2ca113c29f2d903571"
-"checksum git2 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "39f27186fbb5ec67ece9a56990292bc5aed3c3fc51b9b07b0b52446b1dfb4a82"
 "checksum hprof 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "17b42e67c01ef27237e424783538a0bc45721ecd53438fab5c3f8bbf5dfd8516"
-"checksum idna 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9"
-"checksum jobserver 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "f2b1d42ef453b30b7387e113da1c83ab1605d90c5b4e0eb8e96d016ed3b8c160"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-"checksum libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)" = "34fcd2c08d2f832f376f4173a231990fa5aef4e99fb569867318a227ef4c06ba"
-"checksum libgit2-sys 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a30f8637eb59616ee3b8a00f6adff781ee4ddd8343a615b8238de756060cc1b3"
-"checksum libz-sys 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)" = "2eb5e43362e38e2bca2fd5f5134c4d4564a23a5c28e9b95411652021a8675ebe"
 "checksum linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ae91b68aebc4ddb91978b11a1b02ddd8602a05ec19002801c5666000e05e0f83"
 "checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
-"checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 "checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
-"checksum num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bcef43580c035376c0705c42792c294b66974abbfd2789b511784023f71f3273"
-"checksum percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
-"checksum pkg-config 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)" = "72d5370d90f49f70bd033c3d75e87fc529fbfff9d6f7cccef07d6170079d91ea"
 "checksum regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dc220bd33bdce8f093101afe22a037b8eb0e5af33592e6a9caafff0d4cb81cbd"
 "checksum regex-syntax 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "11a7e20d1cce64ef2fed88b66d347f88bd9babb82845b2b858f3edbf59a4f716"
 "checksum rustdoc-stripper 0.1.10 (git+https://github.com/GuillaumeGomez/rustdoc-stripper)" = "<none>"
 "checksum serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)" = "9796c9b7ba2ffe7a9ce53c2287dfc48080f4b2b362fcc245a259b3a7201119dd"
-"checksum smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ab606a9c5e214920bb66c458cd7be8ef094f813f20fe77a54cc7dbfff220d4b7"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum toml 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c7aabe75941d914b72bf3e5d3932ed92ce0664d49d8432305a8b547c37227724"
-"checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
-"checksum unicode-normalization 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "141339a08b982d942be2ca06ff8b076563cbe223d1befd5450716790d44e2426"
 "checksum unicode-width 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7007dbd421b92cc6e28410fe7362e2e0a2503394908f417b68ec8d1c364c4e20"
-"checksum url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "75b414f6c464c879d7f9babf951f23bc3743fb7313c081b2e6ca719067ea9d61"
-"checksum vcpkg 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "33dd455d0f96e90a75803cfeb7f948768c08d70a6de9a8d2362461935698bf95"
-"checksum wasi 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b89c3ce4ce14bdc6fb6beaf9ec7928ca331de5df7e5ea278375642a2f478570d"
 "checksum xml-rs 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "541b12c998c5b56aa2b4e6f18f03664eef9a4fd0a246a55594efae6cc2d964b5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ bitflags = "1.0"
 getopts = "0.2.21"
 xml-rs = "0.8"
 toml = { version = "0.5" , features = ["preserve_order"] }
-env_logger = "0.7"
+env_logger = { version = "0.7", default-features = false }
 git2 = { version = "0.10", default-features = false }
 lazy_static = "1.0"
 log = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 
 [dependencies]
 bitflags = "1.0"
-docopt = "1.0"
+getopts = "0.2.21"
 xml-rs = "0.8"
 toml = { version = "0.5" , features = ["preserve_order"] }
 env_logger = "0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,15 +16,11 @@ getopts = "0.2.21"
 xml-rs = "0.8"
 toml = { version = "0.5" , features = ["preserve_order"] }
 env_logger = { version = "0.7", default-features = false }
-git2 = { version = "0.10", default-features = false }
 lazy_static = "1.0"
 log = "0.4"
 regex = "1.0"
 hprof = "0.1"
 rustdoc-stripper = { git = "https://github.com/GuillaumeGomez/rustdoc-stripper" }
-
-[build-dependencies]
-git2 = { version = "0.10", default-features = false }
 
 [profile.release]
 codegen-units = 4

--- a/build.rs
+++ b/build.rs
@@ -4,7 +4,7 @@ use std::{fs::File, io::Write};
 mod git;
 
 fn main() {
-    let ver = git::repo_hash(".").unwrap_or_else(|_| "???".into());
+    let ver = git::repo_hash(".").unwrap_or_else(|| "???".into());
 
     File::create("src/gir_version.rs")
         .and_then(|mut f| writeln!(f, "pub const VERSION: &str = \"{}\";", ver))

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -110,7 +110,7 @@ impl Config {
             }
             Some(a) => a.into(),
         };
-        let girs_version = repo_hash(&girs_dir).unwrap_or_else(|_| "???".into());
+        let girs_version = repo_hash(&girs_dir).unwrap_or_else(|| "???".into());
 
         let (library_name, library_version) = match (library_name.into(), library_version.into()) {
             (Some(""), Some("")) | (None, None) => (

--- a/src/git.rs
+++ b/src/git.rs
@@ -1,246 +1,37 @@
-#![allow(non_camel_case_types)]
-
-use std::ffi::CString;
-use std::mem;
-use std::ops::Deref;
-use std::os::raw::{c_char, c_int, c_uint, c_void};
 use std::path::Path;
-use std::ptr;
-use std::slice;
-use std::str;
+use std::process::Command;
 
-const GIT_STATUS_OPTIONS_VERSION: c_uint = 1;
+pub fn repo_hash<P: AsRef<Path>>(path: P) -> Option<String> {
+    let git_path = path.as_ref().to_str();
+    let mut args =
+        match git_path {
+            Some(path) => vec!["-C", path],
+            None => vec![],
+        };
+    args.extend(&["rev-parse", "--short", "HEAD"]);
+    let hash = String::from_utf8(Command::new("git")
+        .args(&args)
+        .output().ok()?
+        .stdout).ok()?;
+    let hash = hash.trim_end_matches('\n');
 
-type git_repository = *mut c_void;
-type git_object = *mut c_void;
-type git_status_list = *mut c_void;
-
-#[allow(dead_code)]
-#[repr(C)]
-enum git_status_opt_t {
-    GIT_STATUS_OPT_INCLUDE_UNTRACKED = (1 << 0),
-    GIT_STATUS_OPT_INCLUDE_IGNORED = (1 << 1),
-    GIT_STATUS_OPT_INCLUDE_UNMODIFIED = (1 << 2),
-    GIT_STATUS_OPT_EXCLUDE_SUBMODULES = (1 << 3),
-    GIT_STATUS_OPT_RECURSE_UNTRACKED_DIRS = (1 << 4),
-    GIT_STATUS_OPT_DISABLE_PATHSPEC_MATCH = (1 << 5),
-    GIT_STATUS_OPT_RECURSE_IGNORED_DIRS = (1 << 6),
-    GIT_STATUS_OPT_RENAMES_HEAD_TO_INDEX = (1 << 7),
-    GIT_STATUS_OPT_RENAMES_INDEX_TO_WORKDIR = (1 << 8),
-    GIT_STATUS_OPT_SORT_CASE_SENSITIVELY = (1 << 9),
-    GIT_STATUS_OPT_SORT_CASE_INSENSITIVELY = (1 << 10),
-
-    GIT_STATUS_OPT_RENAMES_FROM_REWRITES = (1 << 11),
-    GIT_STATUS_OPT_NO_REFRESH = (1 << 12),
-    GIT_STATUS_OPT_UPDATE_INDEX = (1 << 13),
-    GIT_STATUS_OPT_INCLUDE_UNREADABLE = (1 << 14),
-    GIT_STATUS_OPT_INCLUDE_UNREADABLE_AS_UNTRACKED = (1 << 15),
-}
-
-#[repr(C)]
-struct git_buf {
-    ptr: *mut c_char,
-    asize: usize,
-    size: usize,
-}
-
-#[repr(C)]
-struct git_status_options {
-    version: c_uint,
-    show: *mut c_void,
-    flags: c_uint,
-    pathspec: *mut c_void,
-    baseline: *mut c_void,
-}
-
-#[link(name = "git2")]
-extern "C" {
-    fn git_repository_open(out: *mut git_repository, path: *const c_char) -> c_int;
-    fn git_revparse_single(
-        out: *mut git_object,
-        repo: git_repository,
-        spec: *const c_char,
-    ) -> c_int;
-    fn git_object_short_id(out: *mut git_buf, obj: git_object) -> c_int;
-    fn git_status_list_new(
-        out: *mut git_status_list,
-        repo: git_repository,
-        opts: *const git_status_options,
-    ) -> c_int;
-    fn git_status_init_options(opts: *mut git_status_options, version: c_uint) -> c_int;
-    fn git_libgit2_init() -> c_int;
-    fn git_buf_dispose(buffer: *mut git_buf);
-    fn git_repository_free(repo: git_repository);
-    fn git_status_list_free(statuslist: git_status_list);
-    fn git_status_list_entrycount(statuslist: git_status_list) -> usize;
-    fn git_object_free(object: git_object);
-}
-
-struct Buf(git_buf);
-struct Object(git_object);
-struct Repository(git_repository);
-struct StatusOptions(git_status_options);
-
-fn init() {
-    use std::sync::Once;
-
-    static INIT: Once = Once::new();
-    INIT.call_once(|| unsafe {
-        if git_libgit2_init() < 0 {
-            panic!("Cannot initialize libgit2");
-        }
-    });
-}
-
-impl StatusOptions {
-    fn new() -> Option<Self> {
-        unsafe {
-            let mut options = mem::zeroed();
-            if git_status_init_options(&mut options, GIT_STATUS_OPTIONS_VERSION) != 0 {
-                return None;
-            }
-            return Some(Self(options));
-        }
-    }
-
-    fn flag(&mut self, flag: git_status_opt_t, on: bool) -> &mut StatusOptions {
-        if on {
-            self.0.flags |= flag as u32;
-        } else {
-            self.0.flags &= !(flag as u32);
-        }
-        self
-    }
-
-    fn include_untracked(&mut self, include: bool) -> &mut StatusOptions {
-        self.flag(git_status_opt_t::GIT_STATUS_OPT_INCLUDE_UNTRACKED, include)
-    }
-
-    fn include_ignored(&mut self, include: bool) -> &mut StatusOptions {
-        self.flag(git_status_opt_t::GIT_STATUS_OPT_INCLUDE_IGNORED, include)
-    }
-
-    fn include_unmodified(&mut self, include: bool) -> &mut StatusOptions {
-        self.flag(git_status_opt_t::GIT_STATUS_OPT_INCLUDE_UNMODIFIED, include)
+    if dirty(path) {
+        Some(format!("{}+", hash))
+    } else {
+        Some(hash.into())
     }
 }
 
-impl Buf {
-    fn new() -> Self {
-        init();
-        Buf(git_buf {
-            ptr: ptr::null_mut(),
-            asize: 0,
-            size: 0,
-        })
+fn dirty<P: AsRef<Path>>(path: P) -> bool {
+    let path = path.as_ref().to_str();
+    let mut args =
+        match path {
+            Some(path) => vec!["-C", path],
+            None => vec![],
+        };
+    args.extend(&["ls-files", "-m"]);
+    match Command::new("git").args(&args).output() {
+        Ok(modified_files) => !modified_files.stdout.is_empty(),
+        Err(_) => false,
     }
-
-    fn as_str(&self) -> Option<&str> {
-        str::from_utf8(&**self).ok()
-    }
-}
-
-impl Deref for Buf {
-    type Target = [u8];
-    fn deref(&self) -> &[u8] {
-        unsafe { slice::from_raw_parts((self.0).ptr as *const u8, (self.0).size as usize) }
-    }
-}
-
-impl Drop for Buf {
-    fn drop(&mut self) {
-        unsafe { git_buf_dispose(&mut self.0) }
-    }
-}
-
-impl Object {
-    fn short_id(&self) -> Option<Buf> {
-        unsafe {
-            let out = Buf::new();
-            if git_object_short_id(&out.0 as *const _ as *mut _, self.0) != 0 {
-                return None;
-            }
-            Some(out)
-        }
-    }
-}
-
-impl Drop for Object {
-    fn drop(&mut self) {
-        unsafe {
-            git_object_free(self.0);
-        }
-    }
-}
-
-impl Repository {
-    fn open<P: AsRef<Path>>(path: P) -> Option<Self> {
-        init();
-
-        let path = CString::new(path.as_ref().to_str()?).ok()?;
-        unsafe {
-            let mut repository = ptr::null_mut();
-            let result = git_repository_open(&mut repository, path.as_ptr());
-            if result != 0 {
-                return None;
-            }
-            Some(Self(repository))
-        }
-    }
-
-    fn revparse_single(&self, spec: &str) -> Option<Object> {
-        let mut object = ptr::null_mut();
-        let spec = CString::new(spec).ok()?;
-        unsafe {
-            if git_revparse_single(&mut object, self.0, spec.as_ptr()) != 0 {
-                return None;
-            }
-            Some(Object(object))
-        }
-    }
-
-    fn status_count(&self, options: &mut StatusOptions) -> Option<usize> {
-        unsafe {
-            let mut list = ptr::null_mut();
-            if git_status_list_new(&mut list, self.0, &options.0) != 0 {
-                return None;
-            }
-            let count = git_status_list_entrycount(list);
-            git_status_list_free(list);
-            Some(count)
-        }
-    }
-}
-
-impl Drop for Repository {
-    fn drop(&mut self) {
-        unsafe { git_repository_free(self.0) }
-    }
-}
-
-pub fn repo_hash<P: AsRef<Path>>(path: P) -> Result<String, ()> {
-    if let Some(repo) = Repository::open(path) {
-        if let Some(buf) = repo.revparse_single("HEAD").and_then(|obj| obj.short_id()) {
-            if let Some(s) = buf.as_str() {
-                if dirty(&repo) {
-                    return Ok(format!("{}+", s));
-                } else {
-                    return Ok(s.into());
-                }
-            }
-        }
-    }
-    Err(())
-}
-
-fn dirty(repo: &Repository) -> bool {
-    repo.status_count(
-        StatusOptions::new()
-            .expect("status options")
-            .include_ignored(false)
-            .include_untracked(false)
-            .include_unmodified(false),
-    )
-    .map(|count| count > 0)
-    .unwrap_or(false)
 }

--- a/src/git.rs
+++ b/src/git.rs
@@ -3,16 +3,12 @@ use std::process::Command;
 
 pub fn repo_hash<P: AsRef<Path>>(path: P) -> Option<String> {
     let git_path = path.as_ref().to_str();
-    let mut args =
-        match git_path {
-            Some(path) => vec!["-C", path],
-            None => vec![],
-        };
+    let mut args = match git_path {
+        Some(path) => vec!["-C", path],
+        None => vec![],
+    };
     args.extend(&["rev-parse", "--short", "HEAD"]);
-    let hash = String::from_utf8(Command::new("git")
-        .args(&args)
-        .output().ok()?
-        .stdout).ok()?;
+    let hash = String::from_utf8(Command::new("git").args(&args).output().ok()?.stdout).ok()?;
     let hash = hash.trim_end_matches('\n');
 
     if dirty(path) {
@@ -24,11 +20,10 @@ pub fn repo_hash<P: AsRef<Path>>(path: P) -> Option<String> {
 
 fn dirty<P: AsRef<Path>>(path: P) -> bool {
     let path = path.as_ref().to_str();
-    let mut args =
-        match path {
-            Some(path) => vec!["-C", path],
-            None => vec![],
-        };
+    let mut args = match path {
+        Some(path) => vec!["-C", path],
+        None => vec![],
+    };
     args.extend(&["ls-files", "-m"]);
     match Command::new("git").args(&args).output() {
         Ok(modified_files) => !modified_files.stdout.is_empty(),

--- a/src/git.rs
+++ b/src/git.rs
@@ -1,9 +1,220 @@
-use git2::{Repository, StatusOptions};
+#![allow(non_camel_case_types)]
+
+use std::ffi::CString;
+use std::mem;
+use std::ops::Deref;
+use std::os::raw::{c_char, c_int, c_uint, c_void};
+use std::ptr;
 use std::path::Path;
+use std::slice;
+use std::str;
+
+const GIT_STATUS_OPTIONS_VERSION: c_uint = 1;
+
+type git_repository = *mut c_void;
+type git_object = *mut c_void;
+type git_status_list = *mut c_void;
+
+#[allow(dead_code)]
+#[repr(C)]
+enum git_status_opt_t {
+    GIT_STATUS_OPT_INCLUDE_UNTRACKED = (1 << 0),
+    GIT_STATUS_OPT_INCLUDE_IGNORED = (1 << 1),
+    GIT_STATUS_OPT_INCLUDE_UNMODIFIED = (1 << 2),
+    GIT_STATUS_OPT_EXCLUDE_SUBMODULES = (1 << 3),
+    GIT_STATUS_OPT_RECURSE_UNTRACKED_DIRS = (1 << 4),
+    GIT_STATUS_OPT_DISABLE_PATHSPEC_MATCH = (1 << 5),
+    GIT_STATUS_OPT_RECURSE_IGNORED_DIRS = (1 << 6),
+    GIT_STATUS_OPT_RENAMES_HEAD_TO_INDEX = (1 << 7),
+    GIT_STATUS_OPT_RENAMES_INDEX_TO_WORKDIR = (1 << 8),
+    GIT_STATUS_OPT_SORT_CASE_SENSITIVELY = (1 << 9),
+    GIT_STATUS_OPT_SORT_CASE_INSENSITIVELY = (1 << 10),
+
+    GIT_STATUS_OPT_RENAMES_FROM_REWRITES = (1 << 11),
+    GIT_STATUS_OPT_NO_REFRESH = (1 << 12),
+    GIT_STATUS_OPT_UPDATE_INDEX = (1 << 13),
+    GIT_STATUS_OPT_INCLUDE_UNREADABLE = (1 << 14),
+    GIT_STATUS_OPT_INCLUDE_UNREADABLE_AS_UNTRACKED = (1 << 15),
+}
+
+#[repr(C)]
+struct git_buf {
+    ptr: *mut c_char,
+    asize: usize,
+    size: usize,
+}
+
+#[repr(C)]
+struct git_status_options {
+    version: c_uint,
+    show: *mut c_void,
+    flags: c_uint,
+    pathspec: *mut c_void,
+    baseline: *mut c_void,
+}
+
+#[link(name="git2")]
+extern "C" {
+    fn git_repository_open(out: *mut git_repository, path: *const c_char) -> c_int;
+    fn git_revparse_single(out: *mut git_object, repo: git_repository, spec: *const c_char) -> c_int;
+    fn git_object_short_id(out: *mut git_buf, obj: git_object) -> c_int;
+    fn git_status_list_new(out: *mut git_status_list, repo: git_repository, opts: *const git_status_options) -> c_int;
+    fn git_status_init_options(opts: *mut git_status_options, version: c_uint) -> c_int;
+    fn git_libgit2_init() -> c_int;
+    fn git_buf_dispose(buffer: *mut git_buf);
+    fn git_repository_free(repo: git_repository);
+    fn git_status_list_free(statuslist: git_status_list);
+    fn git_status_list_entrycount(statuslist: git_status_list) -> usize;
+    fn git_object_free(object: git_object);
+}
+
+struct Buf(git_buf);
+struct Object(git_object);
+struct Repository(git_repository);
+struct StatusOptions(git_status_options);
+
+fn init() {
+    use std::sync::Once;
+
+    static INIT: Once = Once::new();
+    INIT.call_once(||
+        unsafe {
+            if git_libgit2_init() < 0 {
+                panic!("Cannot initialize libgit2");
+            }
+        }
+    );
+}
+
+impl StatusOptions {
+    fn new() -> Option<Self> {
+        unsafe {
+            let mut options = mem::zeroed();
+            if git_status_init_options(&mut options, GIT_STATUS_OPTIONS_VERSION) != 0 {
+                return None;
+            }
+            return Some(Self(options));
+        }
+    }
+
+    fn flag(&mut self, flag: git_status_opt_t, on: bool) -> &mut StatusOptions {
+        if on {
+            self.0.flags |= flag as u32;
+        } else {
+            self.0.flags &= !(flag as u32);
+        }
+        self
+    }
+
+    fn include_untracked(&mut self, include: bool) -> &mut StatusOptions {
+        self.flag(git_status_opt_t::GIT_STATUS_OPT_INCLUDE_UNTRACKED, include)
+    }
+
+    fn include_ignored(&mut self, include: bool) -> &mut StatusOptions {
+        self.flag(git_status_opt_t::GIT_STATUS_OPT_INCLUDE_IGNORED, include)
+    }
+
+    fn include_unmodified(&mut self, include: bool) -> &mut StatusOptions {
+        self.flag(git_status_opt_t::GIT_STATUS_OPT_INCLUDE_UNMODIFIED, include)
+    }
+}
+
+impl Buf {
+    fn new() -> Self {
+        init();
+        Buf(git_buf {
+            ptr: ptr::null_mut(),
+            asize: 0,
+            size: 0,
+        })
+    }
+
+    fn as_str(&self) -> Option<&str> {
+        str::from_utf8(&**self).ok()
+    }
+}
+
+impl Deref for Buf {
+    type Target = [u8];
+    fn deref(&self) -> &[u8] {
+        unsafe { slice::from_raw_parts((self.0).ptr as *const u8, (self.0).size as usize) }
+    }
+}
+
+impl Drop for Buf {
+    fn drop(&mut self) {
+        unsafe { git_buf_dispose(&mut self.0) }
+    }
+}
+
+impl Object {
+    fn short_id(&self) -> Option<Buf> {
+        unsafe {
+            let out = Buf::new();
+            if git_object_short_id(&out.0 as *const _ as *mut _, self.0) != 0 {
+                return None;
+            }
+            Some(out)
+        }
+    }
+}
+
+impl Drop for Object {
+    fn drop(&mut self) {
+        unsafe {
+            git_object_free(self.0);
+        }
+    }
+}
+
+impl Repository {
+    fn open<P: AsRef<Path>>(path: P) -> Option<Self> {
+        init();
+
+        let path = CString::new(path.as_ref().to_str()?).ok()?;
+        unsafe {
+            let mut repository = ptr::null_mut();
+            let result = git_repository_open(&mut repository, path.as_ptr());
+            if result != 0 {
+                return None;
+            }
+            Some(Self(repository))
+        }
+    }
+
+    fn revparse_single(&self, spec: &str) -> Option<Object> {
+        let mut object = ptr::null_mut();
+        let spec = CString::new(spec).ok()?;
+        unsafe {
+            if git_revparse_single(&mut object, self.0, spec.as_ptr()) != 0 {
+                return None;
+            }
+            Some(Object(object))
+        }
+    }
+
+    fn status_count(&self, options: &mut StatusOptions) -> Option<usize> {
+        unsafe {
+            let mut list = ptr::null_mut();
+            if git_status_list_new(&mut list, self.0, &options.0) != 0 {
+                return None;
+            }
+            let count = git_status_list_entrycount(list);
+            git_status_list_free(list);
+            Some(count)
+        }
+    }
+}
+
+impl Drop for Repository {
+    fn drop(&mut self) {
+        unsafe { git_repository_free(self.0) }
+    }
+}
 
 pub fn repo_hash<P: AsRef<Path>>(path: P) -> Result<String, ()> {
-    if let Ok(repo) = Repository::open(path) {
-        if let Ok(buf) = repo.revparse_single("HEAD").and_then(|obj| obj.short_id()) {
+    if let Some(repo) = Repository::open(path) {
+        if let Some(buf) = repo.revparse_single("HEAD").and_then(|obj| obj.short_id()) {
             if let Some(s) = buf.as_str() {
                 if dirty(&repo) {
                     return Ok(format!("{}+", s));
@@ -17,13 +228,13 @@ pub fn repo_hash<P: AsRef<Path>>(path: P) -> Result<String, ()> {
 }
 
 fn dirty(repo: &Repository) -> bool {
-    repo.statuses(Some(
+    repo.status_count(
         StatusOptions::new()
+            .expect("status options")
             .include_ignored(false)
             .include_untracked(false)
             .include_unmodified(false),
-    ))
-    .ok()
-    .map(|s| !s.is_empty())
+    )
+    .map(|count| count > 0)
     .unwrap_or(false)
 }

--- a/src/git.rs
+++ b/src/git.rs
@@ -4,8 +4,8 @@ use std::ffi::CString;
 use std::mem;
 use std::ops::Deref;
 use std::os::raw::{c_char, c_int, c_uint, c_void};
-use std::ptr;
 use std::path::Path;
+use std::ptr;
 use std::slice;
 use std::str;
 
@@ -53,12 +53,20 @@ struct git_status_options {
     baseline: *mut c_void,
 }
 
-#[link(name="git2")]
+#[link(name = "git2")]
 extern "C" {
     fn git_repository_open(out: *mut git_repository, path: *const c_char) -> c_int;
-    fn git_revparse_single(out: *mut git_object, repo: git_repository, spec: *const c_char) -> c_int;
+    fn git_revparse_single(
+        out: *mut git_object,
+        repo: git_repository,
+        spec: *const c_char,
+    ) -> c_int;
     fn git_object_short_id(out: *mut git_buf, obj: git_object) -> c_int;
-    fn git_status_list_new(out: *mut git_status_list, repo: git_repository, opts: *const git_status_options) -> c_int;
+    fn git_status_list_new(
+        out: *mut git_status_list,
+        repo: git_repository,
+        opts: *const git_status_options,
+    ) -> c_int;
     fn git_status_init_options(opts: *mut git_status_options, version: c_uint) -> c_int;
     fn git_libgit2_init() -> c_int;
     fn git_buf_dispose(buffer: *mut git_buf);
@@ -77,13 +85,11 @@ fn init() {
     use std::sync::Once;
 
     static INIT: Once = Once::new();
-    INIT.call_once(||
-        unsafe {
-            if git_libgit2_init() < 0 {
-                panic!("Cannot initialize libgit2");
-            }
+    INIT.call_once(|| unsafe {
+        if git_libgit2_init() < 0 {
+            panic!("Cannot initialize libgit2");
         }
-    );
+    });
 }
 
 impl StatusOptions {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,30 +1,45 @@
+use std::{cell::RefCell, str::FromStr};
+use std::env;
+use std::process;
+
+use getopts::Options;
 use hprof::Profiler;
 use libgir::{self as gir, Config, Library, WorkMode};
-use std::{cell::RefCell, str::FromStr};
 
-static USAGE: &str = "
-Usage: gir [options] [<library> <version>]
-       gir (-h | --help)
+fn print_usage(program: &str, opts: Options) {
 
-Options:
-    -h, --help              Show this message.
-    -c CONFIG               Config file path (default: Gir.toml)
-    -d GIRSPATH             Directory for girs
-    -m MODE                 Work mode: doc, normal, sys or not_bound
-    -o PATH                 Target path
-    --doc-target-path PATH  Doc target path
-    -b, --make-backup       Make backup before generating
-    -s, --stats             Show statistics
-";
+    let brief = format!("Usage: {program} [options] [<library> <version>]
+       {program} (-h | --help)", program = program);
+    print!("{}", opts.usage(&brief));
+}
 
 fn build_config() -> Result<Config, String> {
-    let args = match docopt::Docopt::new(USAGE).and_then(|dopt| dopt.parse()) {
-        Ok(args) => args,
+    let args: Vec<_> = env::args().collect();
+    let program = args[0].clone();
+
+    let mut options = Options::new();
+    options.optopt("c", "config", "Config file path (default: Gir.toml)", "CONFIG");
+    options.optflag("h", "help", "Show this message");
+    options.optopt("d", "gir-directory", "Directory for girs", "GIRSPATH");
+    options.optopt("m", "mode", "Work mode: doc, normal, sys or not_bound", "MODE");
+    options.optopt("o", "target", "Target path", "PATH");
+    options.optopt("p", "doc-target-path", "Doc target path", "PATH");
+    options.optflag("b", "make-backup", "Make backup before generating");
+    options.optflag("s", "stats", "Show statistics");
+
+    let matches = match options.parse(&args[1..]) {
+        Ok(matches) => matches,
         Err(e) => return Err(e.to_string()),
     };
-    let work_mode = match args.get_str("-m") {
-        "" => None,
-        s => match WorkMode::from_str(s) {
+
+    if matches.opt_present("h") {
+        print_usage(&program, options);
+        process::exit(0);
+    }
+
+    let work_mode = match matches.opt_str("m") {
+        None => None,
+        Some(s) => match WorkMode::from_str(&s) {
             Ok(w) => Some(w),
             Err(e) => {
                 eprintln!("Error (switching to default work mode): {}", e);
@@ -34,15 +49,15 @@ fn build_config() -> Result<Config, String> {
     };
 
     Config::new(
-        args.get_str("-c"),
+        matches.opt_str("c").as_ref().map(|string| string.as_str()),
         work_mode,
-        args.get_str("-d"),
-        args.get_str("<library>"),
-        args.get_str("<version>"),
-        args.get_str("-o"),
-        args.get_str("--doc-target-path"),
-        args.get_bool("-b"),
-        args.get_bool("-s"),
+        matches.opt_str("d").as_ref().map(|string| string.as_str()),
+        matches.free.get(0).as_ref().map(|string| string.as_str()),
+        matches.free.get(1).as_ref().map(|string| string.as_str()),
+        matches.opt_str("o").as_ref().map(|string| string.as_str()),
+        matches.opt_str("doc-target-path").as_ref().map(|string| string.as_str()),
+        matches.opt_present("b"),
+        matches.opt_present("s"),
     )
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,16 @@ fn print_usage(program: &str, opts: Options) {
     print!("{}", opts.usage(&brief));
 }
 
+trait OptionStr {
+    fn as_str_ref(&self) -> Option<&str>;
+}
+
+impl<S: AsRef<str>> OptionStr for Option<S> {
+    fn as_str_ref(&self) -> Option<&str> {
+        self.as_ref().map(|string| string.as_ref())
+    }
+}
+
 fn build_config() -> Result<Config, String> {
     let args: Vec<_> = env::args().collect();
     let program = args[0].clone();
@@ -61,16 +71,13 @@ fn build_config() -> Result<Config, String> {
     };
 
     Config::new(
-        matches.opt_str("c").as_ref().map(|string| string.as_str()),
+        matches.opt_str("c").as_str_ref(),
         work_mode,
-        matches.opt_str("d").as_ref().map(|string| string.as_str()),
-        matches.free.get(0).as_ref().map(|string| string.as_str()),
-        matches.free.get(1).as_ref().map(|string| string.as_str()),
-        matches.opt_str("o").as_ref().map(|string| string.as_str()),
-        matches
-            .opt_str("doc-target-path")
-            .as_ref()
-            .map(|string| string.as_str()),
+        matches.opt_str("d").as_str_ref(),
+        matches.free.get(0).as_str_ref(),
+        matches.free.get(1).as_str_ref(),
+        matches.opt_str("o").as_str_ref(),
+        matches.opt_str("doc-target-path").as_str_ref(),
         matches.opt_present("b"),
         matches.opt_present("s"),
     )

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,15 +1,17 @@
-use std::{cell::RefCell, str::FromStr};
 use std::env;
 use std::process;
+use std::{cell::RefCell, str::FromStr};
 
 use getopts::Options;
 use hprof::Profiler;
 use libgir::{self as gir, Config, Library, WorkMode};
 
 fn print_usage(program: &str, opts: Options) {
-
-    let brief = format!("Usage: {program} [options] [<library> <version>]
-       {program} (-h | --help)", program = program);
+    let brief = format!(
+        "Usage: {program} [options] [<library> <version>]
+       {program} (-h | --help)",
+        program = program
+    );
     print!("{}", opts.usage(&brief));
 }
 
@@ -18,10 +20,20 @@ fn build_config() -> Result<Config, String> {
     let program = args[0].clone();
 
     let mut options = Options::new();
-    options.optopt("c", "config", "Config file path (default: Gir.toml)", "CONFIG");
+    options.optopt(
+        "c",
+        "config",
+        "Config file path (default: Gir.toml)",
+        "CONFIG",
+    );
     options.optflag("h", "help", "Show this message");
     options.optopt("d", "gir-directory", "Directory for girs", "GIRSPATH");
-    options.optopt("m", "mode", "Work mode: doc, normal, sys or not_bound", "MODE");
+    options.optopt(
+        "m",
+        "mode",
+        "Work mode: doc, normal, sys or not_bound",
+        "MODE",
+    );
     options.optopt("o", "target", "Target path", "PATH");
     options.optopt("p", "doc-target-path", "Doc target path", "PATH");
     options.optflag("b", "make-backup", "Make backup before generating");
@@ -55,7 +67,10 @@ fn build_config() -> Result<Config, String> {
         matches.free.get(0).as_ref().map(|string| string.as_str()),
         matches.free.get(1).as_ref().map(|string| string.as_str()),
         matches.opt_str("o").as_ref().map(|string| string.as_str()),
-        matches.opt_str("doc-target-path").as_ref().map(|string| string.as_str()),
+        matches
+            .opt_str("doc-target-path")
+            .as_ref()
+            .map(|string| string.as_str()),
         matches.opt_present("b"),
         matches.opt_present("s"),
     )


### PR DESCRIPTION
I'll update this text with the compilation time for every change.
It turns out `git2-sys` is very slow to compile (+1 minute).
Maybe we can re-enable the features of `env_logger` since it does not help much.

## Before
Clean build: 4m 15s
Rebuild:     1m 30s

## After removing docopt
Clean build: 2m 26s
Rebuild:     1m 20s

## After disable features of env_logger
Clean build: 2m 23s
Rebuild:     1m 18s

## After removing features of regex
Clean build: 2m 11s
Rebuild:     1m 17s

## After removing git2
Clean build: 1m 28s
Rebuild:     55.24s