### PR TITLE
#849 Add derive Default on Objects with parameters-less new functions

### DIFF
--- a/src/codegen/object.rs
+++ b/src/codegen/object.rs
@@ -151,11 +151,8 @@ pub fn generate(
 fn generate_builder(w: &mut dyn Write, env: &Env, analysis: &analysis::object::Info) -> Result<()> {
     let mut methods = vec![];
     let mut properties = vec![];
-    if analysis.functions.iter().any(|f| {
-        !f.visibility.hidden() && f.name == "new" && f.parameters.rust_parameters.is_empty()
-    }) {
-        writeln!(w, "#[derive(Default)]")?;
-    }
+    general::declare_default_from_new(w, env, &analysis.name, &analysis.functions)?;
+    writeln!(w)?;
     writeln!(w, "pub struct {}Builder {{", analysis.name)?;
     for property in &analysis.builder_properties {
         match rust_type(env, property.typ) {

--- a/src/codegen/object.rs
+++ b/src/codegen/object.rs
@@ -70,7 +70,7 @@ pub fn generate(
 
         writeln!(w, "}}")?;
 
-        general::declare_default_from_new(w, env, &analysis.name, &analysis.functions)?;
+        //general::declare_default_from_new(w, env, &analysis.name, &analysis.functions)?;
     }
 
     trait_impls::generate(
@@ -153,6 +153,11 @@ pub fn generate(
 fn generate_builder(w: &mut dyn Write, env: &Env, analysis: &analysis::object::Info) -> Result<()> {
     let mut methods = vec![];
     let mut properties = vec![];
+    if analysis.functions.iter().any(|f| {
+        !f.visibility.hidden() && f.name == "new" && f.parameters.rust_parameters.is_empty()
+    }) {
+        writeln!(w, "#[derive(Default)]")?;
+    }
     writeln!(w, "pub struct {}Builder {{", analysis.name)?;
     for property in &analysis.builder_properties {
         match rust_type(env, property.typ) {

--- a/src/codegen/object.rs
+++ b/src/codegen/object.rs
@@ -69,8 +69,6 @@ pub fn generate(
         }
 
         writeln!(w, "}}")?;
-
-        //general::declare_default_from_new(w, env, &analysis.name, &analysis.functions)?;
     }
 
     trait_impls::generate(


### PR DESCRIPTION
has been tested with the gtk updated master brach.
it changes from this previous generated code:
```rust
pub struct AboutDialogBuilder {
     artists: Option<Vec<String>>,
     authors: Option<Vec<String>>,
....
}
impl Default for AboutDialogBuilder {
      fn default() -> Self {
            Self::new()
      }
}
```
to:
```rust
#[derive(Default)]
pub struct AboutDialogBuilder {
     artists: Option<Vec<String>>,
     authors: Option<Vec<String>>,
....
}
```
maybe the `generate_default_for_new` function could be removed definitely, but is still used in `src/codegen/record.rs` in the `generate` function.

