### PR TITLE
Generate pinned box futures and use the stabilized futures

### DIFF
--- a/src/analysis/functions.rs
+++ b/src/analysis/functions.rs
@@ -32,8 +32,6 @@ use std::{
     collections::{HashMap, HashSet},
 };
 
-pub const CONSTRAINT_FUTURES: &str = "feature = \"futures\"";
-
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Visibility {
     Public,
@@ -695,15 +693,13 @@ fn analyze_function(
     if r#async && !commented {
         if env.config.library_name != "Gio" {
             imports.add("gio_sys");
-            imports.add_with_constraint("gio", version, Some(CONSTRAINT_FUTURES));
+            imports.add_with_constraint("gio", version, None);
         }
         imports.add("glib_sys");
         imports.add("gobject_sys");
         imports.add("std::ptr");
         imports.add("std::boxed::Box as Box_");
-        if async_future.is_some() {
-            imports.add_with_constraint("futures::future", version, Some(CONSTRAINT_FUTURES));
-        }
+        imports.add("std::pin::Pin");
 
         if let Some(ref trampoline) = trampoline {
             for par in &trampoline.output_params {

--- a/src/codegen/function.rs
+++ b/src/codegen/function.rs
@@ -98,7 +98,7 @@ pub fn generate(
 
         writeln!(
             w,
-            "{}{}#[cfg(any(feature = \"futures\", feature = \"dox\"))]",
+            "{}{}",
             tabs(indent),
             comment_prefix
         )?;
@@ -168,7 +168,7 @@ pub fn declaration_futures(env: &Env, analysis: &analysis::functions::Info) -> S
     let async_future = analysis.async_future.as_ref().unwrap();
 
     let return_str = format!(
-        " -> Box_<dyn future::Future<Output = Result<{}, {}>> + std::marker::Unpin>",
+        " -> Pin<Box_<dyn std::future::Future<Output = Result<{}, {}>> + 'static>>",
         async_future.success_parameters, async_future.error_parameters
     );
 


### PR DESCRIPTION
@GuillaumeGomez This depends on https://github.com/gtk-rs/glib/pull/531

When regenerating, all other crates need their `futures` feature removed and the dependency on the `futures` crate