### PR TITLE
Migrate to `tempfile` from deprecated `temdir`

### DIFF
--- a/src/codegen/sys/cargo_toml.rs
+++ b/src/codegen/sys/cargo_toml.rs
@@ -87,7 +87,8 @@ fn fill_in(root: &mut Table, env: &Env) {
     {
         let dev_deps = upsert_table(root, "dev-dependencies");
         set_string(dev_deps, "shell-words", "0.1.0");
-        set_string(dev_deps, "tempdir", "0.3");
+        set_string(dev_deps, "tempfile", "3");
+        unset(dev_deps, "tempdir");
     }
 
     {
@@ -149,6 +150,10 @@ fn set_string<S: Into<String>>(table: &mut Table, name: &str, new_value: S) {
         return;
     }
     table.insert(name.into(), Value::String(new_value.into()));
+}
+
+fn unset(table: &mut Table, name: &str) {
+    table.remove(name);
 }
 
 fn upsert_table<S: Into<String>>(parent: &mut Table, name: S) -> &mut Table {

--- a/src/codegen/sys/tests.rs
+++ b/src/codegen/sys/tests.rs
@@ -273,13 +273,14 @@ fn generate_abi_rs(
 
     writeln!(w, "extern crate {};", crate_name)?;
     writeln!(w, "extern crate shell_words;")?;
-    writeln!(w, "extern crate tempdir;")?;
+    writeln!(w, "extern crate tempfile;")?;
     writeln!(w, "use std::env;")?;
     writeln!(w, "use std::error::Error;")?;
     writeln!(w, "use std::path::Path;")?;
     writeln!(w, "use std::mem::{{align_of, size_of}};")?;
     writeln!(w, "use std::process::Command;")?;
     writeln!(w, "use std::str;")?;
+    writeln!(w, "use tempfile::Builder;")?;
     writeln!(w, "use {}::*;\n", crate_name)?;
     writeln!(w, "static PACKAGES: &[&str] = &[\"{}\"];", package_name)?;
     writeln!(
@@ -401,7 +402,7 @@ impl Results {
 
 #[test]
 fn cross_validate_constants_with_c() {
-    let tmpdir = tempdir::TempDir::new("abi").expect("temporary directory");
+    let tmpdir = Builder::new().prefix("abi").tempdir().expect("temporary directory");
     let cc = Compiler::new().expect("configured compiler");
 
     assert_eq!("1",
@@ -434,7 +435,7 @@ fn cross_validate_constants_with_c() {
 
 #[test]
 fn cross_validate_layout_with_c() {
-    let tmpdir = tempdir::TempDir::new("abi").expect("temporary directory");
+    let tmpdir = Builder::new().prefix("abi").tempdir().expect("temporary directory");
     let cc = Compiler::new().expect("configured compiler");
 
     assert_eq!(Layout {size: 1, alignment: 1},


### PR DESCRIPTION
The `tempdir` crate was deprecated by its authors, and `tempfile` is
recommended as a replacement.

I assume this is the first time that a dependency needs to be removed
from `Cargo.toml` files, because I found no functionality to remove the
entry. I created an `unset` function analogous to the `set_string`
function found in the `cargo_toml.rs` file.

Rationale: I do packaging work for rust crates in Debian, and due to
it's deprecation, we decided to not package the `tempdir` crate at all,
but to submit patches to the projects that still use it instead.