### PR TITLE
Fix off-by-one line numbers in xmlparser::ErrorEmitter

### DIFF
--- a/src/xmlparser.rs
+++ b/src/xmlparser.rs
@@ -37,13 +37,7 @@ struct ErrorEmitter {
 impl ErrorEmitter {
     pub fn emit(&self, message: &str, position: TextPosition) -> String {
         let enriched = match self.path {
-            Some(ref path) => format!(
-                "{} at line {}:{}: {}",
-                path.display(),
-                position.row,
-                position.column,
-                message
-            ),
+            Some(ref path) => format!("{} at line {}: {}", path.display(), position, message),
             None => format!("{} {}", position, message),
         };
         format!("GirXml: {}", enriched)


### PR DESCRIPTION
[TextPosition](https://docs.rs/xml-rs/0.8.0/xml/common/struct.TextPosition.html) starts [counting line numbers at 0](https://docs.rs/xml-rs/0.8.0/xml/common/struct.TextPosition.html#structfield.row). There is a ready made [implementation](https://docs.rs/xml-rs/0.8.0/src/xml/common.rs.html#51-53) of `fmt::Display` that accounts for this when showing a TextPosition to a human.

Using this implementation instead of manually showing the zero-indexed line number fixes an off by one error, that the line numbers displayed by the ErrorEmitter are currently having.