### PR TITLE
Add new nullable_return_is_error configuration for return types

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,9 @@ generate_builder = true
         # convert bool return types to Result<(), glib::BoolError> with
         # the given error message on failure
         bool_return_is_error = "Function failed doing what it is supposed to do"
+        # convert Option return types to Result<T, glib::BoolError> with
+        # the given error message on failure
+        nullable_return_is_error = "Function failed doing what it is supposed to do"
         # change string type. Variants: "utf8", "filename", "os_string"
         string_type = "os_string"
         # overwrite type

--- a/src/analysis/functions.rs
+++ b/src/analysis/functions.rs
@@ -721,10 +721,10 @@ fn analyze_function(
     }
 
     if !commented {
-        if !destroys.is_empty() || !callbacks.is_empty() {
-            if callbacks.iter().any(|c| !c.scope.is_call()) {
-                imports.add("std::boxed::Box as Box_");
-            }
+        if (!destroys.is_empty() || !callbacks.is_empty())
+            && callbacks.iter().any(|c| !c.scope.is_call())
+        {
+            imports.add("std::boxed::Box as Box_");
         }
         if !commented {
             for transformation in &mut parameters.transformations {

--- a/src/analysis/trampolines.rs
+++ b/src/analysis/trampolines.rs
@@ -69,10 +69,8 @@ pub fn analyze(
 
     //TODO: move to object.signal.return config
     let inhibit = configured_signals.iter().any(|f| f.inhibit);
-    if inhibit {
-        if signal.ret.typ != library::TypeId::tid_bool() {
-            error!("Wrong return type for Inhibit for signal '{}'", signal.name);
-        }
+    if inhibit && signal.ret.typ != library::TypeId::tid_bool() {
+        error!("Wrong return type for Inhibit for signal '{}'", signal.name);
     }
 
     let mut bounds: Bounds = Default::default();

--- a/src/chunk/chunk.rs
+++ b/src/chunk/chunk.rs
@@ -1,6 +1,7 @@
 use super::{conversion_from_glib, parameter_ffi_call_out};
 use crate::analysis::{function_parameters::TransformationType, return_value};
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Clone, Debug)]
 pub enum Chunk {
     Comment(Vec<Chunk>),

--- a/src/codegen/property_body.rs
+++ b/src/codegen/property_body.rs
@@ -105,6 +105,7 @@ impl Builder {
             base_tid: None,
             commented: false,
             bool_return_is_error: None,
+            nullable_return_is_error: None,
         };
         let ffi_call = Chunk::FfiCall {
             name: self.get_ffi_func(),
@@ -195,6 +196,7 @@ impl Builder {
             base_tid: None,
             commented: false,
             bool_return_is_error: None,
+            nullable_return_is_error: None,
         };
         body.push(Chunk::FfiCallConversion {
             ret: return_info,

--- a/src/config/functions.rs
+++ b/src/config/functions.rs
@@ -95,6 +95,7 @@ pub type Parameters = Vec<Parameter>;
 pub struct Return {
     pub nullable: Option<Nullable>,
     pub bool_return_is_error: Option<String>,
+    pub nullable_return_is_error: Option<String>,
     pub string_type: Option<StringType>,
     pub type_name: Option<String>,
 }
@@ -105,6 +106,7 @@ impl Return {
             return Return {
                 nullable: None,
                 bool_return_is_error: None,
+                nullable_return_is_error: None,
                 string_type: None,
                 type_name: None,
             };
@@ -112,13 +114,23 @@ impl Return {
 
         let v = toml.unwrap();
         v.check_unwanted(
-            &["nullable", "bool_return_is_error", "string_type", "type"],
+            &[
+                "nullable",
+                "bool_return_is_error",
+                "nullable_return_is_error",
+                "string_type",
+                "type",
+            ],
             "return",
         );
 
         let nullable = v.lookup("nullable").and_then(Value::as_bool).map(Nullable);
         let bool_return_is_error = v
             .lookup("bool_return_is_error")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned);
+        let nullable_return_is_error = v
+            .lookup("nullable_return_is_error")
             .and_then(Value::as_str)
             .map(ToOwned::to_owned);
         let string_type = v.lookup("string_type").and_then(Value::as_str);
@@ -147,6 +159,7 @@ impl Return {
         Return {
             nullable,
             bool_return_is_error,
+            nullable_return_is_error,
             string_type,
             type_name,
         }


### PR DESCRIPTION
This allows converting an Option<T> into an Result<T, glib::BoolError>,
which in case of Option signalling error allows for more ergonomic error
handling code.

----

CC @EPashkin @GuillaumeGomez 