### PR TITLE
Fix returning array from async trampolines

### DIFF
--- a/src/analysis/bounds.rs
+++ b/src/analysis/bounds.rs
@@ -295,7 +295,7 @@ impl PropertyBound {
 }
 
 fn find_out_parameters(env: &Env, function: &Function) -> Vec<String> {
-    let index_to_ignore = find_index_to_ignore(&function.parameters);
+    let index_to_ignore = find_index_to_ignore(&function.parameters, Some(&function.ret));
     function
         .parameters
         .iter()

--- a/src/analysis/functions.rs
+++ b/src/analysis/functions.rs
@@ -1103,9 +1103,10 @@ pub fn finish_function_name(mut func_name: &str) -> String {
     format!("{}_finish", &func_name)
 }
 
-pub fn find_index_to_ignore(parameters: &[Parameter]) -> Option<usize> {
+pub fn find_index_to_ignore(parameters: &[Parameter], ret: Option<&Parameter>) -> Option<usize> {
     parameters
         .iter()
+        .chain(ret)
         .find(|param| param.array_length.is_some())
         .and_then(|param| param.array_length.map(|length| length as usize))
 }

--- a/src/codegen/function_body_chunk.rs
+++ b/src/codegen/function_body_chunk.rs
@@ -754,7 +754,8 @@ impl Builder {
             found_async_result,
             "The check *wasn't* performed in analysis part: Guillaume was wrong!"
         );
-        let index_to_ignore = find_index_to_ignore(&trampoline.output_params);
+        let index_to_ignore =
+            find_index_to_ignore(&trampoline.output_params, trampoline.ffi_ret.as_ref());
         let mut result: Vec<_> = trampoline
             .output_params
             .iter()


### PR DESCRIPTION
Fix #872 

```rust
    fn get_data<P: IsA<gio::Cancellable>, Q: FnOnce(Result<Vec<u8>, glib::Error>) + Send + 'static>(&self, cancellable: Option<&P>, callback: Q) {
        let user_data: Box_<Q> = Box_::new(callback);
        unsafe extern "C" fn get_data_trampoline<Q: FnOnce(Result<Vec<u8>, glib::Error>) + Send + 'static>(_source_object: *mut gobject_sys::GObject, res: *mut gio_sys::GAsyncResult, user_data: glib_sys::gpointer) {
            let mut error = ptr::null_mut();
            let mut length = mem::MaybeUninit::uninit();
            let ret = webkit2_sys::webkit_web_resource_get_data_finish(_source_object as *mut _, res, length.as_mut_ptr(), &mut error);
            let result = if error.is_null() { Ok(FromGlibContainer::from_glib_full_num(ret, length.assume_init() as usize)) } else { Err(from_glib_full(error)) };
            let callback: Box_<Q> = Box_::from_raw(user_data as *mut _);
            callback(result);
        }
        let callback = get_data_trampoline::<Q>;
        unsafe {
            webkit2_sys::webkit_web_resource_get_data(self.as_ref().to_glib_none().0, cancellable.map(|p| p.as_ref()).to_glib_none().0, Some(callback), Box_::into_raw(user_data) as *mut _);
        }
    }
```
no changes in main gtk-rs crates

cc @GuillaumeGomez, @sdroege, @bilelmoussaoui 