### PR TITLE
Allow to override use-return-for-result in function configuration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,10 @@ generate_builder = true
         # convert Option return types to Result<T, glib::BoolError> with
         # the given error message on failure
         nullable_return_is_error = "Function failed doing what it is supposed to do"
+        # always include the return value of throwing functions in the returned Result<...>,
+        # without this option bool and guint return values are assumed to indicate success or error,
+        # and are not included in the returned Result<...>
+        use_return_for_result = true
         # change string type. Variants: "utf8", "filename", "os_string"
         string_type = "os_string"
         # overwrite type

--- a/src/analysis/bounds.rs
+++ b/src/analysis/bounds.rs
@@ -6,6 +6,7 @@ use crate::{
         out_parameters::use_function_return_for_result,
         rust_type::{bounds_rust_type, rust_type, rust_type_with_scope},
     },
+    config,
     consts::TYPE_PARAMETERS_START,
     env::Env,
     library::{
@@ -81,6 +82,7 @@ impl Bounds {
         par: &CParameter,
         r#async: bool,
         concurrency: Concurrency,
+        configured_functions: &[&config::functions::Function],
     ) -> (Option<String>, Option<CallbackInfo>) {
         let type_name = bounds_rust_type(env, par.typ);
         if (r#async && async_param_to_remove(&par.name)) || type_name.is_err() {
@@ -99,7 +101,12 @@ impl Bounds {
                     let finish_func_name = finish_function_name(func_name);
                     if let Some(function) = find_function(env, &finish_func_name) {
                         let mut out_parameters = find_out_parameters(env, function);
-                        if use_function_return_for_result(env, function.ret.typ) {
+                        if use_function_return_for_result(
+                            env,
+                            function.ret.typ,
+                            &func.name,
+                            configured_functions,
+                        ) {
                             out_parameters
                                 .insert(0, rust_type(env, function.ret.typ).into_string());
                         }

--- a/src/config/functions.rs
+++ b/src/config/functions.rs
@@ -96,6 +96,7 @@ pub struct Return {
     pub nullable: Option<Nullable>,
     pub bool_return_is_error: Option<String>,
     pub nullable_return_is_error: Option<String>,
+    pub use_return_for_result: Option<bool>,
     pub string_type: Option<StringType>,
     pub type_name: Option<String>,
 }
@@ -107,6 +108,7 @@ impl Return {
                 nullable: None,
                 bool_return_is_error: None,
                 nullable_return_is_error: None,
+                use_return_for_result: None,
                 string_type: None,
                 type_name: None,
             };
@@ -118,6 +120,7 @@ impl Return {
                 "nullable",
                 "bool_return_is_error",
                 "nullable_return_is_error",
+                "use_return_for_result",
                 "string_type",
                 "type",
             ],
@@ -133,6 +136,7 @@ impl Return {
             .lookup("nullable_return_is_error")
             .and_then(Value::as_str)
             .map(ToOwned::to_owned);
+        let use_return_for_result = v.lookup("use_return_for_result").and_then(Value::as_bool);
         let string_type = v.lookup("string_type").and_then(Value::as_str);
         let string_type = match string_type {
             None => None,
@@ -160,6 +164,7 @@ impl Return {
             nullable,
             bool_return_is_error,
             nullable_return_is_error,
+            use_return_for_result,
             string_type,
             type_name,
         }


### PR DESCRIPTION
This PR allows the configuration file to override `use-return-for-result` per function. There are many functions in practice that return a `boolean` or `guint` where the return value is a real value and doesn't just indicate if an error occurred.

You could argue that libraries shouldn't do that, or that the GIR format should allow a tag to distinguish this. However, I think we also have to be able to deal with the current situation, and I figured this is the most logical work-around.

Feedback welcome :) 