### PR TITLE
Check gir file

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -118,7 +118,7 @@ fn run_check(check_gir_file: &str) -> Result<(), String> {
         Some(p) => p,
         None => return Err(format!("Failed to get parent directory from `{}`", check_gir_file)),
     };
-    return library.read_file(&parent, &lib_name);
+    return library.read_file(&parent, &mut vec![lib_name.to_owned()]);
 }
 
 fn do_main() -> Result<(), String> {
@@ -147,7 +147,7 @@ fn do_main() -> Result<(), String> {
         let _watcher = statistics.enter("Loading");
 
         library = Library::new(&cfg.library_name);
-        library.read_file(&cfg.girs_dir, &cfg.library_full_name())?;
+        library.read_file(&cfg.girs_dir, &mut vec![cfg.library_full_name()])?;
     }
 
     {

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,7 +50,12 @@ fn build_config() -> Result<(Option<Config>, Option<String>), String> {
     options.optflag("b", "make-backup", "Make backup before generating");
     options.optflag("s", "stats", "Show statistics");
     options.optflag("", "disable-format", "Disable formatting generated code");
-    options.optopt("", "check-gir-file", "Check if the given `.gir` file is valid", "PATH");
+    options.optopt(
+        "",
+        "check-gir-file",
+        "Check if the given `.gir` file is valid",
+        "PATH",
+    );
 
     let matches = match options.parse(&args[1..]) {
         Ok(matches) => matches,
@@ -88,7 +93,8 @@ fn build_config() -> Result<(Option<Config>, Option<String>), String> {
         matches.opt_present("b"),
         matches.opt_present("s"),
         matches.opt_present("disable-format"),
-    ).map(|x| (Some(x), None))
+    )
+    .map(|x| (Some(x), None))
 }
 
 #[cfg_attr(test, allow(dead_code))]
@@ -116,7 +122,12 @@ fn run_check(check_gir_file: &str) -> Result<(), String> {
     let mut library = Library::new(lib_name);
     let parent = match path.parent() {
         Some(p) => p,
-        None => return Err(format!("Failed to get parent directory from `{}`", check_gir_file)),
+        None => {
+            return Err(format!(
+                "Failed to get parent directory from `{}`",
+                check_gir_file
+            ))
+        }
     };
     return library.read_file(&parent, &mut vec![lib_name.to_owned()]);
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -27,7 +27,12 @@ impl Library {
         })
     }
 
-    fn read_repository(&mut self, dir: &Path, parser: &mut XmlParser<'_>, libs: &mut Vec<String>) -> Result<(), String> {
+    fn read_repository(
+        &mut self,
+        dir: &Path,
+        parser: &mut XmlParser<'_>,
+        libs: &mut Vec<String>,
+    ) -> Result<(), String> {
         let mut package = None;
         let mut includes = Vec::new();
         parser.elements(|parser, elem| match elem.name() {
@@ -37,7 +42,11 @@ impl Library {
                         if self.find_namespace(name).is_none() {
                             let lib = format!("{}-{}", name, ver);
                             if libs.iter().any(|x| *x == lib) {
-                                return Err(format!("`{}` includes itself (full path:`{}`)!", lib, libs.join("::")));
+                                return Err(format!(
+                                    "`{}` includes itself (full path:`{}`)!",
+                                    lib,
+                                    libs.join("::")
+                                ));
                             }
                             libs.push(lib);
                             self.read_file(dir, libs)?;


### PR DESCRIPTION
The first commit is in order to provide a way to check gir files for GNOME so they don't have to wait for us to report bugs. Once this PR is merged, I'll create a Dockerfile and send it to https://gitlab.gnome.org/GNOME/gtk/tree/master/.gitlab-ci/

The second commit is "funnier": when testing the option, I decided to use the dl.sh script to get the latest (and buggy) gir files for gtk4. And when I ran it (expecting a failure), I got:

```
Can't open file "../gir-files/Gsk-4.0.gir": Too many open files (os error 24)
```

After a little search, and a nice run using strace:

```bash
strace -e trace=open,close,read,write,connect,accept ./target/release/gir --check-gir-file ../gir-files/Gtk-4.0.gir
```

I discovered that gir was opening thousands of file. At this point, it seemed pretty obvious that the problem was a circular dependency. Therefore, I added a small check in order to prevent it to happen.

cc @EPashkin @sdroege 