### PR TITLE
git: check return value from 'git' command

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -8,7 +8,11 @@ pub fn repo_hash<P: AsRef<Path>>(path: P) -> Option<String> {
         None => vec![],
     };
     args.extend(&["rev-parse", "--short", "HEAD"]);
-    let hash = String::from_utf8(Command::new("git").args(&args).output().ok()?.stdout).ok()?;
+    let output = Command::new("git").args(&args).output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let hash = String::from_utf8(output.stdout).ok()?;
     let hash = hash.trim_end_matches('\n');
 
     if dirty(path) {


### PR DESCRIPTION
Command::output() succeeds as long as the command was actually called.
It's up to the user to check if the command was properly executed or
not.

Fix returning Some("") instead of None when calling repo_hash() with an
invalid git repo path.