### PR TITLE
Revert "Remove all transmute calls in generated code"

### DIFF
--- a/src/analysis/properties.rs
+++ b/src/analysis/properties.rs
@@ -293,6 +293,7 @@ fn analyze_property(
             }
             imports.add("glib::signal::connect_raw");
             imports.add("glib::signal::SignalHandlerId");
+            imports.add("std::mem::transmute");
             imports.add("std::boxed::Box as Box_");
             imports.add("glib_sys");
 

--- a/src/analysis/signals.rs
+++ b/src/analysis/signals.rs
@@ -106,6 +106,7 @@ fn analyze_signal(
         }
         imports.add("glib::signal::connect_raw");
         imports.add("glib::signal::SignalHandlerId");
+        imports.add("std::mem::transmute");
         imports.add("std::boxed::Box as Box_");
         imports.add("glib_sys");
     }

--- a/src/writer/to_code.rs
+++ b/src/writer/to_code.rs
@@ -135,7 +135,7 @@ impl ToCode for Chunk {
                 );
                 let self_str = if in_trait { "Self, " } else { "" };
                 let s2 = format!(
-                    "\tSome(*(&{}::<{}F> as *const _ as *const _)), Box_::into_raw(f))",
+                    "\tSome(transmute({}::<{}F> as usize)), Box_::into_raw(f))",
                     trampoline, self_str
                 );
                 vec![s1, s2]


### PR DESCRIPTION
Unfortunately, it wasn't a successful experiment... A solution is still possible without `transmute`:

```rust
fn foo() {
    println!("bla");
}

fn bar(i: u32) {
    println!("bar");
}

fn main() {
    unsafe {
        let b = bar as fn(u32);
        let b = &b;
        let b = b as *const fn(u32) as *const fn();
        (*b)();
    }
}
```

But `transmute` seems to be the simplest solution. So let's go back to it.

Reverts gtk-rs/gir#896

cc @EPashkin @sdroege 