### PR TITLE
tests: use split_build_rs in gdk gir test

### DIFF
--- a/tests/sys/gir-gdk.toml
+++ b/tests/sys/gir-gdk.toml
@@ -5,6 +5,7 @@ library = "Gdk"
 version = "3.0"
 min_cfg_version = "3.4"
 target_path = "./gdk-sys"
+split_build_rs = true
 external_libraries = [
    "GLib",
    "GObject",


### PR DESCRIPTION
The reason #917 was needed (that #915 passed CI) was that the new feature @EPashkin added wasn't actually tested by any of the tests.  This patch causes `gdk-sys` in the tests to require the split build option.  This way bugs in this code in the future should be caught.