### PR TITLE
Add options.extra_versions and lib_version_overrides configurations

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -17,15 +17,6 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         toolchain: [stable]
-        include:
-          - os: windows-latest
-            bits: 32
-            arch: i686
-            toolchain: stable-i686-pc-windows-gnu
-          - os: windows-latest
-            bits: 64
-            arch: x86_64
-            toolchain: stable-x86_64-pc-windows-gnu
 
     defaults:
       run:
@@ -42,15 +33,6 @@ jobs:
           profile: minimal
           components: rustfmt, clippy
         id: toolchain
-      - name: Install MSYS2
-        uses: numworks/setup-msys2@v1
-        if: matrix.os == 'windows-latest'
-      - name: Set up MSYS2 path and other windows env
-        run: |
-          echo "::add-path::$RUNNER_TEMP\\msys\\msys64\\usr\\bin"
-          echo "::add-path::$RUNNER_TEMP\\msys\\msys64\\mingw${{ matrix.bits }}\\bin"
-          echo "::set-env name=LIBGIT2_SYS_USE_PKG_CONFIG::1"
-        if: matrix.os == 'windows-latest'
       - name: Cache cargo registry
         uses: actions/cache@v1
         with:
@@ -69,12 +51,6 @@ jobs:
       - name: Install packages from apt
         run: sudo apt install libgtk-3-dev libssh2-1-dev
         if: matrix.os == 'ubuntu-latest'
-      - name: Install toolchain packages with pacman
-        run: pacman --noconfirm -S base-devel mingw-w64-${{ matrix.arch }}-toolchain
-        if: matrix.os == 'windows-latest'
-      - name: Install library devel packages with pacman
-        run: pacman --noconfirm -S mingw-w64-${{ matrix.arch }}-gtk3 mingw-w64-${{ matrix.arch }}-libgit2 mingw-w64-${{ matrix.arch }}-libsecret
-        if: matrix.os == 'windows-latest'
       - name: "Acquire gir-files"
         uses: actions/checkout@v2
         with:
@@ -86,11 +62,13 @@ jobs:
         with:
           command: clippy
           args: --release --tests -- -D warnings
+        if: matrix.os == 'ubuntu-latest'
       - name: "Run formatting check"
         uses: actions-rs/cargo@v1
         with:
           command: fmt
           args: -- --check
+        if: matrix.os == 'ubuntu-latest'
 
   build:
     name: "Build/Test"

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -51,12 +51,6 @@ jobs:
       - name: Install packages from apt
         run: sudo apt install libgtk-3-dev libssh2-1-dev
         if: matrix.os == 'ubuntu-latest'
-      - name: "Acquire gir-files"
-        uses: actions/checkout@v2
-        with:
-          repository: gtk-rs/gir-files
-          ref: master
-          path: tests/gir-files
       - name: "Run clippy"
         uses: actions-rs/cargo@v1
         with:
@@ -170,15 +164,8 @@ jobs:
           ref: master
           path: gtk-test
         if: matrix.os == 'ubuntu-latest'
-      - name: "Acquire gir-files for GTK test"
-        uses: actions/checkout@v2
-        with:
-          repository: gtk-rs/gir-files
-          ref: master
-          path: gtk-gir-files
-        if: matrix.os == 'ubuntu-latest'
       - name: "Attempt to rebuild GTK gir"
-        run: cd gtk-test && ../target/release/gir -d ../gtk-gir-files/ -o . && rm ../Cargo.* && cargo build
+        run: cd gtk-test && ../target/release/gir -d ../tests/gir-files/ -o . && rm ../Cargo.* && cargo build
         if: matrix.os == 'ubuntu-latest'
       - name: "Acquire gio"
         uses: actions/checkout@v2
@@ -188,5 +175,5 @@ jobs:
           path: gio
         if: matrix.os == 'ubuntu-latest'
       - name: "Rebuild gio"
-        run: cd gio && git submodule update --init && ../target/release/gir -d gir-files -o . && cargo test
+        run: cd gio && ../target/release/gir -d ../tests/gir-files/ -o . && cargo test
         if: matrix.os == 'ubuntu-latest'

--- a/README.md
+++ b/README.md
@@ -63,6 +63,15 @@ work_mode = "sys"
 # and build.rs that generated only if not exists.
 # Defaults to false
 split_build_rs = false
+#Adds extra versions to features
+extra_versions = [
+   "3.15",
+   "3.17",
+]
+#Change library version for version
+[[lib_version_overrides]]
+version = "3.16"
+lib_version = "3.16.1"
 ```
 
 You can mark some functions that has suffix `_utf8` on Windows:

--- a/README.md
+++ b/README.md
@@ -72,6 +72,12 @@ extra_versions = [
 [[lib_version_overrides]]
 version = "3.16"
 lib_version = "3.16.1"
+#Add extra dependencies to feature
+[[feature_dependencies]]
+version = "3.16"
+dependencies = [
+  "glib-sys/v3_16"
+]
 ```
 
 You can mark some functions that has suffix `_utf8` on Windows:

--- a/src/codegen/sys/cargo_toml.rs
+++ b/src/codegen/sys/cargo_toml.rs
@@ -1,3 +1,4 @@
+use super::collect_versions;
 use crate::{config::Config, env::Env, file_saver::save_to_file, nameutil, version::Version};
 use log::info;
 use std::{fs::File, io::prelude::*};
@@ -93,13 +94,8 @@ fn fill_in(root: &mut Table, env: &Env) {
 
     {
         let features = upsert_table(root, "features");
-        let versions = env
-            .namespaces
-            .main()
-            .versions
-            .iter()
-            .filter(|&&v| v > env.config.min_cfg_version);
-        versions.fold(None::<Version>, |prev, &version| {
+        let versions = collect_versions(env);
+        versions.keys().fold(None::<Version>, |prev, &version| {
             let prev_array: Vec<Value> =
                 prev.iter().map(|v| Value::String(v.to_feature())).collect();
             features.insert(version.to_feature(), Value::Array(prev_array));

--- a/src/codegen/sys/mod.rs
+++ b/src/codegen/sys/mod.rs
@@ -1,4 +1,5 @@
-use crate::{codegen::generate_single_version_file, env::Env};
+use crate::{codegen::generate_single_version_file, env::Env, version::Version};
+use std::collections::BTreeMap;
 
 mod build;
 mod cargo_toml;
@@ -15,4 +16,25 @@ pub fn generate(env: &Env) {
     build::generate(env);
     let crate_name = cargo_toml::generate(env);
     tests::generate(env, &crate_name);
+}
+
+pub fn collect_versions(env: &Env) -> BTreeMap<Version, Version> {
+    let mut versions: BTreeMap<Version, Version> = env
+        .namespaces
+        .main()
+        .versions
+        .iter()
+        .filter(|v| **v > env.config.min_cfg_version)
+        .map(|v| (*v, *v))
+        .collect();
+
+    for v in &env.config.extra_versions {
+        versions.insert(*v, *v);
+    }
+
+    for (version, lib_version) in &env.config.lib_version_overrides {
+        versions.insert(*version, *lib_version);
+    }
+
+    versions
 }

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -48,7 +48,7 @@ pub struct Config {
 }
 
 impl Config {
-    pub fn new<'a, S, B, W>(
+    pub fn new<'a, S, W>(
         config_file: S,
         work_mode: W,
         girs_dir: S,
@@ -56,13 +56,12 @@ impl Config {
         library_version: S,
         target_path: S,
         doc_target_path: S,
-        make_backup: B,
-        show_statistics: B,
-        disable_format: B,
+        make_backup: bool,
+        show_statistics: bool,
+        disable_format: bool,
     ) -> Result<Config, String>
     where
         S: Into<Option<&'a str>>,
-        B: Into<Option<bool>>,
         W: Into<Option<WorkMode>>,
     {
         let config_file: PathBuf = match config_file.into() {
@@ -217,12 +216,12 @@ impl Config {
             None => None,
         };
 
-        let disable_format: bool = if let Some(disable_format) = disable_format.into() {
-            disable_format
+        let disable_format: bool = if disable_format {
+            true
         } else {
             match toml.lookup("options.disable_format") {
                 Some(v) => v.as_result_bool("options.disable_format")?,
-                None => false,
+                None => true,
             }
         };
 
@@ -247,10 +246,10 @@ impl Config {
             external_libraries,
             objects,
             min_cfg_version,
-            make_backup: make_backup.into().unwrap_or(false),
+            make_backup,
             generate_safety_asserts,
             deprecate_by_min_version,
-            show_statistics: show_statistics.into().unwrap_or(false),
+            show_statistics,
             concurrency,
             single_version_file,
             generate_display_trait,


### PR DESCRIPTION
Fix #916 

@sdroege Please test this.

I also found that previous version lost "v1_36_7" in pango and "v2_44" in glib in build.rs, and only added it to Cargo.toml

cc @GuillaumeGomez 
