### PR TITLE
Fix some code generation issues

### DIFF
--- a/src/codegen/function_body_chunk.rs
+++ b/src/codegen/function_body_chunk.rs
@@ -414,10 +414,7 @@ impl Builder {
                 add_chunk_for_type(env, par.typ, par, &mut body, &ty_name, nullable);
             if ty_name == "GString" {
                 if *nullable {
-                    arguments.push(Chunk::Name(format!(
-                        "{}.as_ref().map(|x| x.as_str())",
-                        par.name
-                    )));
+                    arguments.push(Chunk::Name(format!("{}.as_ref().as_deref()", par.name)));
                 } else {
                     arguments.push(Chunk::Name(format!("{}.as_str()", par.name)));
                 }
@@ -1364,9 +1361,6 @@ fn add_chunk_for_type(
                 "let {1}{3} = {0}{1}{2};",
                 begin, par.name, end, type_name
             )));
-            if ty_name == "GString" && *nullable {
-                body.push(Chunk::Custom(format!("let {0} = {0}.as_ref();", par.name)));
-            }
             x.is_fundamental()
         }
     }

--- a/src/codegen/signal.rs
+++ b/src/codegen/signal.rs
@@ -125,7 +125,7 @@ pub fn generate(
 
             writeln!(
                 w,
-                "{}let {} = unsafe {{ glib::Object::from_glib_borrow(self.to_glib_none().0 as *mut gobject_sys::GObject).emit(\"{}\", &[{}]).unwrap() }};",
+                "{}let {} = unsafe {{ glib::Object::from_glib_borrow(self.as_ptr() as *mut gobject_sys::GObject).emit(\"{}\", &[{}]).unwrap() }};",
                 tabs(indent + 1),
                 if trampoline.ret.typ != Default::default() {
                     "res"


### PR DESCRIPTION
```
commit 6d9a4cc73a956e6ca97adcbcd3ef2826356c2bce (HEAD -> as_deref)
Author: Sebastian Dröge <sebastian@centricular.com>
Date:   Wed Jun 3 17:31:37 2020 +0300

    Fix generation of signal emit functions outside traits
    
    512 |             glib::Object::from_glib_borrow(self.to_glib_none().0 as *mut gobject_sys::GObject)
        |                                            -----^^^^^^^^^^^^--
        |                                            |    |
        |                                            |    cannot infer type for type parameter `P` declared on the trait `ToGlibPtr`
        |                                            this method call resolves to `glib::translate::Stash<'a, P, Self>`

commit 8d7902afa507498e8342b3ad23d6672aa04b379c
Author: Sebastian Dröge <sebastian@centricular.com>
Date:   Wed Jun 3 17:30:38 2020 +0300

    Use Option::as_deref() in more places to simplify code
    
    And also fixes compiler errors in rare cases:
    
    434 |                 Option::<GString>::from_glib_borrow(data).as_ref().as_ref(),
        |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `str`, found struct `glib::GString`
        |
        = note: expected enum `std::option::Option<&str>`
                   found enum `std::option::Option<&glib::GString>`
```

CC @GuillaumeGomez @EPashkin 