### PR TITLE
Fix and ignore clippy warnings

### DIFF
--- a/src/codegen/enums.rs
+++ b/src/codegen/enums.rs
@@ -93,6 +93,7 @@ pub fn generate(env: &Env, root_path: &Path, mod_rs: &mut Vec<String>) {
     });
 }
 
+#[allow(clippy::write_literal)]
 fn generate_enum(
     env: &Env,
     w: &mut dyn Write,

--- a/src/codegen/flags.rs
+++ b/src/codegen/flags.rs
@@ -75,6 +75,7 @@ pub fn generate(env: &Env, root_path: &Path, mod_rs: &mut Vec<String>) {
     });
 }
 
+#[allow(clippy::write_literal)]
 fn generate_flags(env: &Env, w: &mut dyn Write, flags: &Bitfield, config: &GObject) -> Result<()> {
     let sys_crate_name = env.main_sys_crate_name();
     cfg_deprecated(w, env, flags.deprecated_version, false, 0)?;

--- a/src/codegen/sys/build.rs
+++ b/src/codegen/sys/build.rs
@@ -32,6 +32,7 @@ pub fn generate(env: &Env) {
     }
 }
 
+#[allow(clippy::write_literal)]
 fn generate_build_script(w: &mut dyn Write, env: &Env, split_build_rs: bool) -> Result<()> {
     if !split_build_rs {
         general::start_comments(w, &env.config)?;

--- a/src/codegen/sys/lib_.rs
+++ b/src/codegen/sys/lib_.rs
@@ -183,7 +183,7 @@ fn generate_bitfields(w: &mut dyn Write, env: &Env, items: &[&Bitfield]) -> Resu
             let member_config = config
                 .as_ref()
                 .map(|c| c.members.matched(&member.name))
-                .unwrap_or_else(|| vec![]);
+                .unwrap_or_else(Vec::new);
             let version = member_config.iter().filter_map(|m| m.version).next();
 
             let val: i64 = member.value.parse().unwrap();
@@ -289,7 +289,7 @@ fn generate_enums(w: &mut dyn Write, env: &Env, items: &[&Enumeration]) -> Resul
             let member_config = config
                 .as_ref()
                 .map(|c| c.members.matched(&member.name))
-                .unwrap_or_else(|| vec![]);
+                .unwrap_or_else(Vec::new);
             let is_alias = member_config.iter().any(|m| m.alias);
             let version = member_config.iter().filter_map(|m| m.version).next();
 

--- a/src/codegen/sys/tests.rs
+++ b/src/codegen/sys/tests.rs
@@ -203,6 +203,7 @@ fn generate_manual_h(env: &Env, path: &Path, w: &mut dyn Write) -> io::Result<()
     Ok(())
 }
 
+#[allow(clippy::write_literal)]
 fn generate_layout_c(env: &Env, path: &Path, w: &mut dyn Write) -> io::Result<()> {
     info!("Generating file {:?}", path);
     general::start_comments(w, &env.config)?;
@@ -222,6 +223,7 @@ int main() {
     )
 }
 
+#[allow(clippy::write_literal)]
 fn generate_constant_c(env: &Env, path: &Path, w: &mut dyn Write) -> io::Result<()> {
     info!("Generating file {:?}", path);
     general::start_comments(w, &env.config)?;
@@ -256,6 +258,7 @@ int main() {
     )
 }
 
+#[allow(clippy::write_literal)]
 fn generate_abi_rs(
     env: &Env,
     path: &Path,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -536,7 +536,10 @@ impl Library {
         elem: &Element,
     ) -> Result<(), String> {
         self.read_function_if_not_moved(parser, ns_id, elem.name(), elem)?
-            .map(|func| self.add_type(ns_id, &func.name.clone(), Type::Function(func)));
+            .map(|func| {
+                let name = func.name.clone();
+                self.add_type(ns_id, &name, Type::Function(func))
+            });
 
         Ok(())
     }


### PR DESCRIPTION
New clippy is much stricter.

I decided to ignore `write_literal` because we printing many brackets.

cc @GuillaumeGomez , @sdroege 