### PR TITLE
Correctly get function configuration and make use of it for get_type(…

### DIFF
--- a/src/analysis/namespaces.rs
+++ b/src/analysis/namespaces.rs
@@ -12,6 +12,7 @@ pub struct Namespace {
     pub sys_crate_name: String,
     pub higher_crate_name: String,
     pub package_name: Option<String>,
+    pub symbol_prefixes: Vec<String>,
     pub shared_libs: Vec<String>,
     pub versions: Vec<Version>,
 }
@@ -56,6 +57,7 @@ pub fn run(gir: &library::Library) -> Info {
             sys_crate_name,
             higher_crate_name,
             package_name: ns.package_name.clone(),
+            symbol_prefixes: ns.symbol_prefixes.clone(),
             shared_libs: ns.shared_library.clone(),
             versions: ns.versions.iter().cloned().collect(),
         });

--- a/src/library.rs
+++ b/src/library.rs
@@ -363,6 +363,7 @@ pub struct Member {
 pub struct Enumeration {
     pub name: String,
     pub c_type: String,
+    pub symbol_prefix: Option<String>,
     pub members: Vec<Member>,
     pub functions: Vec<Function>,
     pub version: Option<Version>,
@@ -377,6 +378,7 @@ pub struct Enumeration {
 pub struct Bitfield {
     pub name: String,
     pub c_type: String,
+    pub symbol_prefix: Option<String>,
     pub members: Vec<Member>,
     pub functions: Vec<Function>,
     pub version: Option<Version>,
@@ -390,6 +392,7 @@ pub struct Bitfield {
 pub struct Record {
     pub name: String,
     pub c_type: String,
+    pub symbol_prefix: Option<String>,
     pub glib_get_type: Option<String>,
     pub gtype_struct_for: Option<String>,
     pub fields: Vec<Field>,
@@ -418,6 +421,7 @@ pub struct Field {
 pub struct Union {
     pub name: String,
     pub c_type: Option<String>,
+    pub symbol_prefix: Option<String>,
     pub glib_get_type: Option<String>,
     pub fields: Vec<Field>,
     pub functions: Vec<Function>,
@@ -491,6 +495,7 @@ pub struct Signal {
 pub struct Interface {
     pub name: String,
     pub c_type: String,
+    pub symbol_prefix: String,
     pub type_struct: Option<String>,
     pub c_class_type: Option<String>,
     pub glib_get_type: String,
@@ -508,6 +513,7 @@ pub struct Interface {
 pub struct Class {
     pub name: String,
     pub c_type: String,
+    pub symbol_prefix: String,
     pub type_struct: Option<String>,
     pub c_class_type: Option<String>,
     pub glib_get_type: String,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -140,6 +140,7 @@ impl Library {
     ) -> Result<(), String> {
         let class_name = elem.attr_required("name")?;
         let c_type = self.read_object_c_type(parser, elem)?;
+        let symbol_prefix = elem.attr_required("symbol-prefix").map(ToOwned::to_owned)?;
         let type_struct = elem.attr("type-struct").map(ToOwned::to_owned);
         let get_type = elem.attr_required("get-type")?;
         let version = self.read_version(parser, ns_id, elem)?;
@@ -227,6 +228,7 @@ impl Library {
             doc_deprecated,
             version,
             deprecated_version,
+            symbol_prefix,
         });
         self.add_type(ns_id, class_name, typ);
         Ok(())
@@ -255,6 +257,7 @@ impl Library {
     ) -> Result<Option<Type>, String> {
         let record_name = elem.attr_required("name")?;
         let c_type = elem.attr_required("type")?;
+        let symbol_prefix = elem.attr("symbol-prefix").map(ToOwned::to_owned);
         let get_type = elem.attr("get-type").map(ToOwned::to_owned);
         let gtype_struct_for = elem.attr("is-gtype-struct-for");
         let version = self.read_version(parser, ns_id, elem)?;
@@ -348,6 +351,7 @@ impl Library {
             doc,
             doc_deprecated,
             disguised,
+            symbol_prefix,
         });
 
         Ok(Some(typ))
@@ -388,6 +392,7 @@ impl Library {
         let union_name = elem.attr("name").unwrap_or("");
         let c_type = self.read_object_c_type(parser, elem).unwrap_or("");
         let get_type = elem.attr("get-type").map(|s| s.into());
+        let symbol_prefix = elem.attr("symbol-prefix").map(ToOwned::to_owned);
 
         let mut fields = Vec::new();
         let mut fns = Vec::new();
@@ -475,6 +480,7 @@ impl Library {
             fields,
             functions: fns,
             doc,
+            symbol_prefix,
         })
     }
 
@@ -552,6 +558,7 @@ impl Library {
     ) -> Result<(), String> {
         let interface_name = elem.attr_required("name")?;
         let c_type = self.read_object_c_type(parser, elem)?;
+        let symbol_prefix = elem.attr_required("symbol-prefix").map(ToOwned::to_owned)?;
         let type_struct = elem.attr("type-struct").map(ToOwned::to_owned);
         let get_type = elem.attr_required("get-type")?;
         let version = self.read_version(parser, ns_id, elem)?;
@@ -601,6 +608,7 @@ impl Library {
             doc_deprecated,
             version,
             deprecated_version,
+            symbol_prefix,
         });
         self.add_type(ns_id, interface_name, typ);
         Ok(())
@@ -614,6 +622,7 @@ impl Library {
     ) -> Result<(), String> {
         let bitfield_name = elem.attr_required("name")?;
         let c_type = self.read_object_c_type(parser, elem)?;
+        let symbol_prefix = elem.attr("symbol-prefix").map(ToOwned::to_owned);
         let get_type = elem.attr("get-type").map(|s| s.into());
         let version = self.read_version(parser, ns_id, elem)?;
         let deprecated_version = self.read_deprecated_version(parser, ns_id, elem)?;
@@ -645,6 +654,7 @@ impl Library {
             doc,
             doc_deprecated,
             glib_get_type: get_type,
+            symbol_prefix,
         });
         self.add_type(ns_id, bitfield_name, typ);
         Ok(())
@@ -658,6 +668,7 @@ impl Library {
     ) -> Result<(), String> {
         let enum_name = elem.attr_required("name")?;
         let c_type = self.read_object_c_type(parser, elem)?;
+        let symbol_prefix = elem.attr("symbol-prefix").map(ToOwned::to_owned);
         let get_type = elem.attr("get-type").map(|s| s.into());
         let version = self.read_version(parser, ns_id, elem)?;
         let deprecated_version = self.read_deprecated_version(parser, ns_id, elem)?;
@@ -691,6 +702,7 @@ impl Library {
             doc_deprecated,
             error_domain,
             glib_get_type: get_type,
+            symbol_prefix,
         });
         self.add_type(ns_id, enum_name, typ);
         Ok(())


### PR DESCRIPTION
…) functions in sys mode

We shouldn't look for the full get_type function name but for the name
without the namespace and type name prefix.

Once we have that, make use of the ignore and version configuration in
addition to the general #[cfg] handling. This allows us to ignore
get_type() functions and override their version, for example if the
get_type() function was added after the type like in Pango.

First part of https://github.com/gtk-rs/gir/issues/839

----

CC @EPashkin @GuillaumeGomez 

With this we can configure in sys mode as follows, for example

```toml
[[object]]
name = "Pango.AttrIterator"
status = "generate"
    [[object.function]]
    name = "get_type"
    version = "1.44"
```