### PR TITLE
Handle version configuration on get_type functions in non-sys mode

### DIFF
--- a/src/codegen/enums.rs
+++ b/src/codegen/enums.rs
@@ -314,8 +314,14 @@ impl FromGlib<{sys_crate_name}::{ffi_name}> for {name} {{
 
     // Generate StaticType trait implementation.
     if let Some(ref get_type) = enum_.glib_get_type {
+        let configured_functions = config.functions.matched("get_type");
+        let version = std::iter::once(enum_.version)
+            .chain(configured_functions.iter().map(|f| f.version))
+            .max()
+            .flatten();
+
         cfg_deprecated(w, env, enum_.deprecated_version, false, 0)?;
-        version_condition(w, env, enum_.version, false, 0)?;
+        version_condition(w, env, version, false, 0)?;
         writeln!(
             w,
             "impl StaticType for {name} {{
@@ -330,7 +336,7 @@ impl FromGlib<{sys_crate_name}::{ffi_name}> for {name} {{
         writeln!(w)?;
 
         cfg_deprecated(w, env, enum_.deprecated_version, false, 0)?;
-        version_condition(w, env, enum_.version, false, 0)?;
+        version_condition(w, env, version, false, 0)?;
         writeln!(
             w,
             "impl<'a> FromValueOptional<'a> for {name} {{
@@ -343,7 +349,7 @@ impl FromGlib<{sys_crate_name}::{ffi_name}> for {name} {{
         writeln!(w)?;
 
         cfg_deprecated(w, env, enum_.deprecated_version, false, 0)?;
-        version_condition(w, env, enum_.version, false, 0)?;
+        version_condition(w, env, version, false, 0)?;
         writeln!(
             w,
             "impl<'a> FromValue<'a> for {name} {{
@@ -356,7 +362,7 @@ impl FromGlib<{sys_crate_name}::{ffi_name}> for {name} {{
         writeln!(w)?;
 
         cfg_deprecated(w, env, enum_.deprecated_version, false, 0)?;
-        version_condition(w, env, enum_.version, false, 0)?;
+        version_condition(w, env, version, false, 0)?;
         writeln!(
             w,
             "impl SetValue for {name} {{

--- a/src/codegen/flags.rs
+++ b/src/codegen/flags.rs
@@ -35,6 +35,7 @@ pub fn generate(env: &Env, root_path: &Path, mod_rs: &mut Vec<String>) {
     if !has_any {
         return;
     }
+
     let path = root_path.join("flags.rs");
     file_saver::save_to_file(path, env.config.make_backup, |w| {
         let mut imports = Imports::new(&env.library);
@@ -159,8 +160,14 @@ impl FromGlib<{sys_crate_name}::{ffi_name}> for {name} {{
     )?;
 
     if let Some(ref get_type) = flags.glib_get_type {
+        let configured_functions = config.functions.matched("get_type");
+        let version = std::iter::once(flags.version)
+            .chain(configured_functions.iter().map(|f| f.version))
+            .max()
+            .flatten();
+
         cfg_deprecated(w, env, flags.deprecated_version, false, 0)?;
-        version_condition(w, env, flags.version, false, 0)?;
+        version_condition(w, env, version, false, 0)?;
         writeln!(
             w,
             "impl StaticType for {name} {{
@@ -175,7 +182,7 @@ impl FromGlib<{sys_crate_name}::{ffi_name}> for {name} {{
         writeln!(w)?;
 
         cfg_deprecated(w, env, flags.deprecated_version, false, 0)?;
-        version_condition(w, env, flags.version, false, 0)?;
+        version_condition(w, env, version, false, 0)?;
         writeln!(
             w,
             "impl<'a> FromValueOptional<'a> for {name} {{
@@ -188,7 +195,7 @@ impl FromGlib<{sys_crate_name}::{ffi_name}> for {name} {{
         writeln!(w)?;
 
         cfg_deprecated(w, env, flags.deprecated_version, false, 0)?;
-        version_condition(w, env, flags.version, false, 0)?;
+        version_condition(w, env, version, false, 0)?;
         writeln!(
             w,
             "impl<'a> FromValue<'a> for {name} {{
@@ -201,7 +208,7 @@ impl FromGlib<{sys_crate_name}::{ffi_name}> for {name} {{
         writeln!(w)?;
 
         cfg_deprecated(w, env, flags.deprecated_version, false, 0)?;
-        version_condition(w, env, flags.version, false, 0)?;
+        version_condition(w, env, version, false, 0)?;
         writeln!(
             w,
             "impl SetValue for {name} {{


### PR DESCRIPTION
And only make use of the functions conditionally if they're newer than
the type itself.

This only applies to records (boxed/shared), enums and flags. GObject
types always need a get_type function and won't work without, so there
will never be the case that the function is added later.

Fixes https://github.com/gtk-rs/gir/issues/839

----

This should be all for being able to update pango now. Generates for example the following:

```rust
#[cfg(any(feature = "v1_44", feature = "dox"))]
glib_wrapper! {
    #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
    pub struct AttrIterator(Boxed<pango_sys::PangoAttrIterator>);

    match fn {
        copy => |ptr| pango_sys::pango_attr_iterator_copy(mut_override(ptr)),
        free => |ptr| pango_sys::pango_attr_iterator_destroy(ptr),
        get_type => || pango_sys::pango_attr_iterator_get_type(),
    }
}

#[cfg(not(any(feature = "v1_44", feature = "dox")))]
glib_wrapper! {
    #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
    pub struct AttrIterator(Boxed<pango_sys::PangoAttrIterator>);

    match fn {
        copy => |ptr| pango_sys::pango_attr_iterator_copy(mut_override(ptr)),
        free => |ptr| pango_sys::pango_attr_iterator_destroy(ptr),
    }
}
```

Once merged we need to add the correct version configuration everywhere and then regenerate things.