### PR TITLE
Use `eprintln` for writing to stderr

### DIFF
--- a/src/codegen/sys/build.rs
+++ b/src/codegen/sys/build.rs
@@ -63,7 +63,7 @@ fn main() {} // prevent linking libraries to avoid documentation failure
 #[cfg(not(feature = "dox"))]
 fn main() {
     if let Err(s) = system_deps::Config::new().probe() {
-        let _ = writeln!(io::stderr(), "{}", s);
+        let _ = eprintln!("{}", s);
         process::exit(1);
     }
 }


### PR DESCRIPTION
cc @sdroege , @GuillaumeGomez 