### PR TITLE
sys crates: update shell-words dependency and remove unused imports in build.rs

### DIFF
--- a/src/codegen/sys/build.rs
+++ b/src/codegen/sys/build.rs
@@ -41,10 +41,6 @@ fn generate_build_script(w: &mut dyn Write, env: &Env, split_build_rs: bool) -> 
 extern crate system_deps;
 
 #[cfg(not(feature = "dox"))]
-use std::io::prelude::*;
-#[cfg(not(feature = "dox"))]
-use std::io;
-#[cfg(not(feature = "dox"))]
 use std::process;"##
     )?;
 

--- a/src/codegen/sys/cargo_toml.rs
+++ b/src/codegen/sys/cargo_toml.rs
@@ -87,7 +87,7 @@ fn fill_in(root: &mut Table, env: &Env) {
 
     {
         let dev_deps = upsert_table(root, "dev-dependencies");
-        set_string(dev_deps, "shell-words", "0.1.0");
+        set_string(dev_deps, "shell-words", "1.0.0");
         set_string(dev_deps, "tempfile", "3");
         unset(dev_deps, "tempdir");
     }


### PR DESCRIPTION
shell-words 1.0 is compatible with 0.1: https://github.com/tmiasko/shell-words/commit/ae583f7a19ca886e40d829cf93dcc95365580e78