### PR TITLE
Use char::TryFrom::<u32> to convert from UniChar

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,6 +395,23 @@ status = "generate"
     ignore = true
 ```
 
+Which will prevent gir from generating `stock_list_ids`. If you want to specify
+that a function will be manually implemented, you can use:
+
+
+```toml
+[[object]]
+name = "Gtk.Entry"
+status = "generate"
+    [[object.function]]
+    name = "get_invisible_char"
+    manual = true
+```
+
+This will prevent gir from generating `get_invisible_char` and it won't generate
+`get_property_invisible_char` which would have been generated if we had used
+"ignore = true".
+
 Note that you must not place `Gtk.*` into the `generate` array and
 additionally configure its members.
 

--- a/src/analysis/class_builder.rs
+++ b/src/analysis/class_builder.rs
@@ -63,7 +63,10 @@ fn analyze_properties(
             continue;
         }
         let configured_properties = obj.properties.matched(&prop.name);
-        if configured_properties.iter().any(|f| f.ignore) {
+        if !configured_properties
+            .iter()
+            .all(|f| f.status.need_generate())
+        {
             continue;
         }
 

--- a/src/analysis/constants.rs
+++ b/src/analysis/constants.rs
@@ -22,7 +22,10 @@ pub fn analyze<F: Borrow<library::Constant>>(
         let constant = constant.borrow();
         let configured_constants = obj.constants.matched(&constant.name);
 
-        if configured_constants.iter().any(|c| c.ignore) {
+        if !configured_constants
+            .iter()
+            .all(|c| c.status.need_generate())
+        {
             continue;
         }
 

--- a/src/analysis/info_base.rs
+++ b/src/analysis/info_base.rs
@@ -21,21 +21,21 @@ impl InfoBase {
     pub fn constructors(&self) -> Vec<&functions::Info> {
         self.functions
             .iter()
-            .filter(|f| f.kind == library::FunctionKind::Constructor)
+            .filter(|f| f.status.need_generate() && f.kind == library::FunctionKind::Constructor)
             .collect()
     }
 
     pub fn methods(&self) -> Vec<&functions::Info> {
         self.functions
             .iter()
-            .filter(|f| f.kind == library::FunctionKind::Method)
+            .filter(|f| f.status.need_generate() && f.kind == library::FunctionKind::Method)
             .collect()
     }
 
     pub fn functions(&self) -> Vec<&functions::Info> {
         self.functions
             .iter()
-            .filter(|f| f.kind == library::FunctionKind::Function)
+            .filter(|f| f.status.need_generate() && f.kind == library::FunctionKind::Function)
             .collect()
     }
 }

--- a/src/analysis/object.rs
+++ b/src/analysis/object.rs
@@ -147,7 +147,7 @@ pub fn class(env: &Env, obj: &GObject, deps: &[library::TypeId]) -> Option<Info>
 
     let has_methods = functions
         .iter()
-        .any(|f| f.kind == library::FunctionKind::Method);
+        .any(|f| f.kind == library::FunctionKind::Method && f.status.need_generate());
     let has_signals = signals.iter().any(|s| s.trampoline.is_ok())
         || notify_signals.iter().any(|s| s.trampoline.is_ok());
 

--- a/src/analysis/properties.rs
+++ b/src/analysis/properties.rs
@@ -47,7 +47,10 @@ pub fn analyze(
 
     for prop in props {
         let configured_properties = obj.properties.matched(&prop.name);
-        if configured_properties.iter().any(|f| f.ignore) {
+        if !configured_properties
+            .iter()
+            .all(|f| f.status.need_generate())
+        {
             continue;
         }
 

--- a/src/analysis/signals.rs
+++ b/src/analysis/signals.rs
@@ -31,7 +31,7 @@ pub fn analyze(
 
     for signal in signals {
         let configured_signals = obj.signals.matched(&signal.name);
-        if configured_signals.iter().any(|f| f.ignore) {
+        if !configured_signals.iter().all(|f| f.status.need_generate()) {
             continue;
         }
         if env.is_totally_deprecated(signal.deprecated_version) {

--- a/src/codegen/enums.rs
+++ b/src/codegen/enums.rs
@@ -115,8 +115,8 @@ fn generate_enum(
     for member in &enum_.members {
         let member_config = config.members.matched(&member.name);
         let is_alias = member_config.iter().any(|m| m.alias);
-        let ignore = member_config.iter().any(|m| m.ignore);
-        if is_alias || ignore || vals.contains(&member.value) {
+        let generate = member_config.iter().all(|m| m.status.need_generate());
+        if is_alias || !generate || vals.contains(&member.value) {
             continue;
         }
         vals.insert(member.value.clone());

--- a/src/codegen/flags.rs
+++ b/src/codegen/flags.rs
@@ -89,8 +89,8 @@ fn generate_flags(env: &Env, w: &mut dyn Write, flags: &Bitfield, config: &GObje
     writeln!(w, "    pub struct {}: u32 {{", flags.name)?;
     for member in &flags.members {
         let member_config = config.members.matched(&member.name);
-        let ignore = member_config.iter().any(|m| m.ignore);
-        if ignore {
+        let generate = member_config.iter().all(|m| m.status.need_generate());
+        if !generate {
             continue;
         }
 

--- a/src/codegen/function.rs
+++ b/src/codegen/function.rs
@@ -33,6 +33,10 @@ pub fn generate(
     only_declaration: bool,
     indent: usize,
 ) -> Result<()> {
+    if !analysis.status.need_generate() {
+        return Ok(());
+    }
+
     if analysis.is_async_finish(env) {
         return Ok(());
     }

--- a/src/codegen/function_body_chunk.rs
+++ b/src/codegen/function_body_chunk.rs
@@ -1310,10 +1310,17 @@ fn add_chunk_for_type(
     let type_ = env.type_(typ_);
     match *type_ {
         library::Type::Fundamental(ref x) if !x.requires_conversion() => true,
-        library::Type::Fundamental(library::Fundamental::Boolean)
-        | library::Type::Fundamental(library::Fundamental::UniChar) => {
+        library::Type::Fundamental(library::Fundamental::Boolean) => {
             body.push(Chunk::Custom(format!(
                 "let {0} = from_glib({0});",
+                par.name
+            )));
+            true
+        }
+        library::Type::Fundamental(library::Fundamental::UniChar) => {
+            body.push(Chunk::Custom(format!(
+                "let {0} = std::convert::TryFrom::try_from({0})\
+                     .expect(\"conversion from an invalid Unicode value attempted\");",
                 par.name
             )));
             true

--- a/src/codegen/general.rs
+++ b/src/codegen/general.rs
@@ -639,7 +639,10 @@ pub fn declare_default_from_new(
     functions: &[analysis::functions::Info],
 ) -> Result<()> {
     if let Some(func) = functions.iter().find(|f| {
-        !f.visibility.hidden() && f.name == "new" && f.parameters.rust_parameters.is_empty()
+        !f.visibility.hidden()
+            && f.status.need_generate()
+            && f.name == "new"
+            && f.parameters.rust_parameters.is_empty()
     }) {
         writeln!(w)?;
         cfg_deprecated(w, env, func.deprecated_version, false, 0)?;

--- a/src/codegen/record.rs
+++ b/src/codegen/record.rs
@@ -91,7 +91,11 @@ pub fn generate(w: &mut dyn Write, env: &Env, analysis: &analysis::record::Info)
         );
     }
 
-    if analysis.functions.iter().any(|f| !f.visibility.hidden()) {
+    if analysis
+        .functions
+        .iter()
+        .any(|f| f.status.need_generate() && !f.visibility.hidden())
+    {
         writeln!(w)?;
         write!(w, "impl {} {{", analysis.name)?;
 

--- a/src/codegen/sys/functions.rs
+++ b/src/codegen/sys/functions.rs
@@ -211,7 +211,10 @@ fn generate_object_funcs(
     if write_get_type {
         let configured_functions = obj.functions.matched("get_type");
 
-        if !configured_functions.iter().any(|f| f.ignore) {
+        if configured_functions
+            .iter()
+            .all(|f| f.status.need_generate())
+        {
             let version = std::iter::once(version)
                 .chain(configured_functions.iter().map(|f| f.version))
                 .max()
@@ -224,7 +227,10 @@ fn generate_object_funcs(
 
     for func in functions {
         let configured_functions = obj.functions.matched(&func.name);
-        if configured_functions.iter().any(|f| f.ignore) {
+        if !configured_functions
+            .iter()
+            .all(|f| f.status.need_generate())
+        {
             continue;
         }
         let is_windows_utf8 = configured_functions.iter().any(|f| f.is_windows_utf8);

--- a/src/config/gobjects.rs
+++ b/src/config/gobjects.rs
@@ -31,6 +31,9 @@ impl GStatus {
     pub fn ignored(self) -> bool {
         self == GStatus::Ignore
     }
+    pub fn manual(self) -> bool {
+        self == GStatus::Manual
+    }
     pub fn need_generate(self) -> bool {
         self == GStatus::Generate
     }


### PR DESCRIPTION
This holds if we assume the C side Unicode validity can be trusted.

Consequence of the removal of `FromGlib<u32>` for `char` and `Option<char>` in https://github.com/gtk-rs/glib/pull/718.

The following projects were updated:
- https://github.com/fengalin/atk/tree/translate-option-result
- https://github.com/fengalin/pango/tree/translate-option-result
- https://github.com/fengalin/gtk/tree/translate-option-result

With these updates, `gtk-rs/examples` builds successfully. `gstreamer-rs` doesn't seem affected.

I'll send pull requests for `atk`, `pango` and `gtk` when this is merged.