### PR TITLE
Generate error quark functions in -sys mode if they exist

### DIFF
--- a/src/codegen/function_body_chunk.rs
+++ b/src/codegen/function_body_chunk.rs
@@ -1064,6 +1064,8 @@ impl Builder {
             NullMutPtr => Chunk::NullMutPtr,
         }
     }
+
+    #[allow(clippy::blocks_in_if_conditions)]
     fn generate_out_return(&self, uninitialized_vars: &mut Vec<(String, bool)>) -> Option<Chunk> {
         if !self.outs_as_return {
             return None;


### PR DESCRIPTION
That is, don't remove them from the list of functions to generate. We
only do that for the non-sys bindings as there these shouldn't become
separate functions but part of the glib::ErrorDomain trait impl.

----

After this we should regenerate things.