### PR TITLE
toml: use new system-deps versions syntax

### DIFF
--- a/src/codegen/sys/cargo_toml.rs
+++ b/src/codegen/sys/cargo_toml.rs
@@ -82,7 +82,7 @@ fn fill_in(root: &mut Table, env: &Env) {
 
     {
         let build_deps = upsert_table(root, "build-dependencies");
-        set_string(build_deps, "system-deps", "1.3");
+        set_string(build_deps, "system-deps", "2.0");
     }
 
     {
@@ -119,12 +119,15 @@ fn fill_in(root: &mut Table, env: &Env) {
         set_string(meta, "name", lib_name);
         set_string(meta, "version", env.config.min_cfg_version.to_string());
 
-        let versions = upsert_table(meta, "feature-versions");
+        // Old version API
+        unset(meta, "feature-versions");
+
         collect_versions(env)
             .iter()
             .filter(|(&v, _)| v > env.config.min_cfg_version)
             .for_each(|(v, lib_version)| {
-                set_string(versions, &v.to_feature(), lib_version.to_string());
+                let version_section = upsert_table(meta, &v.to_feature());
+                set_string(version_section, "version", lib_version.to_string());
             });
     }
 

--- a/tests/sys/secret-sys/Cargo.toml
+++ b/tests/sys/secret-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [build-dependencies]
 pkg-config = "0.3.7"
-system-deps = "1.3"
+system-deps = "2.0"
 
 [dependencies]
 bitflags = "1.0"
@@ -32,9 +32,11 @@ version = "0.2.0"
 name = "libsecret-1"
 version = "0.0"
 
-[package.metadata.system-deps.libsecret_1.feature-versions]
-v0_18_6 = "0.18.6"
-v0_19 = "0.19"
+[package.metadata.system-deps.libsecret_1.v0_18_6]
+version = "0.18.6"
+[package.metadata.system-deps.libsecret_1.v0_19]
+version = "0.19"
+
 [package.metadata.docs.rs]
 features = ["dox"]
 


### PR DESCRIPTION
This will allow us to override the library name depending on the
version, see https://github.com/gdesmott/system-deps/issues/11