### PR TITLE
Make sure that closures in global functions require Send+Sync

### DIFF
--- a/src/analysis/functions.rs
+++ b/src/analysis/functions.rs
@@ -491,7 +491,7 @@ fn analyze_function(
         library::Type::Class(_) | library::Type::Interface(_) | library::Type::Record(_) => {
             obj.concurrency
         }
-        _ => library::Concurrency::None,
+        _ => library::Concurrency::SendSync,
     };
 
     let mut commented = false;


### PR DESCRIPTION
This was accidentally changed in 3303549443533079b3d9e49b61c6336f5ccdeacb.