### PR TITLE
Do not pass $rust_class_name to glib_wrapper!

### DIFF
--- a/src/analysis/object.rs
+++ b/src/analysis/object.rs
@@ -11,7 +11,6 @@ pub struct Info {
     pub base: InfoBase,
     pub c_type: String,
     pub c_class_type: Option<String>,
-    pub rust_class_type: Option<String>,
     pub get_type: String,
     pub is_interface: bool,
     pub supertypes: Vec<general::StatusedTypeId>,
@@ -172,8 +171,6 @@ pub fn class(env: &Env, obj: &GObject, deps: &[library::TypeId]) -> Option<Info>
         imports.add("glib::ObjectExt");
     }
 
-    let rust_class_type = Some(format!("{}Class", name));
-
     let base = InfoBase {
         full_name,
         type_id: class_tid,
@@ -204,7 +201,6 @@ pub fn class(env: &Env, obj: &GObject, deps: &[library::TypeId]) -> Option<Info>
         base,
         c_type: klass.c_type.clone(),
         c_class_type: klass.c_class_type.clone(),
-        rust_class_type,
         get_type: klass.glib_get_type.clone(),
         is_interface: false,
         supertypes,
@@ -318,7 +314,6 @@ pub fn interface(env: &Env, obj: &GObject, deps: &[library::TypeId]) -> Option<I
         base,
         c_type: iface.c_type.clone(),
         c_class_type: None,
-        rust_class_type: None,
         get_type: iface.glib_get_type.clone(),
         is_interface: true,
         supertypes,

--- a/src/codegen/general.rs
+++ b/src/codegen/general.rs
@@ -78,7 +78,6 @@ pub fn define_object_type(
     type_name: &str,
     glib_name: &str,
     glib_class_name: Option<&str>,
-    rust_class_name: Option<&str>,
     glib_func_name: &str,
     is_interface: bool,
     parents: &[StatusedTypeId],
@@ -87,14 +86,6 @@ pub fn define_object_type(
     let class_name = {
         if let Some(s) = glib_class_name {
             format!(", {}::{}", sys_crate_name, s)
-        } else {
-            "".to_string()
-        }
-    };
-
-    let rust_class_name = {
-        if let Some(s) = rust_class_name {
-            format!(", {}", s)
         } else {
             "".to_string()
         }
@@ -113,8 +104,8 @@ pub fn define_object_type(
     if parents.is_empty() {
         writeln!(
             w,
-            "\tpub struct {}({}<{}::{}{}{}>);",
-            type_name, kind_name, sys_crate_name, glib_name, class_name, rust_class_name
+            "\tpub struct {}({}<{}::{}{}>);",
+            type_name, kind_name, sys_crate_name, glib_name, class_name
         )?;
     } else if is_interface {
         let prerequisites: Vec<String> =
@@ -122,13 +113,12 @@ pub fn define_object_type(
 
         writeln!(
             w,
-            "\tpub struct {}({}<{}::{}{}{}>) @requires {};",
+            "\tpub struct {}({}<{}::{}{}>) @requires {};",
             type_name,
             kind_name,
             sys_crate_name,
             glib_name,
             class_name,
-            rust_class_name,
             prerequisites.join(", ")
         )?;
     } else {
@@ -172,14 +162,8 @@ pub fn define_object_type(
 
         writeln!(
             w,
-            "\tpub struct {}({}<{}::{}{}{}>){};",
-            type_name,
-            kind_name,
-            sys_crate_name,
-            glib_name,
-            class_name,
-            rust_class_name,
-            parents_string,
+            "\tpub struct {}({}<{}::{}{}>){};",
+            type_name, kind_name, sys_crate_name, glib_name, class_name, parents_string,
         )?;
     }
     writeln!(w)?;

--- a/src/codegen/object.rs
+++ b/src/codegen/object.rs
@@ -27,7 +27,6 @@ pub fn generate(
         &analysis.name,
         &analysis.c_type,
         analysis.c_class_type.as_deref(),
-        analysis.rust_class_type.as_deref(),
         &analysis.get_type,
         analysis.is_interface,
         &analysis.supertypes,
@@ -364,17 +363,10 @@ pub fn generate_reexports(
         String::new()
     };
 
-    if let Some(ref class_name) = analysis.rust_class_type {
-        contents.push(format!(
-            "pub use self::{}::{{{}, {}{}}};",
-            module_name, analysis.name, class_name, none_type
-        ));
-    } else {
-        contents.push(format!(
-            "pub use self::{}::{{{}{}}};",
-            module_name, analysis.name, none_type
-        ));
-    }
+    contents.push(format!(
+        "pub use self::{}::{{{}{}}};",
+        module_name, analysis.name, none_type
+    ));
     if need_generate_trait(analysis) {
         contents.extend_from_slice(&cfgs);
         contents.push(format!(


### PR DESCRIPTION
This is possible due to https://github.com/gtk-rs/gtk-rs/pull/10.

Regenerating the gtk-rs bindings and compiling it seems to work with the current changes there in https://github.com/gtk-rs/gtk-rs/pull/11.