### PR TITLE
Generate `impl` blocks for associated enum functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,9 +154,9 @@ source = "git+https://github.com/GuillaumeGomez/rustdoc-stripper#bbdf0a350a85c8d
 
 [[package]]
 name = "serde"
-version = "1.0.117"
+version = "1.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b88fa983de7720629c9387e9f517353ed404164b1e482c970a90c1a4aaf7dc1a"
+checksum = "06c64263859d87aa2eb554587e2d23183398d617427327cf2b3d0ed8c69e4800"
 
 [[package]]
 name = "thread_local"

--- a/src/analysis/enums.rs
+++ b/src/analysis/enums.rs
@@ -26,7 +26,7 @@ impl Info {
     }
 }
 
-pub fn new(env: &Env, obj: &GObject) -> Option<Info> {
+pub fn new(env: &Env, obj: &GObject, imports: &mut Imports) -> Option<Info> {
     info!("Analyzing enumeration {}", obj.name);
 
     let enumeration_tid = env.library.find_type(0, &obj.name)?;
@@ -35,8 +35,6 @@ pub fn new(env: &Env, obj: &GObject) -> Option<Info> {
 
     let name = split_namespace_name(&obj.name).1;
 
-    let mut imports = Imports::with_defined(&env.library, name);
-
     let mut functions = functions::analyze(
         env,
         &enumeration.functions,
@@ -44,13 +42,13 @@ pub fn new(env: &Env, obj: &GObject) -> Option<Info> {
         false,
         false,
         obj,
-        &mut imports,
+        imports,
         None,
         None,
     );
     let specials = special_functions::extract(&mut functions);
 
-    special_functions::analyze_imports(&specials, &mut imports);
+    special_functions::analyze_imports(&specials, imports);
 
     let (version, deprecated_version) = info_base::versions(
         env,
@@ -66,7 +64,8 @@ pub fn new(env: &Env, obj: &GObject) -> Option<Info> {
         name: name.to_owned(),
         functions,
         specials,
-        imports,
+        // TODO: Don't use!
+        imports: Imports::new(&env.library),
         version,
         deprecated_version,
         cfg_condition: obj.cfg_condition.clone(),

--- a/src/analysis/enums.rs
+++ b/src/analysis/enums.rs
@@ -1,20 +1,15 @@
-use super::{function_parameters::TransformationType, imports::Imports, info_base::InfoBase, *};
+use super::{function_parameters::TransformationType, imports::Imports, *};
 use crate::{config::gobjects::GObject, env::Env, nameutil::*, traits::*};
 
 use log::info;
-use std::ops::Deref;
 
 #[derive(Debug, Default)]
 pub struct Info {
-    pub base: InfoBase,
-}
-
-impl Deref for Info {
-    type Target = InfoBase;
-
-    fn deref(&self) -> &InfoBase {
-        &self.base
-    }
+    pub full_name: String,
+    pub type_id: library::TypeId,
+    pub name: String,
+    pub functions: Vec<functions::Info>,
+    pub specials: special_functions::Infos,
 }
 
 impl Info {
@@ -116,29 +111,13 @@ pub fn new(env: &Env, obj: &GObject, imports: &mut Imports) -> Option<Info> {
 
     special_functions::analyze_imports(&specials, imports);
 
-    let (version, deprecated_version) = info_base::versions(
-        env,
-        obj,
-        &functions,
-        enumeration.version,
-        enumeration.deprecated_version,
-    );
-
-    let base = InfoBase {
+    let info = Info {
         full_name: obj.name.clone(),
         type_id: enumeration_tid,
         name: name.to_owned(),
         functions,
         specials,
-        // TODO: Don't use!
-        imports: Imports::new(&env.library),
-        version,
-        deprecated_version,
-        cfg_condition: obj.cfg_condition.clone(),
-        concurrency: obj.concurrency,
     };
-
-    let info = Info { base };
 
     Some(info)
 }

--- a/src/analysis/enums.rs
+++ b/src/analysis/enums.rs
@@ -35,6 +35,9 @@ pub fn new(env: &Env, obj: &GObject, imports: &mut Imports) -> Option<Info> {
 
     let name = split_namespace_name(&obj.name).1;
 
+    // Mark the type as available within the enum namespace:
+    imports.add_defined(&format!("crate::{}", name));
+
     let mut functions = functions::analyze(
         env,
         &enumeration.functions,

--- a/src/analysis/enums.rs
+++ b/src/analysis/enums.rs
@@ -1,0 +1,79 @@
+use super::{imports::Imports, info_base::InfoBase, *};
+use crate::{config::gobjects::GObject, env::Env, library, nameutil::*, traits::*};
+use log::info;
+use std::ops::Deref;
+
+#[derive(Debug, Default)]
+pub struct Info {
+    pub base: InfoBase,
+}
+
+impl Deref for Info {
+    type Target = InfoBase;
+
+    fn deref(&self) -> &InfoBase {
+        &self.base
+    }
+}
+
+impl Info {
+    pub fn type_<'a>(&self, library: &'a library::Library) -> &'a library::Enumeration {
+        let type_ = library
+            .type_(self.type_id)
+            .maybe_ref()
+            .unwrap_or_else(|| panic!("{} is not an enumeration.", self.full_name));
+        type_
+    }
+}
+
+pub fn new(env: &Env, obj: &GObject) -> Option<Info> {
+    info!("Analyzing enumeration {}", obj.name);
+
+    let enumeration_tid = env.library.find_type(0, &obj.name)?;
+    let type_ = env.type_(enumeration_tid);
+    let enumeration: &library::Enumeration = type_.maybe_ref()?;
+
+    let name = split_namespace_name(&obj.name).1;
+
+    let mut imports = Imports::with_defined(&env.library, name);
+
+    let mut functions = functions::analyze(
+        env,
+        &enumeration.functions,
+        enumeration_tid,
+        false,
+        false,
+        obj,
+        &mut imports,
+        None,
+        None,
+    );
+    let specials = special_functions::extract(&mut functions);
+
+    special_functions::analyze_imports(&specials, &mut imports);
+
+    let (version, deprecated_version) = info_base::versions(
+        env,
+        obj,
+        &functions,
+        enumeration.version,
+        enumeration.deprecated_version,
+    );
+
+    let base = InfoBase {
+        full_name: obj.name.clone(),
+        type_id: enumeration_tid,
+        name: name.to_owned(),
+        functions,
+        specials,
+        imports,
+        version,
+        deprecated_version,
+        cfg_condition: obj.cfg_condition.clone(),
+        concurrency: obj.concurrency,
+    };
+
+    let info = Info { base };
+
+    Some(info)
+}

--- a/src/analysis/enums.rs
+++ b/src/analysis/enums.rs
@@ -1,5 +1,5 @@
 use super::{function_parameters::TransformationType, imports::Imports, info_base::InfoBase, *};
-use crate::{config::gobjects::GObject, env::Env, library, nameutil::*, traits::*};
+use crate::{config::gobjects::GObject, env::Env, nameutil::*, traits::*};
 
 use log::info;
 use std::ops::Deref;
@@ -112,7 +112,7 @@ pub fn new(env: &Env, obj: &GObject, imports: &mut Imports) -> Option<Info> {
         }
     }
 
-    let specials = special_functions::extract(&mut functions);
+    let specials = special_functions::extract(&mut functions, type_);
 
     special_functions::analyze_imports(&specials, imports);
 

--- a/src/analysis/enums.rs
+++ b/src/analysis/enums.rs
@@ -107,7 +107,7 @@ pub fn new(env: &Env, obj: &GObject, imports: &mut Imports) -> Option<Info> {
         }
     }
 
-    let specials = special_functions::extract(&mut functions, type_);
+    let specials = special_functions::extract(&mut functions, type_, obj);
 
     special_functions::analyze_imports(&specials, imports);
 

--- a/src/analysis/flags.rs
+++ b/src/analysis/flags.rs
@@ -101,7 +101,7 @@ pub fn new(env: &Env, obj: &GObject, imports: &mut Imports) -> Option<Info> {
         }
     }
 
-    let specials = special_functions::extract(&mut functions, type_);
+    let specials = special_functions::extract(&mut functions, type_, obj);
 
     special_functions::analyze_imports(&specials, imports);
 

--- a/src/analysis/flags.rs
+++ b/src/analysis/flags.rs
@@ -1,0 +1,117 @@
+use super::{function_parameters::TransformationType, imports::Imports, *};
+use crate::{config::gobjects::GObject, env::Env, nameutil::*, traits::*};
+
+use log::info;
+
+#[derive(Debug, Default)]
+pub struct Info {
+    pub full_name: String,
+    pub type_id: library::TypeId,
+    pub name: String,
+    pub functions: Vec<functions::Info>,
+    pub specials: special_functions::Infos,
+}
+
+impl Info {
+    pub fn type_<'a>(&self, library: &'a library::Library) -> &'a library::Bitfield {
+        let type_ = library
+            .type_(self.type_id)
+            .maybe_ref()
+            .unwrap_or_else(|| panic!("{} is not an flags.", self.full_name));
+        type_
+    }
+}
+
+pub fn new(env: &Env, obj: &GObject, imports: &mut Imports) -> Option<Info> {
+    info!("Analyzing flags {}", obj.name);
+
+    if !obj.status.need_generate() {
+        return None;
+    }
+
+    if !obj
+        .type_id
+        .map_or(false, |tid| tid.ns_id == namespaces::MAIN)
+    {
+        return None;
+    }
+
+    let flags_tid = env.library.find_type(0, &obj.name)?;
+    let type_ = env.type_(flags_tid);
+    let flags: &library::Bitfield = type_.maybe_ref()?;
+
+    let name = split_namespace_name(&obj.name).1;
+
+    // Mark the type as available within the bitfield namespace:
+    imports.add_defined(&format!("crate::{}", name));
+
+    let has_get_type = flags.glib_get_type.is_some();
+    if has_get_type {
+        imports.add("glib::Type");
+        imports.add("glib::StaticType");
+        imports.add("glib::value::SetValue");
+        imports.add("glib::value::FromValue");
+        imports.add("glib::value::FromValueOptional");
+    }
+
+    if obj.generate_display_trait {
+        imports.add("std::fmt");
+    }
+
+    let mut functions = functions::analyze(
+        env,
+        &flags.functions,
+        flags_tid,
+        false,
+        false,
+        obj,
+        imports,
+        None,
+        None,
+    );
+
+    // Gir does not currently mark the first parameter of associated bitfield functions -
+    // that are identical to its bitfield type - as instance parameter since most languages
+    // do not support this.
+    for f in &mut functions {
+        if f.parameters.c_parameters.is_empty() {
+            continue;
+        }
+
+        let first_param = &mut f.parameters.c_parameters[0];
+
+        if first_param.typ == flags_tid {
+            first_param.instance_parameter = true;
+
+            let t = f
+                .parameters
+                .transformations
+                .iter_mut()
+                .find(|t| t.ind_c == 0)
+                .unwrap();
+
+            if let TransformationType::ToGlibScalar { name, .. } = &mut t.transformation_type {
+                *name = "self".to_owned();
+            } else {
+                panic!(
+                    "Bitfield function instance param must be passed as scalar, not {:?}",
+                    t.transformation_type
+                );
+            }
+        }
+    }
+
+    let specials = special_functions::extract(&mut functions, type_);
+
+    special_functions::analyze_imports(&specials, imports);
+
+    let info = Info {
+        full_name: obj.name.clone(),
+        type_id: flags_tid,
+        name: name.to_owned(),
+        functions,
+        specials,
+    };
+
+    Some(info)
+}

--- a/src/analysis/function_parameters.rs
+++ b/src/analysis/function_parameters.rs
@@ -375,11 +375,8 @@ fn is_length(par: &library::Parameter) -> bool {
     if len >= 3 && &par.name[len - 3..len] == "len" {
         return true;
     }
-    if par.name.find("length").is_some() {
-        return true;
-    }
 
-    false
+    par.name.contains("length")
 }
 
 fn has_length(env: &Env, typ: TypeId) -> bool {

--- a/src/analysis/functions.rs
+++ b/src/analysis/functions.rs
@@ -845,7 +845,7 @@ fn analyze_async(
     }) = callback_info
     {
         // Checks for /*Ignored*/ or other error comments
-        *commented |= callback_type.find("/*").is_some();
+        *commented |= callback_type.contains("/*");
         let func_name = func.c_identifier.as_ref().unwrap();
         let finish_func_name = finish_function_name(func_name);
         let mut output_params = vec![];

--- a/src/analysis/imports.rs
+++ b/src/analysis/imports.rs
@@ -120,11 +120,14 @@ impl Imports {
         self.defaults.clear();
     }
 
-    /// The goals of this function is to discard unwanted imports like "ffi" and "crate". It
+    /// The goals of this function is to discard unwanted imports like "crate". It
     /// also extends the checks in case you are implementing "X". For example, you don't want to
     /// import "X" or "crate::X" in this case.
     fn common_checks(&self, name: &str) -> bool {
-        if name == "crate::ffi" || (!name.contains("::") && name != "xlib") {
+        // The ffi namespace is used directly, including it is a programmer error.
+        assert_ne!(name, "crate::ffi");
+
+        if !name.contains("::") && name != "xlib" {
             false
         } else if let Some(ref defined) = self.defined {
             !((name.starts_with("crate::") && &name[7..] == defined) || name == defined)

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -65,6 +65,7 @@ pub fn run(env: &mut Env) {
     }
 
     let mut enum_imports = Imports::new(&env.library);
+    enum_imports.add("glib::translate::*");
 
     let mut analyzed = 1;
     while analyzed > 0 {

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -12,6 +12,7 @@ pub mod class_builder;
 pub mod class_hierarchy;
 pub mod constants;
 pub mod conversion_type;
+pub mod enums;
 pub mod ffi_type;
 pub mod function_parameters;
 pub mod functions;
@@ -44,6 +45,7 @@ pub struct Analysis {
     pub records: BTreeMap<String, record::Info>,
     pub global_functions: Option<info_base::InfoBase>,
     pub constants: Vec<constants::Info>,
+    pub enumerations: Vec<enums::Info>,
 }
 
 pub fn run(env: &mut Env) {
@@ -171,6 +173,11 @@ fn analyze(env: &mut Env, tid: TypeId, deps: &[TypeId]) {
         Type::Record(_) => {
             if let Some(info) = record::new(env, obj) {
                 env.analysis.records.insert(full_name, info);
+            }
+        }
+        Type::Enumeration(_) => {
+            if let Some(info) = enums::new(env, obj) {
+                env.analysis.enumerations.push(info);
             }
         }
         _ => {}

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -110,7 +110,6 @@ fn analyze_global_functions(env: &mut Env) {
 
     let mut imports = imports::Imports::new(&env.library);
     imports.add("glib::translate::*");
-    imports.add(&format!("crate::{}", env.main_sys_crate_name()));
 
     let functions = functions::analyze(
         env,

--- a/src/analysis/object.rs
+++ b/src/analysis/object.rs
@@ -98,7 +98,7 @@ pub fn class(env: &Env, obj: &GObject, deps: &[library::TypeId]) -> Option<Info>
         special_functions::Type::Hash,
         special_functions::Type::Equal,
         special_functions::Type::Compare,
-        special_functions::Type::ToString,
+        special_functions::Type::Display,
     ] {
         special_functions::unhide(&mut functions, &specials, *t);
         specials.remove(t);

--- a/src/analysis/object.rs
+++ b/src/analysis/object.rs
@@ -88,7 +88,7 @@ pub fn class(env: &Env, obj: &GObject, deps: &[library::TypeId]) -> Option<Info>
         Some(&mut signatures),
         Some(deps),
     );
-    let mut specials = special_functions::extract(&mut functions, type_);
+    let mut specials = special_functions::extract(&mut functions, type_, obj);
     // `copy` will duplicate an object while `clone` just adds a reference
     special_functions::unhide(&mut functions, &specials, special_functions::Type::Copy);
     // these are all automatically derived on objects and compare by pointer. If such functions

--- a/src/analysis/object.rs
+++ b/src/analysis/object.rs
@@ -99,7 +99,7 @@ pub fn class(env: &Env, obj: &GObject, deps: &[library::TypeId]) -> Option<Info>
         special_functions::Type::Compare,
     ] {
         special_functions::unhide(&mut functions, &specials, *t);
-        specials.remove(t);
+        specials.traits_mut().remove(t);
     }
     special_functions::analyze_imports(&specials, &mut imports);
 

--- a/src/analysis/object.rs
+++ b/src/analysis/object.rs
@@ -88,7 +88,7 @@ pub fn class(env: &Env, obj: &GObject, deps: &[library::TypeId]) -> Option<Info>
         Some(&mut signatures),
         Some(deps),
     );
-    let mut specials = special_functions::extract(&mut functions);
+    let mut specials = special_functions::extract(&mut functions, type_);
     // `copy` will duplicate an object while `clone` just adds a reference
     special_functions::unhide(&mut functions, &specials, special_functions::Type::Copy);
     // these are all automatically derived on objects and compare by pointer. If such functions
@@ -97,7 +97,6 @@ pub fn class(env: &Env, obj: &GObject, deps: &[library::TypeId]) -> Option<Info>
         special_functions::Type::Hash,
         special_functions::Type::Equal,
         special_functions::Type::Compare,
-        special_functions::Type::Display,
     ] {
         special_functions::unhide(&mut functions, &specials, *t);
         specials.remove(t);

--- a/src/analysis/object.rs
+++ b/src/analysis/object.rs
@@ -62,7 +62,6 @@ pub fn class(env: &Env, obj: &GObject, deps: &[library::TypeId]) -> Option<Info>
 
     let mut imports = Imports::with_defined(&env.library, &name);
     imports.add("glib::translate::*");
-    imports.add(&format!("crate::{}", env.main_sys_crate_name()));
     if obj.generate_display_trait {
         imports.add("std::fmt");
     }
@@ -230,7 +229,6 @@ pub fn interface(env: &Env, obj: &GObject, deps: &[library::TypeId]) -> Option<I
 
     let mut imports = Imports::with_defined(&env.library, &name);
     imports.add("glib::translate::*");
-    imports.add(&format!("crate::{}", env.main_sys_crate_name()));
     imports.add("glib::object::IsA");
     if obj.generate_display_trait {
         imports.add("std::fmt");

--- a/src/analysis/record.rs
+++ b/src/analysis/record.rs
@@ -92,7 +92,7 @@ pub fn new(env: &Env, obj: &GObject) -> Option<Info> {
         None,
         None,
     );
-    let specials = special_functions::extract(&mut functions);
+    let specials = special_functions::extract(&mut functions, type_);
 
     let (version, deprecated_version) = info_base::versions(
         env,

--- a/src/analysis/record.rs
+++ b/src/analysis/record.rs
@@ -92,7 +92,7 @@ pub fn new(env: &Env, obj: &GObject) -> Option<Info> {
         None,
         None,
     );
-    let specials = special_functions::extract(&mut functions, type_);
+    let specials = special_functions::extract(&mut functions, type_, obj);
 
     let (version, deprecated_version) = info_base::versions(
         env,

--- a/src/analysis/record.rs
+++ b/src/analysis/record.rs
@@ -80,7 +80,6 @@ pub fn new(env: &Env, obj: &GObject) -> Option<Info> {
     let is_boxed = obj.use_boxed_functions || RecordType::of(&record) == RecordType::AutoBoxed;
 
     let mut imports = Imports::with_defined(&env.library, &name);
-    imports.add(&format!("crate::{}", env.main_sys_crate_name()));
 
     let mut functions = functions::analyze(
         env,

--- a/src/analysis/signals.rs
+++ b/src/analysis/signals.rs
@@ -47,9 +47,7 @@ pub fn analyze(
             obj,
             imports,
         );
-        if let Some(info) = info {
-            sns.push(info);
-        }
+        sns.push(info);
     }
 
     sns
@@ -63,7 +61,7 @@ fn analyze_signal(
     configured_signals: &[&config::signals::Signal],
     obj: &GObject,
     imports: &mut Imports,
-) -> Option<Info> {
+) -> Info {
     let mut used_types: Vec<String> = Vec::with_capacity(4);
     let version = configured_signals
         .iter()
@@ -117,5 +115,6 @@ fn analyze_signal(
         deprecated_version,
         doc_hidden,
     };
-    Some(info)
+
+    info
 }

--- a/src/analysis/special_functions.rs
+++ b/src/analysis/special_functions.rs
@@ -33,7 +33,7 @@ impl FromStr for Type {
             "free" | "destroy" => Ok(Free),
             "is_equal" => Ok(Equal),
             "ref" | "ref_" => Ok(Ref),
-            "to_string" => Ok(Display),
+            "to_string" | "to_str" | "name" | "get_name" => Ok(Display),
             "unref" => Ok(Unref),
             "hash" => Ok(Hash),
             _ => Err(format!("Unknown type '{}'", s)),
@@ -41,23 +41,50 @@ impl FromStr for Type {
     }
 }
 
-impl Type {
-    fn extract(s: &str) -> Option<Self> {
-        s.parse().ok().or_else(|| match s {
-            "get_name" | "name" => Some(Self::Display),
-            _ => None,
-        })
-    }
-}
-
 #[derive(Debug, Clone)]
-pub struct Info {
+pub struct TraitInfo {
     pub glib_name: String,
-    pub returns_static_ref: bool,
     pub version: Option<Version>,
 }
 
-pub type Infos = BTreeMap<Type, Info>;
+type TraitInfos = BTreeMap<Type, TraitInfo>;
+
+#[derive(Clone, Copy, Eq, Debug, Ord, PartialEq, PartialOrd)]
+pub enum FunctionType {
+    StaticStringify,
+}
+
+#[derive(Debug, Clone)]
+pub struct FunctionInfo {
+    pub type_: FunctionType,
+    pub version: Option<Version>,
+}
+
+type FunctionInfos = BTreeMap<String, FunctionInfo>;
+
+#[derive(Debug, Default)]
+pub struct Infos {
+    traits: TraitInfos,
+    functions: FunctionInfos,
+}
+
+impl Infos {
+    pub fn traits(&self) -> &TraitInfos {
+        &self.traits
+    }
+
+    pub fn traits_mut(&mut self) -> &mut TraitInfos {
+        &mut self.traits
+    }
+
+    pub fn has_trait(&self, type_: Type) -> bool {
+        self.traits.contains_key(&type_)
+    }
+
+    pub fn functions(&self) -> &FunctionInfos {
+        &self.functions
+    }
+}
 
 fn update_func(func: &mut FuncInfo, type_: Type, parent_type: &LibType, obj: &GObject) -> bool {
     if func.visibility != Visibility::Comment {
@@ -71,52 +98,42 @@ fn update_func(func: &mut FuncInfo, type_: Type, parent_type: &LibType, obj: &GO
         if !func.parameters.c_parameters[0].instance_parameter {
             return false;
         }
-        if !func
-            .ret
-            .parameter
-            .as_ref()
-            .map_or(false, |p| p.typ == TypeId::tid_utf8())
-        {
-            return false;
-        }
 
-        if func.name == "to_string" {
-            // Rename to to_str to make sure it doesn't clash with ToString::to_string
-            func.name = "to_str".to_owned();
+        if let Some(ret) = func.ret.parameter.as_mut() {
+            if ret.typ != TypeId::tid_utf8() {
+                return false;
+            }
 
-            // As to not change old code behaviour, assume non-nullability outside
-            // enums and flags only. Function inside enums and flags have been
-            // appropriately marked in Gir.
-            if !obj.trust_return_value_nullability
-                && !matches!(parent_type, LibType::Enumeration(_) | LibType::Bitfield(_))
-            {
-                if let Some(par) = func.ret.parameter.as_mut() {
-                    *par.nullable = false;
+            if func.name == "to_string" {
+                // Rename to to_str to make sure it doesn't clash with ToString::to_string
+                func.name = "to_str".to_owned();
+
+                // As to not change old code behaviour, assume non-nullability outside
+                // enums and flags only, and exclusively for to_string. Function inside
+                // enums and flags have been appropriately marked in Gir.
+                if !obj.trust_return_value_nullability
+                    && !matches!(parent_type, LibType::Enumeration(_) | LibType::Bitfield(_))
+                {
+                    *ret.nullable = false;
                 }
             }
-        }
 
-        // Cannot generate Display implementation for Option<>
-        if func
-            .ret
-            .parameter
-            .as_ref()
-            .map_or(false, |ret| *ret.nullable)
-        {
-            return false;
+            // Cannot generate Display implementation for Option<>
+            return !*ret.nullable;
         }
     }
+
     true
 }
 
 pub fn extract(functions: &mut Vec<FuncInfo>, parent_type: &LibType, obj: &GObject) -> Infos {
-    let mut specials = Infos::new();
+    let mut specials = Infos::default();
     let mut has_copy = false;
     let mut has_free = false;
     let mut destroy = None;
 
     for (pos, func) in functions.iter_mut().enumerate() {
-        if let Some(type_) = Type::extract(&func.name) {
+        if let Ok(type_) = func.name.parse() {
             if func.name == "destroy" {
                 destroy = Some((func.glib_name.clone(), pos));
                 continue;
@@ -130,25 +147,35 @@ pub fn extract(functions: &mut Vec<FuncInfo>, parent_type: &LibType, obj: &GObje
                 has_free = true;
             }
 
-            let return_transfer_none = func.ret.parameter.as_ref().map_or(false, |ret| {
-                ret.transfer == crate::library::Transfer::None
-                // This is enforced already, otherwise no impl Display can be generated.
-                && !*ret.nullable
-            });
+            let return_transfer_none = func
+                .ret
+                .parameter
+                .as_ref()
+                .map_or(false, |ret| ret.transfer == crate::library::Transfer::None);
 
             // Assume only enumerations and bitfields can return static strings
-            let returns_static_ref = type_ == Type::Display
-                && return_transfer_none
+            let returns_static_ref = return_transfer_none
                 && matches!(parent_type, LibType::Enumeration(_) | LibType::Bitfield(_))
                 // We cannot mandate returned lifetime if this is not generated.
                 // (And this prevents an unused std::ffi::CStr from being emitted below)
                 && func.status.need_generate();
 
-            specials.insert(
+            if returns_static_ref {
+                // Override the function with a &'static (non allocating) -returning string
+                // if the transfer type is none and it matches the above heuristics.
+                specials.functions.insert(
+                    func.glib_name.clone(),
+                    FunctionInfo {
+                        type_: FunctionType::StaticStringify,
+                        version: func.version,
+                    },
+                );
+            }
+
+            specials.traits.insert(
                 type_,
-                Info {
+                TraitInfo {
                     glib_name: func.glib_name.clone(),
-                    returns_static_ref,
                     version: func.version,
                 },
             );
@@ -160,11 +187,10 @@ pub fn extract(functions: &mut Vec<FuncInfo>, parent_type: &LibType, obj: &GObje
             let ty_ = Type::from_str("destroy").unwrap();
             let func = &mut functions[pos];
             update_func(func, ty_, parent_type, obj);
-            specials.insert(
+            specials.traits.insert(
                 ty_,
-                Info {
+                TraitInfo {
                     glib_name,
-                    returns_static_ref: false,
                     version: func.version,
                 },
             );
@@ -185,7 +211,7 @@ fn visibility(t: Type) -> Visibility {
 
 // Some special functions (e.g. `copy` on refcounted types) should be exposed
 pub fn unhide(functions: &mut Vec<FuncInfo>, specials: &Infos, type_: Type) {
-    if let Some(func) = specials.get(&type_) {
+    if let Some(func) = specials.traits().get(&type_) {
         let func = functions
             .iter_mut()
             .find(|f| f.glib_name == func.glib_name && f.visibility != Visibility::Comment);
@@ -196,18 +222,20 @@ pub fn unhide(functions: &mut Vec<FuncInfo>, specials: &Infos, type_: Type) {
 }
 
 pub fn analyze_imports(specials: &Infos, imports: &mut Imports) {
-    use self::Type::*;
-    for (type_, info) in specials {
+    for (type_, info) in specials.traits() {
+        use self::Type::*;
         match *type_ {
             Compare => imports.add_with_version("std::cmp", info.version),
-            Display => {
-                imports.add_with_version("std::fmt", info.version);
-                if info.returns_static_ref {
-                    imports.add_with_version("std::ffi::CStr", info.version);
-                }
-            }
+            Display => imports.add_with_version("std::fmt", info.version),
             Hash => imports.add_with_version("std::hash", info.version),
             _ => {}
+        }
+    }
+    for info in specials.functions().values() {
+        match info.type_ {
+            FunctionType::StaticStringify => {
+                imports.add_with_version("std::ffi::CStr", info.version)
+            }
         }
     }
 }

--- a/src/analysis/special_functions.rs
+++ b/src/analysis/special_functions.rs
@@ -14,7 +14,7 @@ pub enum Type {
     Equal,
     Free,
     Ref,
-    ToString,
+    Display,
     Unref,
     Hash,
 }
@@ -31,7 +31,7 @@ impl FromStr for Type {
             "free" | "destroy" => Ok(Free),
             "is_equal" => Ok(Equal),
             "ref" | "ref_" => Ok(Ref),
-            "to_string" => Ok(ToString),
+            "to_string" => Ok(Display),
             "unref" => Ok(Unref),
             "hash" => Ok(Hash),
             _ => Err(format!("Unknown type '{}'", s)),
@@ -46,7 +46,7 @@ fn update_func(func: &mut FuncInfo, type_: Type) -> bool {
         func.visibility = visibility(type_);
     }
 
-    if type_ == Type::ToString {
+    if type_ == Type::Display {
         if func.parameters.c_parameters.len() != 1 {
             return false;
         }
@@ -114,7 +114,7 @@ fn visibility(t: Type) -> Visibility {
     match t {
         Copy | Free | Ref | Unref => Visibility::Hidden,
         Hash | Compare | Equal => Visibility::Private,
-        ToString => Visibility::Public,
+        Display => Visibility::Public,
     }
 }
 
@@ -135,7 +135,7 @@ pub fn analyze_imports(specials: &Infos, imports: &mut Imports) {
     for type_ in specials.keys() {
         match *type_ {
             Compare => imports.add("std::cmp"),
-            ToString => imports.add("std::fmt"),
+            Display => imports.add("std::fmt"),
             Hash => imports.add("std::hash"),
             _ => {}
         }

--- a/src/codegen/constants.rs
+++ b/src/codegen/constants.rs
@@ -17,7 +17,6 @@ pub fn generate(env: &Env, root_path: &Path, mod_rs: &mut Vec<String>) {
     }
 
     let sys_crate_name = env.main_sys_crate_name();
-    imports.add(&format!("crate::{}", sys_crate_name));
     imports.add("std::ffi::CStr");
 
     file_saver::save_to_file(path, env.config.make_backup, |w| {

--- a/src/codegen/enums.rs
+++ b/src/codegen/enums.rs
@@ -124,23 +124,19 @@ fn generate_enum(
         .collect::<Vec<_>>();
 
     if !functions.is_empty() {
-        let static_tostring = analysis.specials.get(&Type::Display).and_then(|f| {
-            if f.returns_static_ref {
-                Some(f)
-            } else {
-                None
-            }
-        });
-
         writeln!(w)?;
         version_condition(w, env, enum_.version, false, 0)?;
         write!(w, "impl {} {{", analysis.name)?;
         for func_analysis in functions {
-            if Some(&func_analysis.glib_name) == static_tostring.map(|t| &t.glib_name) {
-                function::generate_static_to_str(w, env, func_analysis)?;
-            } else {
-                function::generate(w, env, func_analysis, false, false, 1)?;
-            }
+            function::generate(
+                w,
+                env,
+                func_analysis,
+                Some(&analysis.specials),
+                false,
+                false,
+                1,
+            )?;
         }
         writeln!(w, "}}")?;
     }
@@ -156,7 +152,7 @@ fn generate_enum(
 
     writeln!(w)?;
 
-    if config.generate_display_trait && !analysis.specials.contains_key(&Type::Display) {
+    if config.generate_display_trait && !analysis.specials.has_trait(Type::Display) {
         // Generate Display trait implementation.
         version_condition(w, env, enum_.version, false, 0)?;
         writeln!(

--- a/src/codegen/enums.rs
+++ b/src/codegen/enums.rs
@@ -1,6 +1,7 @@
 use super::{function, trait_impls};
 use crate::{
     analysis::enums::Info,
+    analysis::special_functions::Type,
     codegen::general::{
         self, cfg_deprecated, derives, version_condition, version_condition_no_doc,
         version_condition_string,
@@ -123,10 +124,13 @@ fn generate_enum(
         .collect::<Vec<_>>();
 
     if !functions.is_empty() {
-        let static_tostring = analysis
-            .specials
-            .get(&crate::analysis::special_functions::Type::Display)
-            .and_then(|f| if f.returns_static_ref { Some(f) } else { None });
+        let static_tostring = analysis.specials.get(&Type::Display).and_then(|f| {
+            if f.returns_static_ref {
+                Some(f)
+            } else {
+                None
+            }
+        });
 
         writeln!(w)?;
         version_condition(w, env, enum_.version, false, 0)?;
@@ -152,7 +156,7 @@ fn generate_enum(
 
     writeln!(w)?;
 
-    if config.generate_display_trait {
+    if config.generate_display_trait && !analysis.specials.contains_key(&Type::Display) {
         // Generate Display trait implementation.
         version_condition(w, env, enum_.version, false, 0)?;
         writeln!(

--- a/src/codegen/enums.rs
+++ b/src/codegen/enums.rs
@@ -53,7 +53,6 @@ pub fn generate(env: &Env, root_path: &Path, mod_rs: &mut Vec<String>) {
     }
 
     let mut imports = Imports::new(&env.library);
-    imports.add(&format!("crate::{}", env.main_sys_crate_name()));
     if has_get_quark {
         imports.add("glib::Quark");
         imports.add("glib::error::ErrorDomain");

--- a/src/codegen/enums.rs
+++ b/src/codegen/enums.rs
@@ -167,16 +167,21 @@ fn generate_enum(
         "\
     #[doc(hidden)]
     __Unknown(i32),
-}}
-"
+}}"
     )?;
 
-    version_condition(w, env, enum_.version, false, 0)?;
-    write!(w, "impl {} {{", analysis.name)?;
-    for func_analysis in &analysis.functions() {
-        function::generate(w, env, func_analysis, false, false, 1)?;
+    let functions = analysis.functions();
+
+    if !functions.is_empty() {
+        writeln!(w)?;
+        version_condition(w, env, enum_.version, false, 0)?;
+        write!(w, "impl {} {{", analysis.name)?;
+        for func_analysis in functions {
+            function::generate(w, env, func_analysis, false, false, 1)?;
+        }
+        writeln!(w, "}}")?;
     }
-    writeln!(w, "}}")?;
+
     writeln!(w)?;
 
     if config.generate_display_trait {

--- a/src/codegen/enums.rs
+++ b/src/codegen/enums.rs
@@ -116,7 +116,11 @@ fn generate_enum(
 }}"
     )?;
 
-    let functions = analysis.functions();
+    let functions = analysis
+        .functions
+        .iter()
+        .filter(|f| f.status.need_generate())
+        .collect::<Vec<_>>();
 
     if !functions.is_empty() {
         let static_tostring = analysis

--- a/src/codegen/enums.rs
+++ b/src/codegen/enums.rs
@@ -1,7 +1,7 @@
 use super::function;
 use crate::{
     analysis::enums::Info,
-    analysis::{imports::Imports, namespaces},
+    analysis::namespaces,
     codegen::general::{
         self, cfg_deprecated, derives, version_condition, version_condition_no_doc,
         version_condition_string,
@@ -55,7 +55,9 @@ pub fn generate(env: &Env, root_path: &Path, mod_rs: &mut Vec<String>) {
         return;
     }
 
-    let mut imports = Imports::new(&env.library);
+    // TODO: We should do this just once in analysis without mutation necessary afterwards
+    let mut imports = env.analysis.enum_imports.clone();
+
     if has_get_quark {
         imports.add("glib::Quark");
         imports.add("glib::error::ErrorDomain");

--- a/src/codegen/enums.rs
+++ b/src/codegen/enums.rs
@@ -1,4 +1,4 @@
-use super::function;
+use super::{function, trait_impls};
 use crate::{
     analysis::enums::Info,
     codegen::general::{
@@ -127,6 +127,14 @@ fn generate_enum(
         }
         writeln!(w, "}}")?;
     }
+
+    trait_impls::generate(
+        w,
+        &analysis.name,
+        &analysis.functions,
+        &analysis.specials,
+        None,
+    )?;
 
     writeln!(w)?;
 

--- a/src/codegen/enums.rs
+++ b/src/codegen/enums.rs
@@ -130,6 +130,7 @@ fn generate_enum(
 
     trait_impls::generate(
         w,
+        env,
         &analysis.name,
         &analysis.functions,
         &analysis.specials,

--- a/src/codegen/flags.rs
+++ b/src/codegen/flags.rs
@@ -97,23 +97,19 @@ fn generate_flags(
         .collect::<Vec<_>>();
 
     if !functions.is_empty() {
-        let static_tostring = analysis.specials.get(&Type::Display).and_then(|f| {
-            if f.returns_static_ref {
-                Some(f)
-            } else {
-                None
-            }
-        });
-
         writeln!(w)?;
         version_condition(w, env, flags.version, false, 0)?;
         write!(w, "impl {} {{", analysis.name)?;
         for func_analysis in functions {
-            if Some(&func_analysis.glib_name) == static_tostring.map(|t| &t.glib_name) {
-                function::generate_static_to_str(w, env, func_analysis)?;
-            } else {
-                function::generate(w, env, func_analysis, false, false, 1)?;
-            }
+            function::generate(
+                w,
+                env,
+                func_analysis,
+                Some(&analysis.specials),
+                false,
+                false,
+                1,
+            )?;
         }
         writeln!(w, "}}")?;
     }
@@ -129,7 +125,7 @@ fn generate_flags(
 
     writeln!(w)?;
 
-    if config.generate_display_trait && !analysis.specials.contains_key(&Type::Display) {
+    if config.generate_display_trait && !analysis.specials.has_trait(Type::Display) {
         // Generate Display trait implementation.
         version_condition(w, env, flags.version, false, 0)?;
         writeln!(

--- a/src/codegen/flags.rs
+++ b/src/codegen/flags.rs
@@ -125,6 +125,20 @@ fn generate_flags(
 
     writeln!(w)?;
 
+    if config.generate_display_trait {
+        // Generate Display trait implementation.
+        version_condition(w, env, flags.version, false, 0)?;
+        writeln!(
+            w,
+            "impl fmt::Display for {0} {{\n\
+            \tfn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {{\n\
+            \t\t<Self as fmt::Debug>::fmt(self, f)\n\
+            \t}}\n\
+            }}\n",
+            flags.name
+        )?;
+    }
+
     version_condition(w, env, flags.version, false, 0)?;
     writeln!(
         w,

--- a/src/codegen/flags.rs
+++ b/src/codegen/flags.rs
@@ -35,7 +35,6 @@ pub fn generate(env: &Env, root_path: &Path, mod_rs: &mut Vec<String>) {
     let path = root_path.join("flags.rs");
     file_saver::save_to_file(path, env.config.make_backup, |w| {
         let mut imports = Imports::new(&env.library);
-        imports.add(&format!("crate::{}", env.main_sys_crate_name()));
         imports.add("glib::translate::*");
         imports.add("bitflags::bitflags");
 

--- a/src/codegen/flags.rs
+++ b/src/codegen/flags.rs
@@ -1,6 +1,7 @@
 use super::{function, trait_impls};
 use crate::{
     analysis::flags::Info,
+    analysis::special_functions::Type,
     codegen::general::{
         self, cfg_deprecated, derives, version_condition, version_condition_string,
     },
@@ -96,10 +97,13 @@ fn generate_flags(
         .collect::<Vec<_>>();
 
     if !functions.is_empty() {
-        let static_tostring = analysis
-            .specials
-            .get(&crate::analysis::special_functions::Type::Display)
-            .and_then(|f| if f.returns_static_ref { Some(f) } else { None });
+        let static_tostring = analysis.specials.get(&Type::Display).and_then(|f| {
+            if f.returns_static_ref {
+                Some(f)
+            } else {
+                None
+            }
+        });
 
         writeln!(w)?;
         version_condition(w, env, flags.version, false, 0)?;
@@ -125,7 +129,7 @@ fn generate_flags(
 
     writeln!(w)?;
 
-    if config.generate_display_trait {
+    if config.generate_display_trait && !analysis.specials.contains_key(&Type::Display) {
         // Generate Display trait implementation.
         version_condition(w, env, flags.version, false, 0)?;
         writeln!(

--- a/src/codegen/function.rs
+++ b/src/codegen/function.rs
@@ -456,3 +456,39 @@ pub fn body_chunk_futures(
 
     Ok(body)
 }
+
+pub(super) fn generate_static_to_str(
+    w: &mut dyn Write,
+    env: &Env,
+    function: &analysis::functions::Info,
+) -> Result<()> {
+    writeln!(w)?;
+    version_condition(w, env, function.version, false, 1)?;
+
+    let visibility = match function.visibility {
+        Visibility::Public => "pub ",
+        _ => "",
+    };
+
+    writeln!(
+        w,
+        "\
+\t{visibility}fn {rust_fn_name}<'a>(self) -> &'a str {{
+\t\tunsafe {{
+\t\t\tCStr::from_ptr(
+\t\t\t\t{ns}::{glib_fn_name}(self.to_glib())
+\t\t\t\t\t.as_ref()
+\t\t\t\t\t.expect(\"{glib_fn_name} returned NULL\"),
+\t\t\t)
+\t\t\t.to_str()
+\t\t\t.expect(\"{glib_fn_name} returned an invalid string\")
+\t\t}}
+\t}}",
+        visibility = visibility,
+        rust_fn_name = function.name,
+        ns = env.main_sys_crate_name(),
+        glib_fn_name = function.glib_name,
+    )?;
+
+    Ok(())
+}

--- a/src/codegen/functions.rs
+++ b/src/codegen/functions.rs
@@ -24,7 +24,7 @@ pub fn generate(env: &Env, root_path: &Path, mod_rs: &mut Vec<String>) {
         mod_rs.push("\npub mod functions;".into());
 
         for func_analysis in &functions.functions {
-            function::generate(w, env, func_analysis, false, false, 0)?;
+            function::generate(w, env, func_analysis, None, false, false, 0)?;
         }
 
         Ok(())

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -21,6 +21,7 @@ mod records;
 mod return_value;
 mod signal;
 mod signal_body;
+mod special_functions;
 mod sys;
 mod trait_impls;
 mod trampoline;

--- a/src/codegen/object.rs
+++ b/src/codegen/object.rs
@@ -37,12 +37,28 @@ pub fn generate(
         writeln!(w)?;
         write!(w, "impl {} {{", analysis.name)?;
         for func_analysis in &analysis.constructors() {
-            function::generate(w, env, func_analysis, false, false, 1)?;
+            function::generate(
+                w,
+                env,
+                func_analysis,
+                Some(&analysis.specials),
+                false,
+                false,
+                1,
+            )?;
         }
 
         if !need_generate_trait(analysis) {
             for func_analysis in &analysis.methods() {
-                function::generate(w, env, func_analysis, false, false, 1)?;
+                function::generate(
+                    w,
+                    env,
+                    func_analysis,
+                    Some(&analysis.specials),
+                    false,
+                    false,
+                    1,
+                )?;
             }
 
             for property in &analysis.properties {
@@ -55,7 +71,15 @@ pub fn generate(
         }
 
         for func_analysis in &analysis.functions() {
-            function::generate(w, env, func_analysis, false, false, 1)?;
+            function::generate(
+                w,
+                env,
+                func_analysis,
+                Some(&analysis.specials),
+                false,
+                false,
+                1,
+            )?;
         }
 
         if !need_generate_trait(analysis) {
@@ -134,7 +158,7 @@ pub fn generate(
         generate_trait(w, env, analysis)?;
     }
 
-    if generate_display_trait && !analysis.specials.contains_key(&Type::Display) {
+    if generate_display_trait && !analysis.specials.has_trait(Type::Display) {
         writeln!(w, "\nimpl fmt::Display for {} {{", analysis.name,)?;
         // Generate Display trait implementation.
         writeln!(
@@ -275,7 +299,15 @@ fn generate_trait(w: &mut dyn Write, env: &Env, analysis: &analysis::object::Inf
     write!(w, "pub trait {}: 'static {{", analysis.trait_name)?;
 
     for func_analysis in &analysis.methods() {
-        function::generate(w, env, func_analysis, true, true, 1)?;
+        function::generate(
+            w,
+            env,
+            func_analysis,
+            Some(&analysis.specials),
+            true,
+            true,
+            1,
+        )?;
     }
     for property in &analysis.properties {
         properties::generate(w, env, property, true, true, 1)?;
@@ -300,7 +332,15 @@ fn generate_trait(w: &mut dyn Write, env: &Env, analysis: &analysis::object::Inf
     )?;
 
     for func_analysis in &analysis.methods() {
-        function::generate(w, env, func_analysis, true, false, 1)?;
+        function::generate(
+            w,
+            env,
+            func_analysis,
+            Some(&analysis.specials),
+            true,
+            false,
+            1,
+        )?;
     }
     for property in &analysis.properties {
         properties::generate(w, env, property, true, false, 1)?;

--- a/src/codegen/object.rs
+++ b/src/codegen/object.rs
@@ -1,5 +1,6 @@
 use super::{child_properties, function, general, properties, signal, trait_impls};
 use crate::{
+    analysis::special_functions::Type,
     analysis::{
         self,
         rust_type::{rust_type, rust_type_full},
@@ -133,7 +134,7 @@ pub fn generate(
         generate_trait(w, env, analysis)?;
     }
 
-    if generate_display_trait {
+    if generate_display_trait && !analysis.specials.contains_key(&Type::Display) {
         writeln!(w, "\nimpl fmt::Display for {} {{", analysis.name,)?;
         // Generate Display trait implementation.
         writeln!(

--- a/src/codegen/parameter.rs
+++ b/src/codegen/parameter.rs
@@ -16,22 +16,22 @@ pub trait ToParameter {
 
 impl ToParameter for CParameter {
     fn to_parameter(&self, env: &Env, bounds: &Bounds) -> String {
-        let mut_str = if self.ref_mode == RefMode::ByRefMut {
-            "mut "
-        } else {
-            ""
+        let ref_str = match self.ref_mode {
+            RefMode::ByRefMut => "&mut ",
+            RefMode::None => "",
+            _ => "&",
         };
         if self.instance_parameter {
-            format!("&{}self", mut_str)
+            format!("{}self", ref_str)
         } else {
             let type_str: String;
             match bounds.get_parameter_alias_info(&self.name) {
                 Some((t, bound_type)) => match bound_type {
                     BoundType::NoWrapper => type_str = t.to_string(),
                     BoundType::IsA(_) if *self.nullable => {
-                        type_str = format!("Option<&{}{}>", mut_str, t)
+                        type_str = format!("Option<{}{}>", ref_str, t)
                     }
-                    BoundType::IsA(_) => type_str = format!("&{}{}", mut_str, t),
+                    BoundType::IsA(_) => type_str = format!("{}{}", ref_str, t),
                     BoundType::AsRef(_) => type_str = t.to_string(),
                 },
                 None => {

--- a/src/codegen/record.rs
+++ b/src/codegen/record.rs
@@ -31,8 +31,8 @@ pub fn generate(w: &mut dyn Write, env: &Env, analysis: &analysis::record::Info)
             );
         }
     } else if let (Some(ref_fn), Some(unref_fn)) = (
-        analysis.specials.get(&Type::Ref),
-        analysis.specials.get(&Type::Unref),
+        analysis.specials.traits().get(&Type::Ref),
+        analysis.specials.traits().get(&Type::Unref),
     ) {
         general::define_shared_type(
             w,
@@ -51,8 +51,8 @@ pub fn generate(w: &mut dyn Write, env: &Env, analysis: &analysis::record::Info)
             &analysis.derives,
         )?;
     } else if let (Some(copy_fn), Some(free_fn)) = (
-        analysis.specials.get(&Type::Copy),
-        analysis.specials.get(&Type::Free),
+        analysis.specials.traits().get(&Type::Copy),
+        analysis.specials.traits().get(&Type::Free),
     ) {
         general::define_boxed_type(
             w,
@@ -100,7 +100,15 @@ pub fn generate(w: &mut dyn Write, env: &Env, analysis: &analysis::record::Info)
         write!(w, "impl {} {{", analysis.name)?;
 
         for func_analysis in &analysis.functions {
-            function::generate(w, env, func_analysis, false, false, 1)?;
+            function::generate(
+                w,
+                env,
+                func_analysis,
+                Some(&analysis.specials),
+                false,
+                false,
+                1,
+            )?;
         }
 
         writeln!(w, "}}")?;

--- a/src/codegen/record.rs
+++ b/src/codegen/record.rs
@@ -39,8 +39,8 @@ pub fn generate(w: &mut dyn Write, env: &Env, analysis: &analysis::record::Info)
             env,
             &analysis.name,
             &type_.c_type,
-            ref_fn,
-            unref_fn,
+            &ref_fn.glib_name,
+            &unref_fn.glib_name,
             analysis.glib_get_type.as_ref().map(|(f, v)| {
                 if v > &analysis.version {
                     (f.clone(), *v)
@@ -59,8 +59,8 @@ pub fn generate(w: &mut dyn Write, env: &Env, analysis: &analysis::record::Info)
             env,
             &analysis.name,
             &type_.c_type,
-            copy_fn,
-            free_fn,
+            &copy_fn.glib_name,
+            &free_fn.glib_name,
             &analysis.init_function_expression,
             &analysis.clear_function_expression,
             analysis.glib_get_type.as_ref().map(|(f, v)| {

--- a/src/codegen/special_functions.rs
+++ b/src/codegen/special_functions.rs
@@ -1,0 +1,60 @@
+use std::io::{Result, Write};
+
+use crate::{
+    analysis::{self, functions::Visibility, special_functions::FunctionType},
+    Env,
+};
+
+use super::general::version_condition;
+
+pub(super) fn generate(
+    w: &mut dyn Write,
+    env: &Env,
+    function: &analysis::functions::Info,
+    specials: &analysis::special_functions::Infos,
+) -> Result<bool> {
+    if let Some(special) = specials.functions().get(&function.glib_name) {
+        match special.type_ {
+            FunctionType::StaticStringify => generate_static_to_str(w, env, function),
+        }
+        .map(|()| true)
+    } else {
+        Ok(false)
+    }
+}
+
+pub(super) fn generate_static_to_str(
+    w: &mut dyn Write,
+    env: &Env,
+    function: &analysis::functions::Info,
+) -> Result<()> {
+    writeln!(w)?;
+    version_condition(w, env, function.version, false, 1)?;
+
+    let visibility = match function.visibility {
+        Visibility::Public => "pub ",
+        _ => "",
+    };
+
+    writeln!(
+        w,
+        "\
+\t{visibility}fn {rust_fn_name}<'a>(self) -> &'a str {{
+\t\tunsafe {{
+\t\t\tCStr::from_ptr(
+\t\t\t\t{ns}::{glib_fn_name}(self.to_glib())
+\t\t\t\t\t.as_ref()
+\t\t\t\t\t.expect(\"{glib_fn_name} returned NULL\"),
+\t\t\t)
+\t\t\t.to_str()
+\t\t\t.expect(\"{glib_fn_name} returned an invalid string\")
+\t\t}}
+\t}}",
+        visibility = visibility,
+        rust_fn_name = function.name,
+        ns = env.main_sys_crate_name(),
+        glib_fn_name = function.glib_name,
+    )?;
+
+    Ok(())
+}

--- a/src/codegen/trait_impls.rs
+++ b/src/codegen/trait_impls.rs
@@ -28,7 +28,7 @@ pub fn generate(
                 Type::Equal => {
                     generate_eq(w, env, type_name, info, trait_name)?;
                 }
-                Type::ToString => generate_display(w, env, type_name, info, trait_name)?,
+                Type::Display => generate_display(w, env, type_name, info, trait_name)?,
                 Type::Hash => generate_hash(w, env, type_name, info, trait_name)?,
                 _ => {}
             }

--- a/src/codegen/trait_impls.rs
+++ b/src/codegen/trait_impls.rs
@@ -16,8 +16,8 @@ pub fn generate(
     specials: &Infos,
     trait_name: Option<&str>,
 ) -> Result<()> {
-    for (type_, name) in specials.iter() {
-        if let Some(info) = lookup(functions, name) {
+    for (type_, special_info) in specials.iter() {
+        if let Some(info) = lookup(functions, &special_info.glib_name) {
             match *type_ {
                 Type::Compare => {
                     if !specials.contains_key(&Type::Equal) {
@@ -40,7 +40,7 @@ pub fn generate(
 fn lookup<'a>(functions: &'a [Info], name: &str) -> Option<&'a Info> {
     functions
         .iter()
-        .find(|f| f.status.need_generate() && f.glib_name == name)
+        .find(|f| !f.status.ignored() && f.glib_name == name)
 }
 
 fn generate_call(func_name: &str, args: &[&str], trait_name: Option<&str>) -> String {

--- a/src/codegen/trait_impls.rs
+++ b/src/codegen/trait_impls.rs
@@ -16,11 +16,11 @@ pub fn generate(
     specials: &Infos,
     trait_name: Option<&str>,
 ) -> Result<()> {
-    for (type_, special_info) in specials.iter() {
+    for (type_, special_info) in specials.traits().iter() {
         if let Some(info) = lookup(functions, &special_info.glib_name) {
             match *type_ {
                 Type::Compare => {
-                    if !specials.contains_key(&Type::Equal) {
+                    if !specials.has_trait(Type::Equal) {
                         generate_eq_compare(w, env, type_name, info, trait_name)?;
                     }
                     generate_ord(w, env, type_name, info, trait_name)?;

--- a/src/env.rs
+++ b/src/env.rs
@@ -53,10 +53,6 @@ impl Env {
     }
 
     pub fn main_sys_crate_name(&self) -> &str {
-        if &self.namespaces[MAIN_NAMESPACE].sys_crate_name != "gobject_ffi" {
-            "ffi"
-        } else {
-            "gobject_ffi"
-        }
+        &self.namespaces[MAIN_NAMESPACE].sys_crate_name
     }
 }


### PR DESCRIPTION
Leverage existing function generation for class/record to generate associated functions on enumerations as well, instead of having to write these by hand :tada:. The MR for `gstreamer-rs` can be found [here](https://gitlab.freedesktop.org/gstreamer/gstreamer-rs/-/merge_requests/630). These changes came up during https://gitlab.freedesktop.org/gstreamer/gstreamer-rs/-/merge_requests/581.

This relies on functions being associated with the `<enumeration>` in `.gir` files as opposed to being free (same story with class/record), see https://gitlab.freedesktop.org/gstreamer/gst-plugins-base/-/merge_requests/805 for an example where this was not the case.

Note that we have [decided](https://gitlab.freedesktop.org/gstreamer/gst-plugins-base/-/merge_requests/805#note_616786) against turning the first argument from `<parameter>` into `<instance-parameter>` in Gir files (to make these functions behave like `fn my_func(&self)` instead of `fn my_func(my_enum: Self)`). This is instead overridden during analysis, it's a bit ugly so perhaps we need to revisit this discussion. It all depends on other tooling, and how many other languages (potentially) support functions on enum instances like Rust.

- [x] Apologies for finding out about SSR in the history of this repo and performing some refactorings :grimacing:. Perhaps those are better submitted in a separate, easier-to-review PR?

### Related PRs/MRs

- gstreamer-rs: https://gitlab.freedesktop.org/gstreamer/gstreamer-rs/-/merge_requests/630


### TODO

- [x]  Active review comment threads
  - [x] `to_string` seems quite a large task still:
    - [x] When do we use it?
    - [x] How do we generate generic (error-handling) code for it?
    - [x] Fix recursion because of `fn to_string(self)` (ie. by naming it consistently `to_str` across the board)
    - [x] Fix that one remaining unused `use glib::GString` in `webrtc/enums` (due to `&'static str` replacement)
    - [x] Decide on panicking rules:
      ```rust
      .map(|ptr| CStr::from_ptr(ptr).to_str().unwrap())
      .unwrap_or("INVALID")
      ```
      versus:
      ```rust
      .and_then(|ptr| CStr::from_ptr(ptr).to_str().ok())
      .unwrap_or("INVALID")
      ```
      Even though the latter discards a descriptive `Err` in favour of `None`.
- [x]  Adding support for flags (which should be exactly the same)
  - [x] Check if we can reduce code duplication
- [x]  Moving the quote stuff into a separate PR
  Removed from this PR, separate PR comes when rebasing doesn't conflict with these changes anymore :wink: 
- [x]  Removing the commits from #994 after that one is merged
- [x] ~Autogenerate `from_string`, which is pretty straightforward~ Not worth it: many different types use this function, all with their own semantics.
  - [ ] However manual implementations are updated to call the autogenerated version, which takes care of unsafe, asserting initialization, and glib to/from conversion. Where possible this should be applied to other manual functions as well.
- [x] Do not import `std::fmt` in flags when `generate_display_trait` is true but nothing has `to_string` (only problematic in gtk)
  - This was my mistake, copying the analysis code to add `std::fmt` when `generate_display_trait` is true, without any matching codegen. A sensible Display trait is now emitted in that case.
- [x] Rebase this branch on master as soon as edition2018 drops on gstreamer-rs :)
- [x] Rename `gst_video_chroma_*` functions to `gst_video_chroma_site_*` for autogeneration.
- [x] If there is an unknown value in a returned enum (`fn from_*(xxx) -> EnumType`), turn that into a `Result<..., BoolError>`;