### PR TITLE
Simplify `match` blocks into `?` operator using SSR

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,185 +2,189 @@
 # It is not intended for manual editing.
 [[package]]
 name = "aho-corasick"
-version = "0.7.13"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5"
 dependencies = [
- "memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr",
 ]
 
 [[package]]
 name = "autocfg"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "clock_ticks"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c49a90f58e73ac5f41ed0ac249861ceb5f0976db35fabc2b9c2c856916042d63"
 
 [[package]]
 name = "env_logger"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
 dependencies = [
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.11",
 ]
 
 [[package]]
 name = "getopts"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
 dependencies = [
- "unicode-width 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-width",
 ]
 
 [[package]]
 name = "gir"
 version = "0.0.1"
 dependencies = [
- "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "getopts 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "hprof 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustdoc-stripper 0.1.13 (git+https://github.com/GuillaumeGomez/rustdoc-stripper)",
- "toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "xml-rs 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags",
+ "env_logger",
+ "getopts",
+ "hprof",
+ "log 0.4.11",
+ "once_cell",
+ "regex",
+ "rustdoc-stripper",
+ "toml",
+ "xml-rs",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
 
 [[package]]
 name = "hprof"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17b42e67c01ef27237e424783538a0bc45721ecd53438fab5c3f8bbf5dfd8516"
 dependencies = [
- "clock_ticks 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clock_ticks",
+ "log 0.3.9",
 ]
 
 [[package]]
 name = "indexmap"
-version = "1.4.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55e2e4c765aa53a0424761bf9f41aa7a6ac1efa87238f59560640e27fca028f2"
 dependencies = [
- "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg",
+ "hashbrown",
 ]
 
 [[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "log"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 dependencies = [
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.11",
 ]
 
 [[package]]
 name = "log"
-version = "0.4.8"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
 dependencies = [
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if",
 ]
 
 [[package]]
 name = "memchr"
-version = "2.3.3"
+version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
 
 [[package]]
 name = "once_cell"
-version = "1.4.0"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13bd41f508810a131401606d54ac32a467c97172d74ba7662562ebba5ad07fa0"
 
 [[package]]
 name = "regex"
-version = "1.3.9"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38cf2c13ed4745de91a5eb834e11c00bcc3709e773173b2ce4c56c9fbde04b9c"
 dependencies = [
- "aho-corasick 0.7.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.6.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "thread_local 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+ "thread_local",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.18"
+version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b181ba2dcf07aaccad5448e8ead58db5b742cf85dfe035e2227f137a539a189"
 
 [[package]]
 name = "rustdoc-stripper"
-version = "0.1.13"
-source = "git+https://github.com/GuillaumeGomez/rustdoc-stripper#bb9c409fce167452753a6a4c87754bb59387ce64"
+version = "0.1.16"
+source = "git+https://github.com/GuillaumeGomez/rustdoc-stripper#bbdf0a350a85c8d4d1bda779b7eba75bd3de7862"
 
 [[package]]
 name = "serde"
-version = "1.0.114"
+version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b88fa983de7720629c9387e9f517353ed404164b1e482c970a90c1a4aaf7dc1a"
 
 [[package]]
 name = "thread_local"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
 dependencies = [
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static",
 ]
 
 [[package]]
 name = "toml"
-version = "0.5.6"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75cf45bb0bef80604d001caaec0d09da99611b3c0fd39d3080468875cdb65645"
 dependencies = [
- "indexmap 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
+ "indexmap",
+ "serde",
 ]
 
 [[package]]
 name = "unicode-width"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
 
 [[package]]
 name = "xml-rs"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[metadata]
-"checksum aho-corasick 0.7.13 (registry+https://github.com/rust-lang/crates.io-index)" = "043164d8ba5c4c3035fec9bbee8647c0261d788f3474306f93bb65901cae0e86"
-"checksum autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
-"checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
-"checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
-"checksum clock_ticks 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c49a90f58e73ac5f41ed0ac249861ceb5f0976db35fabc2b9c2c856916042d63"
-"checksum env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
-"checksum getopts 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)" = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
-"checksum hprof 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "17b42e67c01ef27237e424783538a0bc45721ecd53438fab5c3f8bbf5dfd8516"
-"checksum indexmap 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c398b2b113b55809ceb9ee3e753fcbac793f1956663f3c36549c1346015c2afe"
-"checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-"checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
-"checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
-"checksum memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
-"checksum once_cell 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0b631f7e854af39a1739f401cf34a8a013dfe09eac4fa4dba91e9768bd28168d"
-"checksum regex 1.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "9c3780fcf44b193bc4d09f36d2a3c87b251da4a046c87795a0d35f4f927ad8e6"
-"checksum regex-syntax 0.6.18 (registry+https://github.com/rust-lang/crates.io-index)" = "26412eb97c6b088a6997e05f69403a802a92d520de2f8e63c2b65f9e0f47c4e8"
-"checksum rustdoc-stripper 0.1.13 (git+https://github.com/GuillaumeGomez/rustdoc-stripper)" = "<none>"
-"checksum serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)" = "5317f7588f0a5078ee60ef675ef96735a1442132dc645eb1d12c018620ed8cd3"
-"checksum thread_local 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
-"checksum toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ffc92d160b1eef40665be3a05630d003936a3bc7da7421277846c2613e92c71a"
-"checksum unicode-width 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
-"checksum xml-rs 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b07db065a5cf61a7e4ba64f29e67db906fb1787316516c4e6e5ff0fea1efcd8a"
+checksum = "b07db065a5cf61a7e4ba64f29e67db906fb1787316516c4e6e5ff0fea1efcd8a"

--- a/src/analysis/object.rs
+++ b/src/analysis/object.rs
@@ -52,19 +52,13 @@ pub fn class(env: &Env, obj: &GObject, deps: &[library::TypeId]) -> Option<Info>
     info!("Analyzing class {}", obj.name);
     let full_name = obj.name.clone();
 
-    let class_tid = match env.library.find_type(0, &full_name) {
-        Some(tid) => tid,
-        None => return None,
-    };
+    let class_tid = env.library.find_type(0, &full_name)?;
 
     let type_ = env.type_(class_tid);
 
     let name: String = split_namespace_name(&full_name).1.into();
 
-    let klass: &library::Class = match type_.maybe_ref() {
-        Some(klass) => klass,
-        None => return None,
-    };
+    let klass: &library::Class = type_.maybe_ref()?;
 
     let mut imports = Imports::with_defined(&env.library, &name);
     imports.add("glib::translate::*");
@@ -226,19 +220,13 @@ pub fn interface(env: &Env, obj: &GObject, deps: &[library::TypeId]) -> Option<I
     info!("Analyzing interface {}", obj.name);
     let full_name = obj.name.clone();
 
-    let iface_tid = match env.library.find_type(0, &full_name) {
-        Some(tid) => tid,
-        None => return None,
-    };
+    let iface_tid = env.library.find_type(0, &full_name)?;
 
     let type_ = env.type_(iface_tid);
 
     let name: String = split_namespace_name(&full_name).1.into();
 
-    let iface: &library::Interface = match type_.maybe_ref() {
-        Some(iface) => iface,
-        None => return None,
-    };
+    let iface: &library::Interface = type_.maybe_ref()?;
 
     let mut imports = Imports::with_defined(&env.library, &name);
     imports.add("glib::translate::*");

--- a/src/analysis/record.rs
+++ b/src/analysis/record.rs
@@ -69,19 +69,13 @@ pub fn new(env: &Env, obj: &GObject) -> Option<Info> {
     info!("Analyzing record {}", obj.name);
     let full_name = obj.name.clone();
 
-    let record_tid = match env.library.find_type(0, &full_name) {
-        Some(tid) => tid,
-        None => return None,
-    };
+    let record_tid = env.library.find_type(0, &full_name)?;
 
     let type_ = env.type_(record_tid);
 
     let name: String = split_namespace_name(&full_name).1.into();
 
-    let record: &library::Record = match type_.maybe_ref() {
-        Some(record) => record,
-        None => return None,
-    };
+    let record: &library::Record = type_.maybe_ref()?;
 
     let is_boxed = obj.use_boxed_functions || RecordType::of(&record) == RecordType::AutoBoxed;
 

--- a/src/codegen/enums.rs
+++ b/src/codegen/enums.rs
@@ -156,10 +156,10 @@ fn generate_enum(
     }
     writeln!(
         w,
-        "{}",
-        "    #[doc(hidden)]
+        "\
+    #[doc(hidden)]
     __Unknown(i32),
-}
+}}
 "
     )?;
 
@@ -208,13 +208,13 @@ impl ToGlib for {name} {{
             enum_.name, member.name, sys_crate_name, member.c_name
         )?;
     }
-    writeln!(w, "\t\t\t{}::__Unknown(value) => value", enum_.name)?;
+    writeln!(w, "\t\t\t{}::__Unknown(value) => value,", enum_.name)?;
     writeln!(
         w,
-        "{}",
-        "        }
-    }
-}
+        "\
+        }}
+    }}
+}}
 "
     )?;
 
@@ -248,10 +248,10 @@ impl FromGlib<{sys_crate_name}::{ffi_name}> for {name} {{
     writeln!(w, "\t\t\tvalue => {}::__Unknown(value),", enum_.name)?;
     writeln!(
         w,
-        "{}",
-        "        }
-    }
-}
+        "\
+        }}
+    }}
+}}
 "
     )?;
 
@@ -319,10 +319,10 @@ impl FromGlib<{sys_crate_name}::{ffi_name}> for {name} {{
 
         writeln!(
             w,
-            "{}",
-            "        }
-    }
-}
+            "\
+        }}
+    }}
+}}
 "
         )?;
     }

--- a/src/codegen/sys/tests.rs
+++ b/src/codegen/sys/tests.rs
@@ -90,10 +90,8 @@ fn prepare_ctype(env: &Env, ns: &Namespace, t: &Type) -> Option<CType> {
     if env.type_status_sys(&full_name).ignored() {
         return None;
     }
-    let name = match t.get_glib_name() {
-        None => return None,
-        Some(name) => name,
-    };
+    let name = t.get_glib_name()?;
+
     if is_name_made_up(name) {
         return None;
     }

--- a/src/codegen/trait_impls.rs
+++ b/src/codegen/trait_impls.rs
@@ -88,7 +88,7 @@ fn generate_display(
             call
         )
     } else {
-        format!("write!(f, \"{{}}\", {})", call)
+        format!("f.write_str(&{})", call)
     };
 
     writeln!(

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -173,15 +173,10 @@ impl Config {
             Some(v) => v.as_result_vec("options.docs_rs_features")?.as_slice(),
             None => &[],
         } {
-            docs_rs_features.push(match v.as_str() {
-                Some(s) => s.to_owned(),
-                None => {
-                    return Err(format!(
-                        "Invalid `docs_rs_features` value element, expected a string, found {}",
-                        v.type_str()
-                    ))
-                }
-            });
+            docs_rs_features.push(v.as_str().map(|s| s.to_owned()).ok_or(format!(
+                "Invalid `docs_rs_features` value element, expected a string, found {}",
+                v.type_str()
+            ))?);
         }
 
         // options.concurrency is the default of all objects if nothing

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -12,8 +12,7 @@ use crate::{
 use log::warn;
 use std::{
     collections::HashMap,
-    fs::File,
-    io::Read,
+    fs,
     path::{Path, PathBuf},
     str::FromStr,
 };
@@ -312,32 +311,16 @@ fn read_toml<P: AsRef<Path>>(filename: P) -> Result<toml::Value, String> {
     if !filename.as_ref().is_file() {
         return Err("Config don't exists or not file".to_owned());
     }
-    let mut input = String::new();
-    match File::open(&filename) {
-        Ok(mut f) => {
-            if let Err(e) = f.read_to_string(&mut input) {
-                return Err(format!(
-                    "read_to_string failed on \"{}\": {}",
-                    filename.as_ref().display(),
-                    e
-                ));
-            }
+    let input = fs::read(&filename)
+        .map_err(|e| format!("Failed to read file \"{:?}\": {}", filename.as_ref(), e))?;
 
-            match toml::from_str(&input) {
-                Ok(toml) => Ok(toml),
-                Err(e) => Err(format!(
-                    "Invalid toml format in \"{}\": {}",
-                    filename.as_ref().display(),
-                    e
-                )),
-            }
-        }
-        Err(e) => Err(format!(
-            "Cannot open file \"{}\": {}",
+    toml::from_slice(&input).map_err(|e| {
+        format!(
+            "Invalid toml format in \"{}\": {}",
             filename.as_ref().display(),
             e
-        )),
-    }
+        )
+    })
 }
 
 fn make_single_version_file(configured: Option<&str>, target_path: &Path) -> PathBuf {

--- a/src/config/error.rs
+++ b/src/config/error.rs
@@ -37,14 +37,8 @@ impl TomlHelper for toml::Value {
     fn lookup<'a>(&'a self, option: &str) -> Option<&'a toml::Value> {
         let mut value = self;
         for opt in option.split('.') {
-            let table = match value.as_table() {
-                Some(table) => table,
-                None => return None,
-            };
-            value = match table.get(opt) {
-                Some(value) => value,
-                None => return None,
-            };
+            let table = value.as_table()?;
+            value = table.get(opt)?;
         }
         Some(value)
     }

--- a/src/config/property_generate_flags.rs
+++ b/src/config/property_generate_flags.rs
@@ -27,16 +27,11 @@ impl PropertyGenerateFlags {
         let array = toml.as_result_vec(option)?;
         let mut val = PropertyGenerateFlags::empty();
         for v in array {
-            let s = match v.as_str() {
-                Some(s) => s,
-                None => {
-                    return Err(format!(
-                        "Invalid `{}` value element, expected a string, found {}",
-                        option,
-                        v.type_str()
-                    ))
-                }
-            };
+            let s = v.as_str().ok_or(format!(
+                "Invalid `{}` value element, expected a string, found {}",
+                option,
+                v.type_str()
+            ))?;
             match PropertyGenerateFlags::from_str(s) {
                 Ok(v) => val |= v,
                 e @ Err(_) => return e,

--- a/src/main.rs
+++ b/src/main.rs
@@ -158,14 +158,13 @@ fn do_main() -> Result<(), String> {
 
     let watcher_total = statistics.enter("Total");
 
-    let mut library;
-
-    {
+    let mut library = {
         let _watcher = statistics.enter("Loading");
 
-        library = Library::new(&cfg.library_name);
+        let mut library = Library::new(&cfg.library_name);
         library.read_file(&cfg.girs_dir, &mut vec![cfg.library_full_name()])?;
-    }
+        library
+    };
 
     {
         let _watcher = statistics.enter("Preprocessing");
@@ -192,24 +191,22 @@ fn do_main() -> Result<(), String> {
         gir::update_version::check_function_real_version(&mut library);
     }
 
-    let mut env;
-
-    {
+    let mut env = {
         let _watcher = statistics.enter("Namespace/symbol/class analysis");
 
         let namespaces = gir::namespaces_run(&library);
         let symbols = gir::symbols_run(&library, &namespaces);
         let class_hierarchy = gir::class_hierarchy_run(&library);
 
-        env = gir::Env {
+        gir::Env {
             library,
             config: cfg,
             namespaces,
             symbols: RefCell::new(symbols),
             class_hierarchy,
             analysis: Default::default(),
-        };
-    }
+        }
+    };
 
     if env.config.work_mode != WorkMode::Sys {
         let _watcher = statistics.enter("Analyzing");

--- a/src/main.rs
+++ b/src/main.rs
@@ -131,8 +131,7 @@ fn run_check(check_gir_file: &str) -> Result<(), String> {
 
 fn do_main() -> Result<(), String> {
     if std::env::var_os("RUST_LOG").is_none() {
-        std::env::set_var("RUST_LOG", "gir=warn");
-        std::env::set_var("RUST_LOG", "libgir=warn");
+        std::env::set_var("RUST_LOG", "gir=warn,libgir=warn");
     }
     env_logger::init();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -119,7 +119,7 @@ fn run_check(check_gir_file: &str) -> Result<(), String> {
         .ok_or(format!("Failed to get file stem from `{}`", check_gir_file))?;
     let lib_name = lib_name
         .to_str()
-        .ok_or("failed to convert OsStr to str".to_owned())?;
+        .ok_or_else(|| "failed to convert OsStr to str".to_owned())?;
     let mut library = Library::new(lib_name);
     let parent = path.parent().ok_or(format!(
         "Failed to get parent directory from `{}`",

--- a/src/main.rs
+++ b/src/main.rs
@@ -117,24 +117,17 @@ fn run_check(check_gir_file: &str) -> Result<(), String> {
     if !path.is_file() {
         return Err(format!("`{}`: file not found", check_gir_file));
     }
-    let lib_name = match path.file_stem() {
-        Some(f) => f,
-        None => return Err(format!("Failed to get file stem from `{}`", check_gir_file)),
-    };
-    let lib_name = match lib_name.to_str() {
-        Some(l) => l,
-        None => return Err("failed to convert OsStr to str".to_owned()),
-    };
+    let lib_name = path
+        .file_stem()
+        .ok_or(format!("Failed to get file stem from `{}`", check_gir_file))?;
+    let lib_name = lib_name
+        .to_str()
+        .ok_or("failed to convert OsStr to str".to_owned())?;
     let mut library = Library::new(lib_name);
-    let parent = match path.parent() {
-        Some(p) => p,
-        None => {
-            return Err(format!(
-                "Failed to get parent directory from `{}`",
-                check_gir_file
-            ))
-        }
-    };
+    let parent = path.parent().ok_or(format!(
+        "Failed to get parent directory from `{}`",
+        check_gir_file
+    ))?;
 
     library.read_file(&parent, &mut vec![lib_name.to_owned()])
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,10 +63,7 @@ fn build_config() -> Result<RunKind, String> {
         "PATH",
     );
 
-    let matches = match options.parse(&args[1..]) {
-        Ok(matches) => matches,
-        Err(e) => return Err(e.to_string()),
-    };
+    let matches = options.parse(&args[1..]).map_err(|e| e.to_string())?;
 
     if let Some(check_gir_file) = matches.opt_str("check-gir-file") {
         return Ok(RunKind::CheckGirFile(check_gir_file));

--- a/src/xmlparser.rs
+++ b/src/xmlparser.rs
@@ -308,9 +308,7 @@ impl<'a> XmlParser<'a> {
                     }
                 }
                 Err(_) => {
-                    if let Err(e) = self.next_event() {
-                        return Err(e);
-                    }
+                    self.next_event()?;
                     unreachable!();
                 }
                 _ if result.is_empty() => {


### PR DESCRIPTION
Extracted from #991

While addressing minor code inconsistency I stumbled upon a commit from Heftig using `rerast` for structural refactoring, and it turns out Rust-analyzer supports SSR as well. This made it possible to easily do a bulk of conversions to use `?` instead of manual `match` blocks. See the relevant commits for the rules used.

One minor deficiency is the inability to repeat labels: it is impossible to specify `Some($a) => $a`, meaning that a manual check is necessary to see if the right hand side wasn't doing any extra conversion. These had to be addressed by hand, but weren't many.