### PR TITLE
codegen/enum: Do not generate doc(cfg) on match arms

### DIFF
--- a/src/codegen/enums.rs
+++ b/src/codegen/enums.rs
@@ -1,7 +1,8 @@
 use crate::{
     analysis::{imports::Imports, namespaces},
     codegen::general::{
-        self, cfg_deprecated, derives, version_condition, version_condition_string,
+        self, cfg_deprecated, derives, version_condition, version_condition_no_doc,
+        version_condition_string,
     },
     config::gobjects::GObject,
     env::Env,
@@ -174,7 +175,7 @@ fn generate_enum(
             enum_.name
         )?;
         for member in &members {
-            version_condition(w, env, member.version, false, 3)?;
+            version_condition_no_doc(w, env, member.version, false, 3)?;
             writeln!(w, "\t\t\t{0}::{1} => \"{1}\",", enum_.name, member.name)?;
         }
         writeln!(
@@ -201,7 +202,7 @@ impl ToGlib for {name} {{
         ffi_name = enum_.c_type
     )?;
     for member in &members {
-        version_condition(w, env, member.version, false, 3)?;
+        version_condition_no_doc(w, env, member.version, false, 3)?;
         writeln!(
             w,
             "\t\t\t{}::{} => {}::{},",
@@ -238,7 +239,7 @@ impl FromGlib<{sys_crate_name}::{ffi_name}> for {name} {{
         assert = assert
     )?;
     for member in &members {
-        version_condition(w, env, member.version, false, 3)?;
+        version_condition_no_doc(w, env, member.version, false, 3)?;
         writeln!(
             w,
             "\t\t\t{} => {}::{},",
@@ -304,7 +305,7 @@ impl FromGlib<{sys_crate_name}::{ffi_name}> for {name} {{
         )?;
 
         for member in &members {
-            version_condition(w, env, member.version, false, 3)?;
+            version_condition_no_doc(w, env, member.version, false, 3)?;
             writeln!(
                 w,
                 "\t\t\t{} => Some({}::{}),",

--- a/src/codegen/general.rs
+++ b/src/codegen/general.rs
@@ -504,14 +504,7 @@ pub fn version_condition_string(
 ) -> Option<String> {
     match version {
         Some(v) if v > env.config.min_cfg_version => {
-            let comment = if commented { "//" } else { "" };
-            Some(format!(
-                "{0}{1}#[cfg(any({2}, feature = \"dox\"))]\n\
-                 {0}{1}#[cfg_attr(feature = \"dox\", doc(cfg({2})))]",
-                tabs(indent),
-                comment,
-                v.to_cfg()
-            ))
+            cfg_condition_string(&Some(v.to_cfg()), commented, indent)
         }
         _ => None,
     }
@@ -523,15 +516,9 @@ pub fn not_version_condition(
     commented: bool,
     indent: usize,
 ) -> Result<()> {
-    if let Some(v) = version {
-        let comment = if commented { "//" } else { "" };
-        let s = format!(
-            "{0}{1}#[cfg(any(not({2}), feature = \"dox\"))]\n\
-             {0}{1}#[cfg_attr(feature = \"dox\", doc(cfg(not({2}))))]",
-            tabs(indent),
-            comment,
-            v.to_cfg()
-        );
+    if let Some(s) = version.and_then(|v| {
+        cfg_condition_string(&Some(format!("not({})", v.to_cfg())), commented, indent)
+    }) {
         writeln!(w, "{}", s)?;
     }
     Ok(())

--- a/src/codegen/general.rs
+++ b/src/codegen/general.rs
@@ -496,6 +496,24 @@ pub fn version_condition(
     Ok(())
 }
 
+pub fn version_condition_no_doc(
+    w: &mut dyn Write,
+    env: &Env,
+    version: Option<Version>,
+    commented: bool,
+    indent: usize,
+) -> Result<()> {
+    match version {
+        Some(v) if v > env.config.min_cfg_version => {
+            if let Some(s) = cfg_condition_string_no_doc(&Some(v.to_cfg()), commented, indent) {
+                writeln!(w, "{}", s)?
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
 pub fn version_condition_string(
     env: &Env,
     version: Option<Version>,
@@ -554,6 +572,25 @@ pub fn cfg_condition(
         writeln!(w, "{}", s)?;
     }
     Ok(())
+}
+
+pub fn cfg_condition_string_no_doc(
+    cfg_condition: &Option<String>,
+    commented: bool,
+    indent: usize,
+) -> Option<String> {
+    match cfg_condition.as_ref() {
+        Some(v) => {
+            let comment = if commented { "//" } else { "" };
+            Some(format!(
+                "{0}{1}#[cfg(any({2}, feature = \"dox\"))]",
+                tabs(indent),
+                comment,
+                v
+            ))
+        }
+        None => None,
+    }
 }
 
 pub fn cfg_condition_string(

--- a/src/codegen/object.rs
+++ b/src/codegen/object.rs
@@ -5,7 +5,7 @@ use crate::{
         rust_type::{rust_type, rust_type_full},
     },
     case::CaseExt,
-    codegen::general::version_condition_string,
+    codegen::general::{version_condition_no_doc, version_condition_string},
     env::Env,
     library, nameutil,
     traits::IntoString,
@@ -235,28 +235,16 @@ impl {}Builder {{
     )?;
     for property in &properties {
         let name = nameutil::mangle_keywords(nameutil::signal_to_snake(&property.name));
-        let version_condition_string = version_condition_string(env, property.version, false, 2);
-        let condition_tabs = if version_condition_string.is_some() {
-            "\t"
-        } else {
-            ""
-        };
-        if let Some(ref version_condition_string) = version_condition_string {
-            writeln!(w, "{}", version_condition_string)?;
-            writeln!(w, "        {{")?;
-        }
+        version_condition_no_doc(w, env, property.version, false, 2)?;
         writeln!(
             w,
-            "{tabs}        if let Some(ref {field}) = self.{field} {{
-{tabs}            properties.push((\"{name}\", {field}));
-{tabs}        }}",
+            "\
+            if let Some(ref {field}) = self.{field} {{
+                properties.push((\"{name}\", {field}));
+            }}",
             name = property.name,
-            field = name,
-            tabs = condition_tabs
+            field = name
         )?;
-        if version_condition_string.is_some() {
-            writeln!(w, "        }}")?;
-        }
     }
     let glib_crate_name = if env.namespaces.is_glib_crate {
         "crate"

--- a/src/version.rs
+++ b/src/version.rs
@@ -12,12 +12,7 @@ pub enum Version {
 
 impl Version {
     pub fn to_cfg(self) -> String {
-        use self::Version::*;
-        match self {
-            Full(major, minor, 0) => format!("feature = \"v{}_{}\"", major, minor),
-            Full(major, minor, patch) => format!("feature = \"v{}_{}_{}\"", major, minor, patch),
-            Short(major) => format!("feature = \"v{}\"", major),
-        }
+        format!("feature = \"{}\"", self.to_feature())
     }
 
     pub fn to_feature(self) -> String {


### PR DESCRIPTION
Simplify some duplicate code around cfg and version handling, and fix the following warnings when compiling with the `dox` feature:

    warning: unused doc comment
    --> gstreamer/src/auto/enums.rs:761:41
        |
    761 |             #[cfg_attr(feature = "dox", doc(cfg(feature = "v1_18")))]
        |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    762 |             66817 => EventType::InstantRateSyncTime,
        |             --------------------------------------- rustdoc does not generate documentation for match arms

Fixes: c63d1fa ("Generate doc cfg attributes for more beautiful docs")