### PR TITLE
Switch to doc cfg instead of feature dox

### DIFF
--- a/src/codegen/general.rs
+++ b/src/codegen/general.rs
@@ -49,12 +49,12 @@ pub fn uses(w: &mut dyn Write, env: &Env, imports: &Imports) -> Result<()> {
         if !scope.constraints.is_empty() {
             writeln!(
                 w,
-                "#[cfg(any({},feature = \"dox\"))]",
+                "#[cfg(any({}, all(not(doctest), doc)))]",
                 scope.constraints.join(", ")
             )?;
             writeln!(
                 w,
-                "#[cfg_attr(feature = \"dox\", doc(cfg({})))]",
+                "#[cfg_attr(all(not(doctest), doc), doc(cfg({})))]",
                 scope.constraints.join(", ")
             )?;
         }
@@ -558,7 +558,7 @@ pub fn not_version_condition_no_dox(
     if let Some(v) = version {
         let comment = if commented { "//" } else { "" };
         let s = format!(
-            "{}{}#[cfg(not(any({}, feature = \"dox\")))]",
+            "{}{}#[cfg(not(any({}, all(not(doctest), doc))))]",
             tabs(indent),
             comment,
             v.to_cfg()
@@ -590,7 +590,7 @@ pub fn cfg_condition_string_no_doc(
         Some(v) => {
             let comment = if commented { "//" } else { "" };
             Some(format!(
-                "{0}{1}#[cfg(any({2}, feature = \"dox\"))]",
+                "{0}{1}#[cfg(any({2}, all(not(doctest), doc)))]",
                 tabs(indent),
                 comment,
                 v
@@ -609,8 +609,8 @@ pub fn cfg_condition_string(
         Some(v) => {
             let comment = if commented { "//" } else { "" };
             Some(format!(
-                "{0}{1}#[cfg(any({2}, feature = \"dox\"))]\n\
-                 {0}{1}#[cfg_attr(feature = \"dox\", doc(cfg({2})))]",
+                "{0}{1}#[cfg(any({2}, all(not(doctest), doc)))]\n\
+                 {0}{1}#[cfg_attr(all(not(doctest), doc), doc(cfg({2})))]",
                 tabs(indent),
                 comment,
                 v

--- a/src/codegen/sys/build.rs
+++ b/src/codegen/sys/build.rs
@@ -37,7 +37,7 @@ fn generate_build_script(w: &mut dyn Write, env: &Env, split_build_rs: bool) -> 
     writeln!(
         w,
         "{}",
-        r##"#[cfg(not(feature = "dox"))]
+        r##"#[cfg(any(not(doc), doctest))]
 use std::process;"##
     )?;
 
@@ -50,10 +50,10 @@ use std::process;"##
         w,
         "{}",
         r##"
-#[cfg(feature = "dox")]
+#[cfg(all(not(doctest), doc))]
 fn main() {} // prevent linking libraries to avoid documentation failure
 
-#[cfg(not(feature = "dox"))]
+#[cfg(any(not(doc), doctest))]
 fn main() {
     if let Err(s) = system_deps::Config::new().probe() {
         let _ = eprintln!("{}", s);

--- a/src/codegen/sys/cargo_toml.rs
+++ b/src/codegen/sys/cargo_toml.rs
@@ -105,7 +105,6 @@ fn fill_in(root: &mut Table, env: &Env) {
             features.insert(version.to_feature(), Value::Array(prev_array));
             Some(version)
         });
-        features.insert("dox".to_string(), Value::Array(Vec::new()));
     }
 
     {
@@ -138,8 +137,7 @@ fn fill_in(root: &mut Table, env: &Env) {
         let docs_rs_metadata = upsert_table(docs_rs_metadata, "metadata");
         let docs_rs_metadata = upsert_table(docs_rs_metadata, "docs");
         let docs_rs_metadata = upsert_table(docs_rs_metadata, "rs");
-        let mut docs_rs_features = env.config.docs_rs_features.clone();
-        docs_rs_features.push("dox".to_owned());
+        let docs_rs_features = env.config.docs_rs_features.clone();
         docs_rs_metadata.insert(
             "features".to_string(),
             Value::Array(

--- a/src/codegen/sys/functions.rs
+++ b/src/codegen/sys/functions.rs
@@ -253,10 +253,14 @@ fn generate_object_funcs(
         let name = func.c_identifier.as_ref().unwrap();
         // since we work with gir-files from Linux, some function names need to be adjusted
         if is_windows_utf8 {
-            writeln!(w, "    {}#[cfg(any(windows, feature = \"dox\"))]", comment)?;
             writeln!(
                 w,
-                "    {}#[cfg_attr(feature = \"dox\", doc(cfg(windows)))]",
+                "    {}#[cfg(any(windows, all(not(doctest), doc)))]",
+                comment
+            )?;
+            writeln!(
+                w,
+                "    {}#[cfg_attr(all(not(doctest), doc), doc(cfg(windows)))]",
                 comment
             )?;
             writeln!(w, "    {}pub fn {}_utf8{};", comment, name, sig)?;

--- a/src/codegen/sys/statics.rs
+++ b/src/codegen/sys/statics.rs
@@ -6,7 +6,7 @@ pub fn begin(w: &mut dyn Write) -> Result<()> {
         "",
         "#![allow(non_camel_case_types, non_upper_case_globals, non_snake_case)]",
         "#![allow(clippy::approx_constant, clippy::type_complexity, clippy::unreadable_literal)]",
-        "#![cfg_attr(feature = \"dox\", feature(doc_cfg))]",
+        "#![cfg_attr(all(not(doctest), doc), feature(doc_cfg))]",
         "",
     ];
 


### PR DESCRIPTION
When rustdoc is running, it provides alongside `cfg(doc)`, which is all we need, making the `dox` feature unnecessary.

I need to check on gtk-rs first if I didn't forget it there so please wait before merging!