### PR TITLE
codegen: Explicitly use glib::Value instead of importing

### DIFF
--- a/src/analysis/child_properties.rs
+++ b/src/analysis/child_properties.rs
@@ -81,7 +81,6 @@ fn analyze_property(
         let prop_name = nameutil::signal_to_snake(&*prop.name);
         let doc_hidden = prop.doc_hidden;
 
-        imports.add("glib::Value");
         imports.add("glib::StaticType");
         if let Ok(s) = used_rust_type(env, typ, false) {
             imports.add_used_type(&s);

--- a/src/analysis/properties.rs
+++ b/src/analysis/properties.rs
@@ -181,7 +181,6 @@ fn analyze_property(
             imports.add_used_type(s);
         }
         if type_string.is_ok() {
-            imports.add("glib::Value");
             imports.add("glib::StaticType");
         }
 
@@ -208,17 +207,14 @@ fn analyze_property(
             imports.add_used_type(s);
         }
         let set_bound = PropertyBound::get(env, prop.typ);
-        if type_string.is_ok() {
-            imports.add("glib::Value");
-            if set_bound.is_some() {
-                imports.add("glib::object::IsA");
-                if !*nullable {
-                    //TODO: support nonnulable setter if found any
-                    warn!(
-                        "Non nulable setter for property generated as nullable \"{}.{}\"",
-                        type_name, name
-                    );
-                }
+        if type_string.is_ok() && set_bound.is_some() {
+            imports.add("glib::object::IsA");
+            if !*nullable {
+                //TODO: support non-nullable setter if found any
+                warn!(
+                    "Non nullable setter for property generated as nullable \"{}.{}\"",
+                    type_name, name
+                );
             }
         }
 

--- a/src/codegen/enums.rs
+++ b/src/codegen/enums.rs
@@ -61,7 +61,6 @@ pub fn generate(env: &Env, root_path: &Path, mod_rs: &mut Vec<String>) {
     if has_get_type {
         imports.add("glib::Type");
         imports.add("glib::StaticType");
-        imports.add("glib::value::Value");
         imports.add("glib::value::SetValue");
         imports.add("glib::value::FromValue");
         imports.add("glib::value::FromValueOptional");
@@ -354,11 +353,12 @@ impl FromGlib<{sys_crate_name}::{ffi_name}> for {name} {{
         writeln!(
             w,
             "impl<'a> FromValueOptional<'a> for {name} {{
-    unsafe fn from_value_optional(value: &Value) -> Option<Self> {{
+    unsafe fn from_value_optional(value: &{gvalue}) -> Option<Self> {{
         Some(FromValue::from_value(value))
     }}
 }}",
             name = enum_.name,
+            gvalue = use_glib_type(env, "Value"),
         )?;
         writeln!(w)?;
 
@@ -366,12 +366,13 @@ impl FromGlib<{sys_crate_name}::{ffi_name}> for {name} {{
         writeln!(
             w,
             "impl<'a> FromValue<'a> for {name} {{
-    unsafe fn from_value(value: &Value) -> Self {{
+    unsafe fn from_value(value: &{gvalue}) -> Self {{
         from_glib({glib}(value.to_glib_none().0))
     }}
 }}",
             name = enum_.name,
             glib = use_glib_type(env, "gobject_ffi::g_value_get_enum"),
+            gvalue = use_glib_type(env, "Value"),
         )?;
         writeln!(w)?;
 
@@ -379,12 +380,13 @@ impl FromGlib<{sys_crate_name}::{ffi_name}> for {name} {{
         writeln!(
             w,
             "impl SetValue for {name} {{
-    unsafe fn set_value(value: &mut Value, this: &Self) {{
+    unsafe fn set_value(value: &mut {gvalue}, this: &Self) {{
         {glib}(value.to_glib_none_mut().0, this.to_glib())
     }}
 }}",
             name = enum_.name,
             glib = use_glib_type(env, "gobject_ffi::g_value_set_enum"),
+            gvalue = use_glib_type(env, "Value"),
         )?;
         writeln!(w)?;
     }

--- a/src/codegen/flags.rs
+++ b/src/codegen/flags.rs
@@ -44,7 +44,6 @@ pub fn generate(env: &Env, root_path: &Path, mod_rs: &mut Vec<String>) {
                 if flags.glib_get_type.is_some() {
                     imports.add("glib::Type");
                     imports.add("glib::StaticType");
-                    imports.add("glib::value::Value");
                     imports.add("glib::value::SetValue");
                     imports.add("glib::value::FromValue");
                     imports.add("glib::value::FromValueOptional");
@@ -178,11 +177,12 @@ impl FromGlib<{sys_crate_name}::{ffi_name}> for {name} {{
         writeln!(
             w,
             "impl<'a> FromValueOptional<'a> for {name} {{
-    unsafe fn from_value_optional(value: &Value) -> Option<Self> {{
+    unsafe fn from_value_optional(value: &{gvalue}) -> Option<Self> {{
         Some(FromValue::from_value(value))
     }}
 }}",
             name = flags.name,
+            gvalue = use_glib_type(env, "Value"),
         )?;
         writeln!(w)?;
 
@@ -190,12 +190,13 @@ impl FromGlib<{sys_crate_name}::{ffi_name}> for {name} {{
         writeln!(
             w,
             "impl<'a> FromValue<'a> for {name} {{
-    unsafe fn from_value(value: &Value) -> Self {{
+    unsafe fn from_value(value: &{gvalue}) -> Self {{
         from_glib({glib}(value.to_glib_none().0))
     }}
 }}",
             name = flags.name,
             glib = use_glib_type(env, "gobject_ffi::g_value_get_flags"),
+            gvalue = use_glib_type(env, "Value"),
         )?;
         writeln!(w)?;
 
@@ -203,12 +204,13 @@ impl FromGlib<{sys_crate_name}::{ffi_name}> for {name} {{
         writeln!(
             w,
             "impl SetValue for {name} {{
-    unsafe fn set_value(value: &mut Value, this: &Self) {{
+    unsafe fn set_value(value: &mut {gvalue}, this: &Self) {{
         {glib}(value.to_glib_none_mut().0, this.to_glib())
     }}
 }}",
             name = flags.name,
             glib = use_glib_type(env, "gobject_ffi::g_value_set_flags"),
+            gvalue = use_glib_type(env, "Value"),
         )?;
 
         writeln!(w)?;

--- a/src/codegen/property_body.rs
+++ b/src/codegen/property_body.rs
@@ -138,7 +138,7 @@ impl<'a> Builder<'a> {
             name: "value".into(),
             is_mut: true,
             value: Box::new(Chunk::Custom(format!(
-                "Value::from_type(<{} as StaticType>::static_type())",
+                "glib::Value::from_type(<{} as StaticType>::static_type())",
                 self.type_
             ))),
             type_: None,
@@ -206,7 +206,7 @@ impl<'a> Builder<'a> {
         )));
         let ref_str = if self.is_ref { "" } else { "&" };
         params.push(Chunk::Custom(format!(
-            "Value::from({}{}).to_glib_none().0",
+            "glib::Value::from({}{}).to_glib_none().0",
             ref_str, self.var_name
         )));
 


### PR DESCRIPTION
Fixes an issue where glib::Value could conflict with other
things named "Value"