### PR TITLE
Use write_str instead of write_fmt when no formatting is needed

### DIFF
--- a/src/codegen/object.rs
+++ b/src/codegen/object.rs
@@ -138,7 +138,7 @@ pub fn generate(
         writeln!(
             w,
             "\tfn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {{\n\
-             \t\twrite!(f, \"{}\")\n\
+             \t\tf.write_str(\"{}\")\n\
              \t}}\n\
              }}",
             analysis.name

--- a/src/codegen/trait_impls.rs
+++ b/src/codegen/trait_impls.rs
@@ -80,11 +80,12 @@ fn generate_display(
     let call = generate_call(&func.name, &[], trait_name);
     let body = if let Mode::Throws(_) = func.outs.mode {
         format!(
-            "if let Ok(val) = {} {{
-            write!(f, \"{{}}\", val)
-        }} else {{
-            Err(fmt::Error)
-        }}",
+            "\
+            if let Ok(val) = {} {{
+                f.write_str(val)
+            }} else {{
+                Err(fmt::Error)
+            }}",
             call
         )
     } else {

--- a/src/config/ident.rs
+++ b/src/config/ident.rs
@@ -12,10 +12,10 @@ pub enum Ident {
 
 impl fmt::Display for Ident {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match *self {
-            Ident::Name(ref name) => write!(f, "{}", name),
+        match self {
+            Ident::Name(name) => f.write_str(name),
             // TODO: maybe store the regex string to display it here?
-            Ident::Pattern(_) => write!(f, "Regex"),
+            Ident::Pattern(_) => f.write_str("Regex"),
         }
     }
 }

--- a/src/library.rs
+++ b/src/library.rs
@@ -600,29 +600,25 @@ pub enum Type {
 
 impl fmt::Display for Type {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{}",
-            match *self {
-                Type::Fundamental(_) => "Fundamental",
-                Type::Alias(_) => "Alias",
-                Type::Enumeration(_) => "Enumeration",
-                Type::Bitfield(_) => "Bitfield",
-                Type::Record(_) => "Record",
-                Type::Union(_) => "Union",
-                Type::Function(_) => "Function",
-                Type::Interface(_) => "Interface",
-                Type::Class(_) => "Class",
-                Type::Custom(_) => "Custom",
-                Type::Array(_) => "Array",
-                Type::CArray(_) => "CArray",
-                Type::FixedArray(_, _, _) => "FixedArray",
-                Type::PtrArray(_) => "PtrArray",
-                Type::HashTable(_, _) => "HashTable",
-                Type::List(_) => "List",
-                Type::SList(_) => "SList",
-            }
-        )
+        f.write_str(match self {
+            Type::Fundamental(_) => "Fundamental",
+            Type::Alias(_) => "Alias",
+            Type::Enumeration(_) => "Enumeration",
+            Type::Bitfield(_) => "Bitfield",
+            Type::Record(_) => "Record",
+            Type::Union(_) => "Union",
+            Type::Function(_) => "Function",
+            Type::Interface(_) => "Interface",
+            Type::Class(_) => "Class",
+            Type::Custom(_) => "Custom",
+            Type::Array(_) => "Array",
+            Type::CArray(_) => "CArray",
+            Type::FixedArray(_, _, _) => "FixedArray",
+            Type::PtrArray(_) => "PtrArray",
+            Type::HashTable(_, _) => "HashTable",
+            Type::List(_) => "List",
+            Type::SList(_) => "SList",
+        })
     }
 }
 


### PR DESCRIPTION
`write_fmt` (what `write!` expands to) needs to be set up with an `std::fmt::Arguments` object that is consequently iterated.  All segments of the format string get `Display::fmt` called on them and those implementations usually result in calling some form of `write_str` (at least for `&str`).

This is a minor change that only saves few unnecessary cyles and is mostly done for cosmetic reasons.  It finishes the work started in 3eaed54.

---

This follows a discussion in https://github.com/gtk-rs/gtk-rs/pull/155. The change results in hundreds of file changes in gtk-rs which is a lot of noise to bear. The new format of `f.write_str("Some string literal")` is nicer to read though, and we're already making massive changes with the docs anyhow.
