### PR TITLE
cargo_toml: Do not overwrite library name for unversioned system-deps

### DIFF
--- a/src/codegen/sys/cargo_toml.rs
+++ b/src/codegen/sys/cargo_toml.rs
@@ -117,7 +117,8 @@ fn fill_in(root: &mut Table, env: &Env) {
         let lib_name = ns.package_name.as_ref().unwrap();
 
         let meta = upsert_table(meta, nameutil::lib_name_to_toml(lib_name));
-        set_string(meta, "name", lib_name);
+        meta.get_mut("name")
+            .get_or_insert(&mut Value::String(lib_name.to_owned()));
         set_string(meta, "version", env.config.min_cfg_version.to_string());
 
         // Old version API


### PR DESCRIPTION
See: https://gitlab.freedesktop.org/gstreamer/gstreamer-rs/-/merge_requests/565#note_709394

In the case of GL EGL/Wayland/X11 we use gstreamer-gl-1.0 for every version except from 1.18 onwards, where these are renamed to `gstreamer-gl-{egl,wayland,x11}-1.0`.
This requires us to manually change the name of the "unversioned" system dep in Cargo.toml, without the generator overwriting it afterwards.

---

Let me know if this should be a separate helper function next to `set_string` instead.
