### PR TITLE
Use `cargo:warning` instead of `eprintln!` for printing warnings

### DIFF
--- a/src/codegen/sys/build.rs
+++ b/src/codegen/sys/build.rs
@@ -56,7 +56,7 @@ fn main() {} // prevent linking libraries to avoid documentation failure
 #[cfg(not(feature = "dox"))]
 fn main() {
     if let Err(s) = system_deps::Config::new().probe() {
-        let _ = eprintln!("{}", s);
+        println!("cargo:warning={}", s);
         process::exit(1);
     }
 }


### PR DESCRIPTION
The latter just disappears instead of being printed.

Fixes https://github.com/gtk-rs/gir/issues/1016