### PR TITLE
Add an error in case a name field has content of the pattern field

### DIFF
--- a/src/config/functions.rs
+++ b/src/config/functions.rs
@@ -565,12 +565,13 @@ pattern = 'func\d+'
 "#,
         );
         let fns = Functions::parse(Some(&toml), "a");
-        assert_eq!(fns.len(), 4);
+        assert_eq!(fns.len(), 3);
 
         assert_eq!(fns.matched("func1").len(), 2);
         assert_eq!(fns.matched("func2").len(), 2);
         assert_eq!(fns.matched("func3").len(), 1);
-        assert_eq!(fns.matched("f1.5").len(), 1);
+        // "f1.5" is not a valid name
+        assert_eq!(fns.matched("f1.5").len(), 0);
         assert_eq!(fns.matched("none").len(), 0);
     }
 

--- a/src/config/ident.rs
+++ b/src/config/ident.rs
@@ -46,10 +46,20 @@ impl Ident {
                     e
                 })
                 .ok(),
-            None => toml
-                .lookup("name")
-                .and_then(Value::as_str)
-                .map(|s| Ident::Name(s.into())),
+            None => match toml.lookup("name").and_then(Value::as_str) {
+                Some(name) => {
+                    if name.contains(['.', '+', '*'].as_ref()) {
+                        error!(
+                            "Should be `pattern` instead of `name` in {} for `{}`",
+                            what, object_name
+                        );
+                        None
+                    } else {
+                        Some(Ident::Name(name.into()))
+                    }
+                }
+                None => None,
+            },
         }
     }
 

--- a/src/config/properties.rs
+++ b/src/config/properties.rs
@@ -184,12 +184,13 @@ pattern = 'prop\d+'
 "#,
         );
         let props = Properties::parse(Some(&toml), "a");
-        assert_eq!(props.len(), 4);
+        assert_eq!(props.len(), 3);
 
         assert_eq!(props.matched("prop1").len(), 2);
         assert_eq!(props.matched("prop2").len(), 2);
         assert_eq!(props.matched("prop3").len(), 1);
-        assert_eq!(props.matched("p1.5").len(), 1);
+        // "p1.5" is an invalid name
+        assert_eq!(props.matched("p1.5").len(), 0);
         assert_eq!(props.matched("none").len(), 0);
     }
 }


### PR DESCRIPTION
It's a common issue when edition the gir files so instead of silently fail, it now displays an error.

cc @sdroege 