### PR TITLE
Do not generate functions ending with _finish_utf8

### DIFF
--- a/src/analysis/functions.rs
+++ b/src/analysis/functions.rs
@@ -104,7 +104,7 @@ impl Info {
             .rust_parameters
             .iter()
             .any(|param| param.typ.full_name(&env.library) == "Gio.AsyncResult");
-        self.name.ends_with("_finish") && has_async_result
+        (self.name.ends_with("_finish") || self.name.ends_with("_finish_utf8")) && has_async_result
     }
 }
 


### PR DESCRIPTION
Such a function is present in
https://lazka.github.io/pgi-docs/Gio-2.0/classes/DataInputStream.html.
Another option would be to explicitly add an exception for this function
in the Gir.toml of gtk-rs/gio.