### PR TITLE
Remove use_boxed_functions override

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -49,7 +49,9 @@ jobs:
           path: target
           key: checks-${{ runner.os }}-cargo-target-dir-${{ steps.toolchain.outputs.rustc_hash }}
       - name: Install packages from apt
-        run: sudo apt install libgtk-3-dev libssh2-1-dev libglib2.0-dev libgraphene-1.0-dev libcairo-gobject2 libcairo2-dev
+        run: |
+          sudo apt update
+          sudo apt install libgtk-3-dev libssh2-1-dev libglib2.0-dev libgraphene-1.0-dev libcairo-gobject2 libcairo2-dev
         if: matrix.os == 'ubuntu-20.04'
       - name: "Run clippy"
         uses: actions-rs/cargo@v1
@@ -121,7 +123,9 @@ jobs:
           path: target
           key: build-${{ runner.os }}-cargo-target-dir-${{ steps.toolchain.outputs.rustc_hash }}
       - name: Install packages from apt
-        run: sudo apt install libgtk-3-dev libssh2-1-dev libglib2.0-dev libgraphene-1.0-dev libcairo-gobject2 libcairo2-dev
+        run: |
+          sudo apt update
+          sudo apt install libgtk-3-dev libssh2-1-dev libglib2.0-dev libgraphene-1.0-dev libcairo-gobject2 libcairo2-dev
         if: matrix.os == 'ubuntu-20.04'
       - name: Install toolchain packages with pacman
         run: pacman --noconfirm -S base-devel mingw-w64-${{ matrix.arch }}-toolchain

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,9 +85,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55e2e4c765aa53a0424761bf9f41aa7a6ac1efa87238f59560640e27fca028f2"
+checksum = "4fb1fa934250de4de8aef298d81c729a7d33d8c239daa3a7575e6b92bfc7313b"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -131,9 +131,9 @@ checksum = "13bd41f508810a131401606d54ac32a467c97172d74ba7662562ebba5ad07fa0"
 
 [[package]]
 name = "regex"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38cf2c13ed4745de91a5eb834e11c00bcc3709e773173b2ce4c56c9fbde04b9c"
+checksum = "d9251239e129e16308e70d853559389de218ac275b515068abc96829d05b948a"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -143,9 +143,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.21"
+version = "0.6.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b181ba2dcf07aaccad5448e8ead58db5b742cf85dfe035e2227f137a539a189"
+checksum = "b5eb417147ba9860a96cfe72a0b93bf88fee1744b5636ec99ab20c1aa9376581"
 
 [[package]]
 name = "rustdoc-stripper"
@@ -160,18 +160,18 @@ checksum = "06c64263859d87aa2eb554587e2d23183398d617427327cf2b3d0ed8c69e4800"
 
 [[package]]
 name = "thread_local"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
+checksum = "bb9bc092d0d51e76b2b19d9d85534ffc9ec2db959a2523cdae0697e2972cd447"
 dependencies = [
  "lazy_static",
 ]
 
 [[package]]
 name = "toml"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75cf45bb0bef80604d001caaec0d09da99611b3c0fd39d3080468875cdb65645"
+checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
 dependencies = [
  "indexmap",
  "serde",

--- a/README.md
+++ b/README.md
@@ -355,18 +355,10 @@ status = "generate"
     cfg_condition = "feature = \"ser_de\""
 ```
 
-Gir auto-detects copy and free functions by looking up `type_name_copy` and `type_name_free` functions.
-If the relevant functions are not named that way, and the type is defined with `G_DEFINE_BOXED_TYPE`,
-`use_boxed_functions=true` can be used to call `g_boxed_copy` and `g_boxed_free` instead.
-
-```toml
-[[object]]
-name = "GstSdp.SDPMessage"
-status = "generate"
-# generates `copy` and `free` function by `g_boxed_copy` and `g_boxed_free`
-# only works if record has `glib:get-type` defined
-use_boxed_functions = true
-```
+Gir auto-detects `copy`/`free` or `ref`/`unref` function pairs for memory management
+on records. It falls back to generic `g_boxed_copy`/`g_boxed_free` if these are not
+found, based on an existing implementation of `get_type`. Otherwise no record
+implementation can be generated.
 
 Some boxed types are passed as `out` parameters to functions and the caller is
 required to allocate them. For this it is necessary to provide Rust

--- a/src/analysis/record.rs
+++ b/src/analysis/record.rs
@@ -77,7 +77,7 @@ pub fn new(env: &Env, obj: &GObject) -> Option<Info> {
 
     let record: &library::Record = type_.maybe_ref()?;
 
-    let is_boxed = obj.use_boxed_functions || RecordType::of(&record) == RecordType::AutoBoxed;
+    let is_boxed = RecordType::of(&record) == RecordType::AutoBoxed;
 
     let mut imports = Imports::with_defined(&env.library, &name);
 
@@ -159,10 +159,9 @@ pub fn new(env: &Env, obj: &GObject) -> Option<Info> {
 
     // Check if we have to make use of the GType and the generic
     // boxed functions.
-    if obj.use_boxed_functions
-        || !is_shared
-            && (!specials.has_trait(special_functions::Type::Copy)
-                || !specials.has_trait(special_functions::Type::Free))
+    if !is_shared
+        && (!specials.has_trait(special_functions::Type::Copy)
+            || !specials.has_trait(special_functions::Type::Free))
     {
         if let Some((_, get_type_version)) = glib_get_type {
             if get_type_version > version {

--- a/src/analysis/record.rs
+++ b/src/analysis/record.rs
@@ -17,7 +17,7 @@ use std::ops::Deref;
 pub struct Info {
     pub base: InfoBase,
     pub glib_get_type: Option<(String, Option<Version>)>,
-    pub use_boxed_functions: bool,
+    pub is_boxed: bool,
     pub derives: Derives,
     pub init_function_expression: Option<String>,
     pub clear_function_expression: Option<String>,
@@ -202,7 +202,7 @@ pub fn new(env: &Env, obj: &GObject) -> Option<Info> {
         base,
         glib_get_type,
         derives,
-        use_boxed_functions: obj.use_boxed_functions,
+        is_boxed,
         init_function_expression: obj.init_function_expression.clone(),
         clear_function_expression: obj.clear_function_expression.clone(),
     };

--- a/src/codegen/record.rs
+++ b/src/codegen/record.rs
@@ -12,7 +12,7 @@ pub fn generate(w: &mut dyn Write, env: &Env, analysis: &analysis::record::Info)
     general::start_comments(w, &env.config)?;
     general::uses(w, env, &analysis.imports)?;
 
-    if analysis.use_boxed_functions {
+    if analysis.is_boxed {
         if let Some((ref glib_get_type, _)) = analysis.glib_get_type {
             general::define_auto_boxed_type(
                 w,
@@ -70,17 +70,6 @@ pub fn generate(w: &mut dyn Write, env: &Env, analysis: &analysis::record::Info)
                     (f.clone(), None)
                 }
             }),
-            &analysis.derives,
-        )?;
-    } else if let Some((ref glib_get_type, _)) = analysis.glib_get_type {
-        general::define_auto_boxed_type(
-            w,
-            env,
-            &analysis.name,
-            &type_.c_type,
-            &analysis.init_function_expression,
-            &analysis.clear_function_expression,
-            glib_get_type,
             &analysis.derives,
         )?;
     } else {

--- a/src/config/gobjects.rs
+++ b/src/config/gobjects.rs
@@ -79,7 +79,6 @@ pub struct GObject {
     pub ref_mode: Option<ref_mode::RefMode>,
     pub must_use: bool,
     pub conversion_type: Option<conversion_type::ConversionType>,
-    pub use_boxed_functions: bool,
     pub generate_display_trait: bool,
     pub trust_return_value_nullability: bool,
     pub manual_traits: Vec<String>,
@@ -113,7 +112,6 @@ impl Default for GObject {
             ref_mode: None,
             must_use: false,
             conversion_type: None,
-            use_boxed_functions: false,
             generate_display_trait: true,
             trust_return_value_nullability: false,
             manual_traits: Vec::default(),
@@ -211,7 +209,6 @@ fn parse_object(
             "trait_name",
             "cfg_condition",
             "must_use",
-            "use_boxed_functions",
             "generate_display_trait",
             "trust_return_value_nullability",
             "manual_traits",
@@ -290,10 +287,6 @@ fn parse_object(
     let child_properties = ChildProperties::parse(toml_object, &name);
     let must_use = toml_object
         .lookup("must_use")
-        .and_then(Value::as_bool)
-        .unwrap_or(false);
-    let use_boxed_functions = toml_object
-        .lookup("use_boxed_functions")
         .and_then(Value::as_bool)
         .unwrap_or(false);
     let generate_display_trait = toml_object
@@ -393,7 +386,6 @@ fn parse_object(
         ref_mode,
         must_use,
         conversion_type,
-        use_boxed_functions,
         generate_display_trait,
         trust_return_value_nullability,
         manual_traits,

--- a/src/config/ident.rs
+++ b/src/config/ident.rs
@@ -7,15 +7,14 @@ use toml::Value;
 #[derive(Clone, Debug)]
 pub enum Ident {
     Name(String),
-    Pattern(Regex),
+    Pattern(Box<Regex>),
 }
 
 impl fmt::Display for Ident {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Ident::Name(name) => f.write_str(name),
-            // TODO: maybe store the regex string to display it here?
-            Ident::Pattern(_) => f.write_str("Regex"),
+            Ident::Pattern(regex) => write!(f, "Regex {}", regex),
         }
     }
 }
@@ -37,6 +36,7 @@ impl Ident {
     pub fn parse(toml: &Value, object_name: &str, what: &str) -> Option<Ident> {
         match toml.lookup("pattern").and_then(Value::as_str) {
             Some(s) => Regex::new(&format!("^{}$", s))
+                .map(Box::new)
                 .map(Ident::Pattern)
                 .map_err(|e| {
                     error!(


### PR DESCRIPTION
This override only works when `get_type` is available and is intended when copy and free are not available, to call the generic `g_boxed_copy/free` functions (which under the hood resolve the right `copy/free` function from its `GType`, as retrieved with get_type).

However, this behaviour is already implied if `copy/free` nor `(un)ref` are found. Hence it is only useful to forcibly use generic `g_boxed_copy/free` even if type-specific functions are directly available in G-IR and Rust. That can almost never be the right thing.

The functionality isn't used for nearly 3 years, and wasn't even used for all that long in gstreamer-rs; it was introduced [here][1] and removed a mere [15 days after][2].

[1]: https://gitlab.freedesktop.org/gstreamer/gstreamer-rs/-/commit/3a0c9723044fb3c9063fcef60e0270171576ba92
[2]: https://gitlab.freedesktop.org/gstreamer/gstreamer-rs/-/commit/92016945fc7882979664bbea6e36a5585a2fea1d