### PR TITLE
function: Teach gir how to generate whole functions as unsafe

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -49,7 +49,9 @@ jobs:
           path: target
           key: checks-${{ runner.os }}-cargo-target-dir-${{ steps.toolchain.outputs.rustc_hash }}
       - name: Install packages from apt
-        run: sudo apt install libgtk-3-dev libssh2-1-dev libglib2.0-dev libgraphene-1.0-dev libcairo-gobject2 libcairo2-dev
+        run: |
+          sudo apt update
+          sudo apt install libgtk-3-dev libssh2-1-dev libglib2.0-dev libgraphene-1.0-dev libcairo-gobject2 libcairo2-dev
         if: matrix.os == 'ubuntu-20.04'
       - name: "Run clippy"
         uses: actions-rs/cargo@v1
@@ -121,7 +123,9 @@ jobs:
           path: target
           key: build-${{ runner.os }}-cargo-target-dir-${{ steps.toolchain.outputs.rustc_hash }}
       - name: Install packages from apt
-        run: sudo apt install libgtk-3-dev libssh2-1-dev libglib2.0-dev libgraphene-1.0-dev libcairo-gobject2 libcairo2-dev
+        run: |
+          sudo apt update
+          sudo apt install libgtk-3-dev libssh2-1-dev libglib2.0-dev libgraphene-1.0-dev libcairo-gobject2 libcairo2-dev
         if: matrix.os == 'ubuntu-20.04'
       - name: Install toolchain packages with pacman
         run: pacman --noconfirm -S base-devel mingw-w64-${{ matrix.arch }}-toolchain

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,9 +85,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55e2e4c765aa53a0424761bf9f41aa7a6ac1efa87238f59560640e27fca028f2"
+checksum = "4fb1fa934250de4de8aef298d81c729a7d33d8c239daa3a7575e6b92bfc7313b"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -131,9 +131,9 @@ checksum = "13bd41f508810a131401606d54ac32a467c97172d74ba7662562ebba5ad07fa0"
 
 [[package]]
 name = "regex"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38cf2c13ed4745de91a5eb834e11c00bcc3709e773173b2ce4c56c9fbde04b9c"
+checksum = "d9251239e129e16308e70d853559389de218ac275b515068abc96829d05b948a"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -143,9 +143,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.21"
+version = "0.6.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b181ba2dcf07aaccad5448e8ead58db5b742cf85dfe035e2227f137a539a189"
+checksum = "b5eb417147ba9860a96cfe72a0b93bf88fee1744b5636ec99ab20c1aa9376581"
 
 [[package]]
 name = "rustdoc-stripper"
@@ -160,18 +160,18 @@ checksum = "06c64263859d87aa2eb554587e2d23183398d617427327cf2b3d0ed8c69e4800"
 
 [[package]]
 name = "thread_local"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
+checksum = "bb9bc092d0d51e76b2b19d9d85534ffc9ec2db959a2523cdae0697e2972cd447"
 dependencies = [
  "lazy_static",
 ]
 
 [[package]]
 name = "toml"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75cf45bb0bef80604d001caaec0d09da99611b3c0fd39d3080468875cdb65645"
+checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
 dependencies = [
  "indexmap",
  "serde",

--- a/README.md
+++ b/README.md
@@ -259,6 +259,8 @@ trust_return_value_nullability = false
         length_of = "str"
         # change string type. Variants: "utf8", "filename", "os_string"
         string_type = "os_string"
+        # make function unsafe to call (emits `fn unsafe`)
+        unsafe = true
 
         # override for return value
         [object.function.return]

--- a/src/analysis/functions.rs
+++ b/src/analysis/functions.rs
@@ -86,6 +86,7 @@ pub struct Info {
     pub assertion: SafetyAssertionMode,
     pub doc_hidden: bool,
     pub r#async: bool,
+    pub unsafe_: bool,
     pub trampoline: Option<AsyncTrampoline>,
     pub callbacks: Vec<Trampoline>,
     pub destroys: Vec<Trampoline>,
@@ -556,6 +557,7 @@ fn analyze_function(
     let doc_hidden = configured_functions.iter().any(|f| f.doc_hidden);
     let disable_length_detect = configured_functions.iter().any(|f| f.disable_length_detect);
     let no_future = configured_functions.iter().any(|f| f.no_future);
+    let unsafe_ = configured_functions.iter().any(|f| f.unsafe_);
     let assertion = configured_functions
         .iter()
         .filter_map(|f| f.assertion)
@@ -803,6 +805,7 @@ fn analyze_function(
         assertion,
         doc_hidden,
         r#async,
+        unsafe_,
         trampoline,
         async_future,
         callbacks,

--- a/src/codegen/function.rs
+++ b/src/codegen/function.rs
@@ -72,6 +72,7 @@ pub fn generate(
         }
         Visibility::Hidden => return Ok(()),
     }
+    let unsafe_ = if analysis.unsafe_ { "unsafe " } else { "" };
     let declaration = declaration(env, analysis);
     let suffix = if only_declaration { ";" } else { " {" };
 
@@ -88,10 +89,11 @@ pub fn generate(
     }
     writeln!(
         w,
-        "{}{}{}{}{}",
+        "{}{}{}{}{}{}",
         tabs(indent),
         comment_prefix,
         pub_prefix,
+        unsafe_,
         declaration,
         suffix,
     )?;
@@ -324,6 +326,7 @@ pub fn body_chunk(env: &Env, analysis: &analysis::functions::Info) -> Chunk {
         .assertion(analysis.assertion)
         .ret(&analysis.ret)
         .transformations(&analysis.parameters.transformations)
+        .in_unsafe(analysis.unsafe_)
         .outs_mode(analysis.outs.mode);
 
     if analysis.r#async {

--- a/src/config/functions.rs
+++ b/src/config/functions.rs
@@ -202,6 +202,7 @@ pub struct Function {
     pub disable_length_detect: bool,
     pub doc_trait_name: Option<String>,
     pub no_future: bool,
+    pub unsafe_: bool,
     pub rename: Option<String>,
     pub assertion: Option<SafetyAssertionMode>,
 }
@@ -233,6 +234,7 @@ impl Parse for Function {
                 "pattern",
                 "doc_trait_name",
                 "no_future",
+                "unsafe",
                 "rename",
                 "assertion",
             ],
@@ -286,6 +288,10 @@ impl Parse for Function {
             .lookup("no_future")
             .and_then(Value::as_bool)
             .unwrap_or(false);
+        let unsafe_ = toml
+            .lookup("unsafe")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
         let rename = toml
             .lookup("rename")
             .and_then(Value::as_str)
@@ -316,6 +322,7 @@ impl Parse for Function {
             disable_length_detect,
             doc_trait_name,
             no_future,
+            unsafe_,
             rename,
             assertion,
         })

--- a/src/config/ident.rs
+++ b/src/config/ident.rs
@@ -7,15 +7,14 @@ use toml::Value;
 #[derive(Clone, Debug)]
 pub enum Ident {
     Name(String),
-    Pattern(Regex),
+    Pattern(Box<Regex>),
 }
 
 impl fmt::Display for Ident {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Ident::Name(name) => f.write_str(name),
-            // TODO: maybe store the regex string to display it here?
-            Ident::Pattern(_) => f.write_str("Regex"),
+            Ident::Pattern(regex) => write!(f, "Regex {}", regex),
         }
     }
 }
@@ -37,6 +36,7 @@ impl Ident {
     pub fn parse(toml: &Value, object_name: &str, what: &str) -> Option<Ident> {
         match toml.lookup("pattern").and_then(Value::as_str) {
             Some(s) => Regex::new(&format!("^{}$", s))
+                .map(Box::new)
                 .map(Ident::Pattern)
                 .map_err(|e| {
                     error!(


### PR DESCRIPTION
While implementing `GLFilter` bindings review suggested to mark a few new functions as `unsafe`.  It saddened me to have to copy these functions to "manual" files and repeatedly update/maintain them as the main repo and `GLFilter` MR progressed: notable are the addition of `doc(alias)` and mutability changes.  Not to mention changes to versioning `cfg()` blocks that those functions were luckily not affected by.