### PR TITLE
CI: Run apt update before apt install

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -49,7 +49,9 @@ jobs:
           path: target
           key: checks-${{ runner.os }}-cargo-target-dir-${{ steps.toolchain.outputs.rustc_hash }}
       - name: Install packages from apt
-        run: sudo apt install libgtk-3-dev libssh2-1-dev libglib2.0-dev libgraphene-1.0-dev libcairo-gobject2 libcairo2-dev
+        run: |
+          sudo apt update
+          sudo apt install libgtk-3-dev libssh2-1-dev libglib2.0-dev libgraphene-1.0-dev libcairo-gobject2 libcairo2-dev
         if: matrix.os == 'ubuntu-20.04'
       - name: "Run clippy"
         uses: actions-rs/cargo@v1
@@ -121,7 +123,9 @@ jobs:
           path: target
           key: build-${{ runner.os }}-cargo-target-dir-${{ steps.toolchain.outputs.rustc_hash }}
       - name: Install packages from apt
-        run: sudo apt install libgtk-3-dev libssh2-1-dev libglib2.0-dev libgraphene-1.0-dev libcairo-gobject2 libcairo2-dev
+        run: |
+          sudo apt update
+          sudo apt install libgtk-3-dev libssh2-1-dev libglib2.0-dev libgraphene-1.0-dev libcairo-gobject2 libcairo2-dev
         if: matrix.os == 'ubuntu-20.04'
       - name: Install toolchain packages with pacman
         run: pacman --noconfirm -S base-devel mingw-w64-${{ matrix.arch }}-toolchain

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,9 +85,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55e2e4c765aa53a0424761bf9f41aa7a6ac1efa87238f59560640e27fca028f2"
+checksum = "4fb1fa934250de4de8aef298d81c729a7d33d8c239daa3a7575e6b92bfc7313b"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -131,9 +131,9 @@ checksum = "13bd41f508810a131401606d54ac32a467c97172d74ba7662562ebba5ad07fa0"
 
 [[package]]
 name = "regex"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38cf2c13ed4745de91a5eb834e11c00bcc3709e773173b2ce4c56c9fbde04b9c"
+checksum = "d9251239e129e16308e70d853559389de218ac275b515068abc96829d05b948a"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -143,9 +143,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.21"
+version = "0.6.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b181ba2dcf07aaccad5448e8ead58db5b742cf85dfe035e2227f137a539a189"
+checksum = "b5eb417147ba9860a96cfe72a0b93bf88fee1744b5636ec99ab20c1aa9376581"
 
 [[package]]
 name = "rustdoc-stripper"
@@ -160,18 +160,18 @@ checksum = "06c64263859d87aa2eb554587e2d23183398d617427327cf2b3d0ed8c69e4800"
 
 [[package]]
 name = "thread_local"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
+checksum = "bb9bc092d0d51e76b2b19d9d85534ffc9ec2db959a2523cdae0697e2972cd447"
 dependencies = [
  "lazy_static",
 ]
 
 [[package]]
 name = "toml"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75cf45bb0bef80604d001caaec0d09da99611b3c0fd39d3080468875cdb65645"
+checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
 dependencies = [
  "indexmap",
  "serde",

--- a/src/config/ident.rs
+++ b/src/config/ident.rs
@@ -7,15 +7,14 @@ use toml::Value;
 #[derive(Clone, Debug)]
 pub enum Ident {
     Name(String),
-    Pattern(Regex),
+    Pattern(Box<Regex>),
 }
 
 impl fmt::Display for Ident {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Ident::Name(name) => f.write_str(name),
-            // TODO: maybe store the regex string to display it here?
-            Ident::Pattern(_) => f.write_str("Regex"),
+            Ident::Pattern(regex) => write!(f, "Regex {}", regex),
         }
     }
 }
@@ -37,6 +36,7 @@ impl Ident {
     pub fn parse(toml: &Value, object_name: &str, what: &str) -> Option<Ident> {
         match toml.lookup("pattern").and_then(Value::as_str) {
             Some(s) => Regex::new(&format!("^{}$", s))
+                .map(Box::new)
                 .map(Ident::Pattern)
                 .map_err(|e| {
                     error!(


### PR DESCRIPTION
The index contained in GH Actions' virtual environments always lag behind a bit and might point to superseded packages (as is the case with CI failures observed in #1032 and #1033).

Also run `cargo update` and fix a linter warning for `Regex` being too large.

These changes are already included in #1032 and #1033.