### PR TITLE
Add extra_dox_features config setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ version = "3.16"
 dependencies = [
   "glib-sys/v3_16"
 ]
+# Add features to the "dox" feature declaration in `Cargo.toml`. So with the following
+# config, it'll generate:
+# dox = ["whatever"]
+dox_feature_dependencies = ["whatever"]
 ```
 
 You can mark some functions that has suffix `_utf8` on Windows:

--- a/src/codegen/sys/cargo_toml.rs
+++ b/src/codegen/sys/cargo_toml.rs
@@ -105,7 +105,16 @@ fn fill_in(root: &mut Table, env: &Env) {
             features.insert(version.to_feature(), Value::Array(prev_array));
             Some(version)
         });
-        features.insert("dox".to_string(), Value::Array(Vec::new()));
+        features.insert(
+            "dox".to_string(),
+            Value::Array(
+                env.config
+                    .dox_feature_dependencies
+                    .iter()
+                    .map(|s| Value::String(s.clone()))
+                    .collect(),
+            ),
+        );
     }
 
     {

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -45,6 +45,7 @@ pub struct Config {
     pub extra_versions: Vec<Version>,
     pub lib_version_overrides: HashMap<Version, Version>,
     pub feature_dependencies: HashMap<Version, Vec<String>>,
+    pub dox_feature_dependencies: Vec<String>,
 }
 
 impl Config {
@@ -246,6 +247,7 @@ impl Config {
         let extra_versions = read_extra_versions(&toml)?;
         let lib_version_overrides = read_lib_version_overrides(&toml)?;
         let feature_dependencies = read_feature_dependencies(&toml)?;
+        let dox_feature_dependencies = read_dox_feature_dependencies(&toml)?;
 
         Ok(Config {
             work_mode,
@@ -273,6 +275,7 @@ impl Config {
             extra_versions,
             lib_version_overrides,
             feature_dependencies,
+            dox_feature_dependencies,
         })
     }
 
@@ -357,6 +360,24 @@ fn read_extra_versions(toml: &toml::Value) -> Result<Vec<Version>, String> {
                 })
             })
             .map(|s| s.and_then(str::parse))
+            .collect(),
+        None => Ok(Vec::new()),
+    }
+}
+
+fn read_dox_feature_dependencies(toml: &toml::Value) -> Result<Vec<String>, String> {
+    match toml.lookup("options.dox_feature_dependencies") {
+        Some(a) => a
+            .as_result_vec("options.dox_feature_dependencies")?
+            .iter()
+            .map(|v| {
+                v.as_str()
+                    .ok_or_else(|| {
+                        "options.dox_feature_dependencies expected to be array of string"
+                            .to_string()
+                    })
+                    .map(str::to_owned)
+            })
             .collect(),
         None => Ok(Vec::new()),
     }


### PR DESCRIPTION
In `gdkx11`, the `cairo` dependency is optional but is still being used with `dox`. We need to be able to generate extra `dox` features and this feature does it.