### PR TITLE
analysis: Move global imports to object-specific analysis and under versioning constraints

### DIFF
--- a/src/analysis/enums.rs
+++ b/src/analysis/enums.rs
@@ -46,6 +46,7 @@ pub fn new(env: &Env, obj: &GObject, imports: &mut Imports) -> Option<Info> {
     imports.add_defined(&format!("crate::{}", name));
 
     let imports = &mut imports.with_defaults(enumeration.version, &None);
+    imports.add("glib::translate::*");
 
     let has_get_quark = enumeration.error_domain.is_some();
     if has_get_quark {

--- a/src/analysis/enums.rs
+++ b/src/analysis/enums.rs
@@ -45,6 +45,8 @@ pub fn new(env: &Env, obj: &GObject, imports: &mut Imports) -> Option<Info> {
     // Mark the type as available within the enum namespace:
     imports.add_defined(&format!("crate::{}", name));
 
+    let imports = &mut imports.with_defaults(enumeration.version, &None);
+
     let has_get_quark = enumeration.error_domain.is_some();
     if has_get_quark {
         imports.add("glib::Quark");

--- a/src/analysis/flags.rs
+++ b/src/analysis/flags.rs
@@ -45,6 +45,8 @@ pub fn new(env: &Env, obj: &GObject, imports: &mut Imports) -> Option<Info> {
     // Mark the type as available within the bitfield namespace:
     imports.add_defined(&format!("crate::{}", name));
 
+    let imports = &mut imports.with_defaults(flags.version, &None);
+
     let has_get_type = flags.glib_get_type.is_some();
     if has_get_type {
         imports.add("glib::Type");

--- a/src/analysis/flags.rs
+++ b/src/analysis/flags.rs
@@ -46,6 +46,8 @@ pub fn new(env: &Env, obj: &GObject, imports: &mut Imports) -> Option<Info> {
     imports.add_defined(&format!("crate::{}", name));
 
     let imports = &mut imports.with_defaults(flags.version, &None);
+    imports.add("glib::translate::*");
+    imports.add("bitflags::bitflags");
 
     let has_get_type = flags.glib_get_type.is_some();
     if has_get_type {

--- a/src/analysis/functions.rs
+++ b/src/analysis/functions.rs
@@ -32,6 +32,8 @@ use std::{
     collections::{HashMap, HashSet},
 };
 
+use super::special_functions;
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Visibility {
     Public,
@@ -759,22 +761,24 @@ fn analyze_function(
         {
             imports.add("std::boxed::Box as Box_");
         }
-        if !commented {
-            for transformation in &mut parameters.transformations {
-                if let Some(to_glib_extra) = to_glib_extras.get(&transformation.ind_c) {
-                    transformation
-                        .transformation_type
-                        .set_to_glib_extra(to_glib_extra);
-                }
-            }
 
-            imports.add_used_types(&used_types);
-            if ret.base_tid.is_some() {
-                imports.add("glib::object::Cast");
+        for transformation in &mut parameters.transformations {
+            if let Some(to_glib_extra) = to_glib_extras.get(&transformation.ind_c) {
+                transformation
+                    .transformation_type
+                    .set_to_glib_extra(to_glib_extra);
             }
-            imports.add("glib::translate::*");
-            bounds.update_imports(imports);
         }
+
+        imports.add_used_types(&used_types);
+        if ret.base_tid.is_some() {
+            imports.add("glib::object::Cast");
+        }
+
+        if func.name.parse::<special_functions::Type>().is_err() {
+            imports.add("glib::translate::*");
+        }
+        bounds.update_imports(imports);
     }
 
     let visibility = if commented {

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -104,7 +104,6 @@ pub fn run(env: &mut Env) {
 
 fn analyze_enums(env: &mut Env) {
     let mut imports = Imports::new(&env.library);
-    imports.add("glib::translate::*");
 
     for obj in env.config.objects.values() {
         if obj.status.ignored() {
@@ -127,8 +126,6 @@ fn analyze_enums(env: &mut Env) {
 
 fn analyze_flags(env: &mut Env) {
     let mut imports = Imports::new(&env.library);
-    imports.add("glib::translate::*");
-    imports.add("bitflags::bitflags");
 
     for obj in env.config.objects.values() {
         if obj.status.ignored() {

--- a/src/analysis/object.rs
+++ b/src/analysis/object.rs
@@ -61,7 +61,6 @@ pub fn class(env: &Env, obj: &GObject, deps: &[library::TypeId]) -> Option<Info>
     let klass: &library::Class = type_.maybe_ref()?;
 
     let mut imports = Imports::with_defined(&env.library, &name);
-    imports.add("glib::translate::*");
     if obj.generate_display_trait {
         imports.add("std::fmt");
     }
@@ -227,7 +226,6 @@ pub fn interface(env: &Env, obj: &GObject, deps: &[library::TypeId]) -> Option<I
     let iface: &library::Interface = type_.maybe_ref()?;
 
     let mut imports = Imports::with_defined(&env.library, &name);
-    imports.add("glib::translate::*");
     imports.add("glib::object::IsA");
     if obj.generate_display_trait {
         imports.add("std::fmt");

--- a/src/analysis/object.rs
+++ b/src/analysis/object.rs
@@ -18,7 +18,6 @@ pub struct Info {
     pub generate_trait: bool,
     pub trait_name: String,
     pub has_constructors: bool,
-    pub has_methods: bool,
     pub has_functions: bool,
     pub signals: Vec<signals::Info>,
     pub notify_signals: Vec<signals::Info>,
@@ -199,7 +198,6 @@ pub fn class(env: &Env, obj: &GObject, deps: &[library::TypeId]) -> Option<Info>
         generate_trait,
         trait_name,
         has_constructors,
-        has_methods,
         has_functions,
         signals,
         notify_signals,
@@ -290,7 +288,6 @@ pub fn interface(env: &Env, obj: &GObject, deps: &[library::TypeId]) -> Option<I
         concurrency: obj.concurrency,
     };
 
-    let has_methods = !base.methods().is_empty();
     let has_functions = !base.functions().is_empty();
 
     let info = Info {
@@ -303,7 +300,6 @@ pub fn interface(env: &Env, obj: &GObject, deps: &[library::TypeId]) -> Option<I
         final_type: false,
         generate_trait: true,
         trait_name,
-        has_methods,
         has_functions,
         signals,
         notify_signals,

--- a/src/analysis/properties.rs
+++ b/src/analysis/properties.rs
@@ -113,6 +113,7 @@ fn analyze_property(
     let generate = generate.unwrap_or_else(PropertyGenerateFlags::all);
 
     let imports = &mut imports.with_defaults(prop_version, &None);
+    imports.add("glib::translate::*");
 
     let type_string = rust_type(env, prop.typ);
     let name_for_func = nameutil::signal_to_snake(&name);

--- a/src/analysis/signals.rs
+++ b/src/analysis/signals.rs
@@ -72,6 +72,7 @@ fn analyze_signal(
     let doc_hidden = configured_signals.iter().any(|f| f.doc_hidden);
 
     let imports = &mut imports.with_defaults(version, &None);
+    imports.add("glib::translate::*");
 
     let connect_name = format!("connect_{}", nameutil::signal_to_snake(&signal.name));
     let trampoline = trampolines::analyze(

--- a/src/analysis/special_functions.rs
+++ b/src/analysis/special_functions.rs
@@ -252,6 +252,9 @@ pub fn analyze_imports(specials: &Infos, imports: &mut Imports) {
     for (type_, info) in specials.traits() {
         use self::Type::*;
         match *type_ {
+            Copy if info.first_parameter_mut => {
+                imports.add_with_version("glib::translate::*", info.version)
+            }
             Compare => imports.add_with_version("std::cmp", info.version),
             Display => imports.add_with_version("std::fmt", info.version),
             Hash => imports.add_with_version("std::hash", info.version),


### PR DESCRIPTION
While adding some new classes to gstreamer-rs gir keeps emitting `use glib::translate::*;` for classes that do not have any members that could possibly use translation functionality, resulting in obvious "unused import" linter warnings. ~Simply adding this import only if there are members (functions, signals or properties) solves that problem for now.~ All these cases have been addressed by adding `with_defaults` import wrappers, and importing "global" imports under these so that they have the appropriate version constraints. In cases where no members exist (or they are commented out) this code does not even run at all, and the import is completely omitted (the original issue this PR was about).