### PR TITLE
codegen: Omit mut_override from boxed copy if parameter is *const

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,9 +23,9 @@ checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "cfg-if"
-version = "0.1.10"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clock_ticks"
@@ -39,7 +39,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
 dependencies = [
- "log 0.4.11",
+ "log 0.4.14",
 ]
 
 [[package]]
@@ -59,7 +59,7 @@ dependencies = [
  "env_logger",
  "getopts",
  "hprof",
- "log 0.4.11",
+ "log 0.4.14",
  "once_cell",
  "regex",
  "rustdoc-stripper",
@@ -94,25 +94,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazy_static"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-
-[[package]]
 name = "log"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 dependencies = [
- "log 0.4.11",
+ "log 0.4.14",
 ]
 
 [[package]]
 name = "log"
-version = "0.4.11"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
+checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
  "cfg-if",
 ]
@@ -149,22 +143,22 @@ checksum = "b5eb417147ba9860a96cfe72a0b93bf88fee1744b5636ec99ab20c1aa9376581"
 
 [[package]]
 name = "rustdoc-stripper"
-version = "0.1.16"
-source = "git+https://github.com/GuillaumeGomez/rustdoc-stripper#bbdf0a350a85c8d4d1bda779b7eba75bd3de7862"
+version = "0.1.17"
+source = "git+https://github.com/GuillaumeGomez/rustdoc-stripper#9c23f667610ccd5656f188e17dc73c25fef9ced1"
 
 [[package]]
 name = "serde"
-version = "1.0.118"
+version = "1.0.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06c64263859d87aa2eb554587e2d23183398d617427327cf2b3d0ed8c69e4800"
+checksum = "92d5161132722baa40d802cc70b15262b98258453e85e5d1d365c757c73869ae"
 
 [[package]]
 name = "thread_local"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb9bc092d0d51e76b2b19d9d85534ffc9ec2db959a2523cdae0697e2972cd447"
+checksum = "d8208a331e1cb318dd5bd76951d2b8fc48ca38a69f5f4e4af1b6a9f8c6236915"
 dependencies = [
- "lazy_static",
+ "once_cell",
 ]
 
 [[package]]

--- a/src/analysis/special_functions.rs
+++ b/src/analysis/special_functions.rs
@@ -44,6 +44,7 @@ impl FromStr for Type {
 pub struct TraitInfo {
     pub glib_name: String,
     pub version: Option<Version>,
+    pub first_parameter_mut: bool,
 }
 
 type TraitInfos = BTreeMap<Type, TraitInfo>;
@@ -172,6 +173,7 @@ pub fn extract(functions: &mut Vec<FuncInfo>, parent_type: &LibType, obj: &GObje
                     TraitInfo {
                         glib_name: func.glib_name.clone(),
                         version: func.version,
+                        first_parameter_mut: false,
                     },
                 );
             }
@@ -189,11 +191,18 @@ pub fn extract(functions: &mut Vec<FuncInfo>, parent_type: &LibType, obj: &GObje
                 has_free = true;
             }
 
+            let first_parameter_mut = func
+                .parameters
+                .c_parameters
+                .first()
+                .map_or(false, |p| p.ref_mode == super::ref_mode::RefMode::ByRefMut);
+
             specials.traits.insert(
                 type_,
                 TraitInfo {
                     glib_name: func.glib_name.clone(),
                     version: func.version,
+                    first_parameter_mut,
                 },
             );
         }
@@ -209,6 +218,7 @@ pub fn extract(functions: &mut Vec<FuncInfo>, parent_type: &LibType, obj: &GObje
                 TraitInfo {
                     glib_name,
                     version: func.version,
+                    first_parameter_mut: true,
                 },
             );
         }

--- a/src/codegen/record.rs
+++ b/src/codegen/record.rs
@@ -59,7 +59,7 @@ pub fn generate(w: &mut dyn Write, env: &Env, analysis: &analysis::record::Info)
             env,
             &analysis.name,
             &type_.c_type,
-            &copy_fn.glib_name,
+            &copy_fn,
             &free_fn.glib_name,
             &analysis.init_function_expression,
             &analysis.clear_function_expression,


### PR DESCRIPTION
While not harmful at all (clippy doesn't even flinch when writing `as *mut _` where a `*const` is required; not to mention opaque `mut_override` function calls) it is misleading to see `mut_override` in calls like `copy` where this is not required at all.

---

This is a rather quick and gross bit of duct-tape for something that's not really harming anything but readability and manual analysis of autogenerated files; feedback and suggestions welcome!
