### PR TITLE
sys: use system-deps 3.0

### DIFF
--- a/src/codegen/sys/cargo_toml.rs
+++ b/src/codegen/sys/cargo_toml.rs
@@ -83,7 +83,7 @@ fn fill_in(root: &mut Table, env: &Env) {
 
     {
         let build_deps = upsert_table(root, "build-dependencies");
-        set_string(build_deps, "system-deps", "2.0");
+        set_string(build_deps, "system-deps", "3");
     }
 
     {


### PR DESCRIPTION
The return type of the probe() method changed, so this will affect user
code doing manual work in their build.rs, the one we generate does not.

I tried regenerating `gtk-rs` and it build fine.