### PR TITLE
signals: rename emit to emit_by_name

### DIFF
--- a/src/codegen/signal.rs
+++ b/src/codegen/signal.rs
@@ -126,7 +126,7 @@ pub fn generate(
 
             writeln!(
                 w,
-                "{}let {} = unsafe {{ glib::Object::from_glib_borrow(self.as_ptr() as *mut {}).emit(\"{}\", &[{}]).unwrap() }};",
+                "{}let {} = unsafe {{ glib::Object::from_glib_borrow(self.as_ptr() as *mut {}).emit_by_name(\"{}\", &[{}]).unwrap() }};",
                 tabs(indent + 1),
                 if trampoline.ret.typ != Default::default() {
                     "res"


### PR DESCRIPTION
ObjectExt::emit should take a SignalId instead of the signal name
see https://developer.gnome.org/gobject/stable/gobject-Signals.html#g-signal-emit-by-name

Needed for https://github.com/gtk-rs/gtk-rs/pull/302