### PR TITLE
Add support for connecting to signals with details

### DIFF
--- a/src/analysis/properties.rs
+++ b/src/analysis/properties.rs
@@ -270,6 +270,7 @@ fn analyze_property(
                     destroy: None,
                 },
                 is_action: false,
+                is_detailed: false, // well, technically this *is* an instance of a detailed signal, but we "pre-detailed" it
                 version: prop_version,
                 deprecated_version: prop.deprecated_version,
                 doc: None,
@@ -301,6 +302,7 @@ fn analyze_property(
                 version: prop_version,
                 deprecated_version: prop.deprecated_version,
                 doc_hidden: false,
+                is_detailed: false, // see above comment
             })
         } else {
             None

--- a/src/analysis/signals.rs
+++ b/src/analysis/signals.rs
@@ -17,6 +17,7 @@ pub struct Info {
     pub version: Option<Version>,
     pub deprecated_version: Option<Version>,
     pub doc_hidden: bool,
+    pub is_detailed: bool,
 }
 
 pub fn analyze(
@@ -115,6 +116,7 @@ fn analyze_signal(
         version,
         deprecated_version,
         doc_hidden,
+        is_detailed: signal.is_detailed,
     };
 
     info

--- a/src/chunk/chunk.rs
+++ b/src/chunk/chunk.rs
@@ -58,6 +58,7 @@ pub enum Chunk {
         signal: String,
         trampoline: String,
         in_trait: bool,
+        is_detailed: bool,
     },
     Name(String),
     ExternCFunc {

--- a/src/codegen/signal.rs
+++ b/src/codegen/signal.rs
@@ -191,7 +191,11 @@ fn function_type_string(
 
 fn declaration(analysis: &analysis::signals::Info, function_type: &Option<String>) -> String {
     let bounds = bounds(function_type);
-    let param_str = "&self, f: F";
+    let param_str = if !analysis.is_detailed {
+        "&self, f: F"
+    } else {
+        "&self, detail: Option<&str>, f: F"
+    };
     let return_str = " -> SignalHandlerId";
     format!(
         "fn {}<{}>({}){}",
@@ -212,7 +216,8 @@ fn body(analysis: &analysis::signals::Info, in_trait: bool) -> Chunk {
     builder
         .signal_name(&analysis.signal_name)
         .trampoline_name(&analysis.trampoline.as_ref().unwrap().name)
-        .in_trait(in_trait);
+        .in_trait(in_trait)
+        .is_detailed(analysis.is_detailed);
 
     builder.generate()
 }

--- a/src/codegen/signal_body.rs
+++ b/src/codegen/signal_body.rs
@@ -5,6 +5,7 @@ pub struct Builder {
     signal_name: String,
     trampoline_name: String,
     in_trait: bool,
+    is_detailed: bool,
 }
 
 impl Builder {
@@ -24,6 +25,11 @@ impl Builder {
 
     pub fn in_trait(&mut self, value: bool) -> &mut Builder {
         self.in_trait = value;
+        self
+    }
+
+    pub fn is_detailed(&mut self, value: bool) -> &mut Builder {
+        self.is_detailed = value;
         self
     }
 
@@ -55,6 +61,7 @@ impl Builder {
             signal: self.signal_name.clone(),
             trampoline: self.trampoline_name.clone(),
             in_trait: self.in_trait,
+            is_detailed: self.is_detailed,
         }
     }
 }

--- a/src/library.rs
+++ b/src/library.rs
@@ -485,6 +485,7 @@ pub struct Signal {
     pub parameters: Vec<Parameter>,
     pub ret: Parameter,
     pub is_action: bool,
+    pub is_detailed: bool,
     pub version: Option<Version>,
     pub deprecated_version: Option<Version>,
     pub doc: Option<String>,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -996,6 +996,7 @@ impl Library {
     ) -> Result<Signal, String> {
         let signal_name = elem.attr_required("name")?;
         let is_action = elem.attr_bool("action", false);
+        let is_detailed = elem.attr_bool("detailed", false);
         let version = self.read_version(parser, ns_id, elem)?;
         let deprecated_version = self.read_deprecated_version(parser, ns_id, elem)?;
 
@@ -1029,6 +1030,7 @@ impl Library {
                 parameters: params,
                 ret,
                 is_action,
+                is_detailed,
                 version,
                 deprecated_version,
                 doc,


### PR DESCRIPTION
Some GObject signals use a non-default [_detail_ argument](https://developer.gnome.org/gobject/stable/signal.html#signal-detail). This allows one to specify that a closure should only be invoked on a subset of that signal's emissions.

There is an attribute in the GIR annotations that specifies when a signal uses non-default values of _detail_. As of time of writing, the code generated by the `gir` tool does not allow one to specify the value of _detail_ in the relevant connect methods&mdash;the closure passed to `connect_<signal name>` will get invoked on all emissions of that signal, regardless of the value of _detail_. This PR contains an attempt at adding such support in. For signals that use _detail_, the relevant method's signature is changed from, e.g.,

```rust
fn connect_state_change<F: Fn(&Self, &str, bool) + 'static>(
    &self,
    f: F
) -> SignalHandlerId
```
to

```rust
fn connect_state_change<F: Fn(&Self, &str, bool) + 'static>(
    &self,
    detail: Option<&str>,
    f: F
) -> SignalHandlerId
```

`Option<&str>` is used because not specifying a _detail_ value in `g_signal_connect*` is valid in these cases (it means the closure will be invoked regardless of the value of _detail_).

This has been tested out on code generation for gtk-rs/gtk-rs and gtk-rs/webkit2gtk-rs, and it produces the expected changes. I have even tested out the use of `Some(_)` and `None` for such a modified connection method (`webkit2gtk::UserContentManagerExt::connect_script_message_received`) and it appears to work as desired.

Some possible issues with my PR as it stands:

- This makes backward-incompatible changes to the API for these signals. Is that OK? If not, what approach(es) would be preferable?
- Is `Option<&str>` the best type to specify the _detail_ value with, or would a bespoke enum serve better?
- This is my first time working in this codebase. I wouldn't mind a sanity check of my work.

Constructive critique of this PR is appreciated!