### PR TITLE
git: Read remote url from upstream or origin

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -2,12 +2,14 @@ use std::path::Path;
 use std::process::Command;
 
 pub fn repo_hash<P: AsRef<Path>>(path: P) -> Option<String> {
-    let git_path = path.as_ref().to_str();
-    let mut args = match git_path {
-        Some(path) => vec!["-C", path],
-        None => vec![],
-    };
+    let git_path = path
+        .as_ref()
+        .to_str()
+        .expect("Repository path must be a valid UTF-8 string");
+
+    let mut args = vec!["-C", git_path];
     args.extend(&["rev-parse", "--short", "HEAD"]);
+
     let output = Command::new("git").args(&args).output().ok()?;
     if !output.status.success() {
         return None;

--- a/src/git.rs
+++ b/src/git.rs
@@ -35,3 +35,16 @@ fn dirty(path: impl AsRef<Path>) -> bool {
         Err(_) => false,
     }
 }
+
+// This file is also compiled from build.rs where this function is unused
+#[allow(dead_code)]
+pub(crate) fn repo_remote_url(path: impl AsRef<Path>) -> Option<String> {
+    let output = ["upstream", "origin"].iter().find_map(|remote| {
+        let output = git_command(path.as_ref(), &["remote", "get-url", remote]).ok()?;
+        // XXX: Use `.then_some` when it is stabilized
+        output.status.success().then(|| output)
+    })?;
+    String::from_utf8(output.stdout)
+        .ok()
+        .map(|s| s.trim_end_matches('\n').into())
+}


### PR DESCRIPTION
Depends on #1041

With the new separate gir directories it is useful to know what repo (url) a git hash came from, without hardcoding it here. Consensus shows that these repos are either directly cloned through submodules with a default remote named `origin` or a manual rename to `upstream` with the personal remote (from which PRs are commonly created) named `origin`. In that case the url of `upstream` is preferred.

CC @GuillaumeGomez @sdroege
