### PR TITLE
add an option to always generate builder patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,10 @@ trust_return_value_nullability = false
 # Disable running `cargo fmt` on generated files
 # (defaults to false)
 disable_format = true
+# Always generate a Builder if possible. This is mostly a convenient setter as most of the 
+# time you might want the Builder to be generated. Ignoring none-desired ones can still be done with per object `generate_builder` configuration.
+# (defaults to false)
+generate_builder = true
 ```
 
 This mode generates only the specified objects. You can either add the object's fullname to the `generate` array or add it to the `manual` array (but in this case, it won't be generated, just used in other functions/methods instead of generating an "ignored" argument). Example:

--- a/README.md
+++ b/README.md
@@ -177,13 +177,13 @@ status = "generate"
 generate_builder = true
 ```
 
-If you want to remove warning messages about the not bound `Builders` during the generation you don't want to be generated, you can ignore them with the `ignore_builder` flag in object configuration:
+If you want to remove warning messages about the not bound `Builders` during the generation you don't want to be generated, you can ignore them with the `generate_builder` flag in object configuration:
 
 ```toml
 [[object]]
 name = "Gtk.TreeView"
 status = "generate"
-ignore_builder = true
+generate_builder = false
 ```
 
 If there is some work which has to be done post-construction before the builder's
@@ -193,7 +193,7 @@ If there is some work which has to be done post-construction before the builder'
 [[object]]
 name = "Gtk.Application"
 status = "generate"
-generage_builder = true
+generate_builder = true
 builder_postprocess = "Application::register_startup_hook(&ret);"
 ```
 

--- a/src/analysis/class_builder.rs
+++ b/src/analysis/class_builder.rs
@@ -19,7 +19,7 @@ pub fn analyze(
     obj: &GObject,
     imports: &mut Imports,
 ) -> Vec<Property> {
-    if !obj.generate_builder || obj.ignore_builder {
+    if !obj.generate_builder {
         return Vec::new();
     }
 

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -174,6 +174,11 @@ impl Config {
             Some(a) => a.into(),
         };
 
+        let generate_builder: bool = toml
+            .lookup("options.generate_builder")
+            .and_then(|a| a.as_bool())
+            .unwrap_or(false);
+
         let auto_path = match toml.lookup("options.auto_path") {
             Some(p) => target_path.join(p.as_result_str("options.auto_path")?),
             None if work_mode == WorkMode::Normal => target_path.join("src").join("auto"),
@@ -224,6 +229,7 @@ impl Config {
                     t,
                     concurrency,
                     generate_display_trait,
+                    generate_builder,
                     trust_return_value_nullability,
                 )
             })
@@ -233,6 +239,7 @@ impl Config {
             &toml,
             concurrency,
             generate_display_trait,
+            generate_builder,
             trust_return_value_nullability,
         );
 

--- a/src/config/gobjects.rs
+++ b/src/config/gobjects.rs
@@ -84,7 +84,6 @@ pub struct GObject {
     pub manual_traits: Vec<String>,
     pub align: Option<u32>,
     pub generate_builder: bool,
-    pub ignore_builder: bool,
     pub builder_postprocess: Option<String>,
     pub init_function_expression: Option<String>,
     pub clear_function_expression: Option<String>,
@@ -117,7 +116,6 @@ impl Default for GObject {
             manual_traits: Vec::default(),
             align: None,
             generate_builder: false,
-            ignore_builder: false,
             builder_postprocess: None,
             init_function_expression: None,
             clear_function_expression: None,
@@ -217,7 +215,6 @@ fn parse_object(
             "manual_traits",
             "align",
             "generate_builder",
-            "ignore_builder",
             "builder_postprocess",
             "init_function_expression",
             "clear_function_expression",
@@ -326,10 +323,7 @@ fn parse_object(
         .lookup("generate_builder")
         .and_then(Value::as_bool)
         .unwrap_or(generate_builder);
-    let ignore_builder = toml_object
-        .lookup("ignore_builder")
-        .and_then(Value::as_bool)
-        .unwrap_or(false);
+
     let builder_postprocess = toml_object
         .lookup("builder_postprocess")
         .and_then(Value::as_str)
@@ -397,7 +391,6 @@ fn parse_object(
         builder_postprocess,
         init_function_expression,
         clear_function_expression,
-        ignore_builder,
     }
 }
 
@@ -464,18 +457,16 @@ pub fn resolve_type_ids(objects: &mut GObjects, library: &Library) {
         let type_id = library.find_type(0, name);
         if type_id.is_none() && name != &global_functions_name {
             warn!("Configured object `{}` missing from the library", name);
-        } else if !object.ignore_builder {
+        } else if object.generate_builder {
             if let Some(ref type_id) = type_id {
                 if library.type_(*type_id).is_abstract() {
-                    if object.generate_builder {
-                        warn!(
-                            "Cannot generate builder for `{}` because it's a base class",
-                            name
-                        );
-                    }
-                    // We set this to `true` to avoid having the "not_bound" mode saying that this
+                    warn!(
+                        "Cannot generate builder for `{}` because it's a base class",
+                        name
+                    );
+                    // We set this to `false` to avoid having the "not_bound" mode saying that this
                     // builder should be generated.
-                    object.ignore_builder = true;
+                    object.generate_builder = false;
                 }
             }
         }

--- a/src/config/gobjects.rs
+++ b/src/config/gobjects.rs
@@ -132,6 +132,7 @@ pub fn parse_toml(
     toml_objects: &Value,
     concurrency: library::Concurrency,
     generate_display_trait: bool,
+    generate_builder: bool,
     trust_return_value_nullability: bool,
 ) -> GObjects {
     let mut objects = GObjects::new();
@@ -140,6 +141,7 @@ pub fn parse_toml(
             toml_object,
             concurrency,
             generate_display_trait,
+            generate_builder,
             trust_return_value_nullability,
         );
         objects.insert(gobject.name.clone(), gobject);
@@ -177,6 +179,7 @@ fn parse_object(
     toml_object: &Value,
     concurrency: library::Concurrency,
     default_generate_display_trait: bool,
+    generate_builder: bool,
     trust_return_value_nullability: bool,
 ) -> GObject {
     let name: String = toml_object
@@ -322,7 +325,7 @@ fn parse_object(
     let generate_builder = toml_object
         .lookup("generate_builder")
         .and_then(Value::as_bool)
-        .unwrap_or(false);
+        .unwrap_or(generate_builder);
     let ignore_builder = toml_object
         .lookup("ignore_builder")
         .and_then(Value::as_bool)
@@ -403,6 +406,7 @@ pub fn parse_status_shorthands(
     toml: &Value,
     concurrency: library::Concurrency,
     generate_display_trait: bool,
+    generate_builder: bool,
     trust_return_value_nullability: bool,
 ) {
     use self::GStatus::*;
@@ -413,6 +417,7 @@ pub fn parse_status_shorthands(
             toml,
             concurrency,
             generate_display_trait,
+            generate_builder,
             trust_return_value_nullability,
         );
     }
@@ -424,6 +429,7 @@ fn parse_status_shorthand(
     toml: &Value,
     concurrency: library::Concurrency,
     generate_display_trait: bool,
+    generate_builder: bool,
     trust_return_value_nullability: bool,
 ) {
     let option_name = format!("options.{:?}", status).to_ascii_lowercase();
@@ -439,6 +445,7 @@ fn parse_status_shorthand(
                             concurrency,
                             generate_display_trait,
                             trust_return_value_nullability,
+                            generate_builder,
                             ..Default::default()
                         },
                     );

--- a/src/library.rs
+++ b/src/library.rs
@@ -1036,7 +1036,7 @@ impl Library {
                             .config
                             .objects
                             .get(&full_name)
-                            .map(|obj| obj.generate_builder || obj.ignore_builder)
+                            .map(|obj| obj.generate_builder)
                             .unwrap_or_else(|| false)
                             && properties
                                 .iter()


### PR DESCRIPTION
In some crates like gtk3/gtk4, creating a builder pattern is often set to true. It makes the configuration file super huge. This is an effort to try to reduce that by adding an option to always enable the builder pattern generation. 
Note that you can still disable builder pattern generation individually using `ignore_builder = true`

See the following commit for a real use case: https://github.com/gtk-rs/gtk4-rs/pull/219/commits/e3eac0f3adc5852b68cffc814445fd7627b31614

