### PR TITLE
"canonicalize" paths

### DIFF
--- a/src/codegen/general.rs
+++ b/src/codegen/general.rs
@@ -33,7 +33,7 @@ pub fn start_comments_no_version(w: &mut dyn Write, conf: &Config) -> Result<()>
             .map(|info| {
                 format!(
                     "// from {}{}\n",
-                    info.gir_dir.display(),
+                    info.gir_dir,
                     info.get_repository_url()
                         .map_or_else(String::new, |url| format!(" ({})", url)),
                 )
@@ -55,7 +55,7 @@ pub fn single_version_file(w: &mut dyn Write, conf: &Config, prefix: &str) -> Re
                 format!(
                     "{}from {} ({}@ {})\n",
                     prefix,
-                    info.gir_dir.display(),
+                    info.gir_dir,
                     info.get_repository_url()
                         .map_or_else(String::new, |u| format!("{} ", u)),
                     info.get_hash(),

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -13,24 +13,55 @@ use log::warn;
 use std::{
     collections::HashMap,
     fs,
-    path::{Path, PathBuf},
+    path::{Component, Path, PathBuf},
     str::FromStr,
 };
 
+fn canonicalize(path: &Path) -> String {
+    let mut parts: Vec<String> = Vec::new();
+
+    for component in path.components() {
+        match component {
+            Component::RootDir | Component::CurDir => {}
+            Component::ParentDir => {
+                parts.pop();
+            }
+            c => parts.push(
+                c.as_os_str()
+                    .to_str()
+                    .expect("OsStr::to_str failed")
+                    .to_owned(),
+            ),
+        }
+    }
+    parts.join("/")
+}
+
 #[derive(Debug)]
 pub struct GirVersion {
-    pub gir_dir: PathBuf,
+    pub gir_dir: String,
+    file_name: Option<String>,
     hash: Option<String>,
 }
 
 impl GirVersion {
+    fn new(gir_dir: &Path, hash: Option<String>) -> Self {
+        Self {
+            gir_dir: canonicalize(gir_dir),
+            file_name: gir_dir
+                .file_name()
+                .map(|s| s.to_str().expect("OsStr::to_str failed").to_owned()),
+            hash,
+        }
+    }
+
     pub fn get_hash(&self) -> &str {
         self.hash.as_deref().unwrap_or("???")
     }
 
     pub fn get_repository_url(&self) -> Option<&str> {
-        match self.gir_dir.file_name() {
-            Some(r) if r == "gir-files" => Some("https://github.com/gtk-rs/gir-files"),
+        match self.file_name {
+            Some(ref r) if r == "gir-files" => Some("https://github.com/gtk-rs/gir-files"),
             _ => None,
         }
     }
@@ -146,10 +177,7 @@ impl Config {
         }
         let mut girs_version = girs_dirs
             .iter()
-            .map(|d| GirVersion {
-                gir_dir: d.clone(),
-                hash: repo_hash(d),
-            })
+            .map(|d| GirVersion::new(&d, repo_hash(d)))
             .collect::<Vec<_>>();
         girs_version.sort_by(|a, b| a.gir_dir.partial_cmp(&b.gir_dir).unwrap());
 


### PR DESCRIPTION
So for example, if we set "a/../b", it'll write up "b" (because "a" is "eaten" since there is a ".."). If there is no parent folder before a "..", it does nothing.