### PR TITLE
config: "Canonicalize" ../ away from relative git paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,9 +85,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.6.1"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb1fa934250de4de8aef298d81c729a7d33d8c239daa3a7575e6b92bfc7313b"
+checksum = "824845a0bf897a9042383849b02c1bc219c2383772efcd5c6f9766fa4b81aef3"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -119,27 +119,26 @@ checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
 
 [[package]]
 name = "once_cell"
-version = "1.5.2"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13bd41f508810a131401606d54ac32a467c97172d74ba7662562ebba5ad07fa0"
+checksum = "af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3"
 
 [[package]]
 name = "regex"
-version = "1.4.3"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9251239e129e16308e70d853559389de218ac275b515068abc96829d05b948a"
+checksum = "957056ecddbeba1b26965114e191d2e8589ce74db242b6ea25fc4062427a5c19"
 dependencies = [
  "aho-corasick",
  "memchr",
  "regex-syntax",
- "thread_local",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.22"
+version = "0.6.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5eb417147ba9860a96cfe72a0b93bf88fee1744b5636ec99ab20c1aa9376581"
+checksum = "24d5f089152e60f62d28b835fbff2cd2e8dc0baf1ac13343bef92ab7eed84548"
 
 [[package]]
 name = "rustdoc-stripper"
@@ -148,18 +147,9 @@ source = "git+https://github.com/GuillaumeGomez/rustdoc-stripper#9c23f667610ccd5
 
 [[package]]
 name = "serde"
-version = "1.0.123"
+version = "1.0.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92d5161132722baa40d802cc70b15262b98258453e85e5d1d365c757c73869ae"
-
-[[package]]
-name = "thread_local"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
-dependencies = [
- "once_cell",
-]
+checksum = "558dc50e1a5a5fa7112ca2ce4effcb321b0300c0d4ccf0776a9f60cd89031171"
 
 [[package]]
 name = "toml"

--- a/src/codegen/general.rs
+++ b/src/codegen/general.rs
@@ -33,7 +33,7 @@ pub fn start_comments_no_version(w: &mut dyn Write, conf: &Config) -> Result<()>
             .map(|info| {
                 format!(
                     "// from {}{}\n",
-                    info.gir_dir,
+                    info.gir_dir.display(),
                     info.get_repository_url()
                         .map_or_else(String::new, |url| format!(" ({})", url)),
                 )
@@ -55,7 +55,7 @@ pub fn single_version_file(w: &mut dyn Write, conf: &Config, prefix: &str) -> Re
                 format!(
                     "{}from {} ({}@ {})\n",
                     prefix,
-                    info.gir_dir,
+                    info.gir_dir.display(),
                     info.get_repository_url()
                         .map_or_else(String::new, |u| format!("{} ", u)),
                     info.get_hash(),


### PR DESCRIPTION
@GuillaumeGomez This is the implementation I intended to make, back when originally noticing and reporting this issue. Unfortunately you merged the PR just before I was able to send it as a review suggestion, so here it is as a PR instead.

- Accepts an `impl AsRef<Path>`;
- Returns a `PathBuf` since it's still a path, so no changes are needed in the other files. Those have been reverted;
- No unnecessary clones, `as_os_str` / `to_str` / `to_owned` confusing code: just playing around with path components and copying them to a new buffer (owned `PathBuf`) at once in the end;
- Fails on paths that go out of their "root/current" directory, ie. `../`;
- Tests, but we'll have to see what to do with silently removing `CurrentDir` and `RootDir`!