### PR TITLE
sys mode: allow clippy warning upper_case_acronyms

### DIFF
--- a/src/codegen/sys/statics.rs
+++ b/src/codegen/sys/statics.rs
@@ -5,7 +5,7 @@ pub fn begin(w: &mut dyn Write) -> Result<()> {
     let v = vec![
         "",
         "#![allow(non_camel_case_types, non_upper_case_globals, non_snake_case)]",
-        "#![allow(clippy::approx_constant, clippy::type_complexity, clippy::unreadable_literal)]",
+        "#![allow(clippy::approx_constant, clippy::type_complexity, clippy::unreadable_literal, clippy::upper_case_acronyms)]",
         "#![cfg_attr(feature = \"dox\", feature(doc_cfg))]",
         "",
     ];


### PR DESCRIPTION
Required to fix gdk since the latest update of clippy

```

error: name `GdkGLError` contains a capitalized acronym
   --> gdk4/sys/src/lib.rs:111:10
    |
111 | pub type GdkGLError = c_int;
    |          ^^^^^^^^^^ help: consider making the acronym lowercase, except the initial letter: `GdkGlError`
    |
    = note: `-D clippy::upper-case-acronyms` implied by `-D warnings`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#upper_case_acronyms

error: name `_GdkGLTextureClass` contains a capitalized acronym
    --> gdk4/sys/src/lib.rs:2699:12
     |
2699 | pub struct _GdkGLTextureClass(c_void);
     |            ^^^^^^^^^^^^^^^^^^ help: consider making the acronym lowercase, except the initial letter: `_GdkGlTextureClass`
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#upper_case_acronyms

error: name `GdkGLTextureClass` contains a capitalized acronym
    --> gdk4/sys/src/lib.rs:2701:10
     |
2701 | pub type GdkGLTextureClass = *mut _GdkGLTextureClass;
     |          ^^^^^^^^^^^^^^^^^ help: consider making the acronym lowercase, except the initial letter: `GdkGlTextureClass`
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#upper_case_acronyms

error: name `GdkRGBA` contains a capitalized acronym
    --> gdk4/sys/src/lib.rs:2777:12
     |
2777 | pub struct GdkRGBA {
     |            ^^^^^^^ help: consider making the acronym lowercase, except the initial letter: `GdkRgba`
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#upper_case_acronyms

error: name `GdkDNDEvent` contains a capitalized acronym
    --> gdk4/sys/src/lib.rs:2964:12
     |
2964 | pub struct GdkDNDEvent(c_void);
     |            ^^^^^^^^^^^ help: consider making the acronym lowercase, except the initial letter: `GdkDndEvent`
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#upper_case_acronyms

error: name `GdkGLContext` contains a capitalized acronym
    --> gdk4/sys/src/lib.rs:3084:12
     |
3084 | pub struct GdkGLContext(c_void);
     |            ^^^^^^^^^^^^ help: consider making the acronym lowercase, except the initial letter: `GdkGlContext`
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#upper_case_acronyms

error: name `GdkGLTexture` contains a capitalized acronym
    --> gdk4/sys/src/lib.rs:3094:12
     |
3094 | pub struct GdkGLTexture(c_void);
     |            ^^^^^^^^^^^^ help: consider making the acronym lowercase, except the initial letter: `GdkGlTexture`
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#upper_case_acronyms

error: aborting due to 7 previous errors
```