### PR TITLE
codegen/general: Emit "Since vXXX" in #[deprecated] attributes

### DIFF
--- a/src/codegen/general.rs
+++ b/src/codegen/general.rs
@@ -495,15 +495,15 @@ pub fn cfg_deprecated(
     commented: bool,
     indent: usize,
 ) -> Result<()> {
-    if let Some(s) = cfg_deprecated_string(deprecated, env, commented, indent) {
+    if let Some(s) = cfg_deprecated_string(env, deprecated, commented, indent) {
         writeln!(w, "{}", s)?;
     }
     Ok(())
 }
 
 pub fn cfg_deprecated_string(
-    deprecated: Option<Version>,
     env: &Env,
+    deprecated: Option<Version>,
     commented: bool,
     indent: usize,
 ) -> Option<String> {

--- a/src/codegen/general.rs
+++ b/src/codegen/general.rs
@@ -508,18 +508,19 @@ pub fn cfg_deprecated_string(
     indent: usize,
 ) -> Option<String> {
     let comment = if commented { "//" } else { "" };
-    if env.is_too_low_version(deprecated) {
-        Some(format!("{}{}#[deprecated]", tabs(indent), comment))
-    } else {
-        deprecated.map(|v| {
+    deprecated.map(|v| {
+        if env.is_too_low_version(Some(v)) {
+            format!("{}{}#[deprecated = \"Since {}\"]", tabs(indent), comment, v)
+        } else {
             format!(
-                "{}{}#[cfg_attr({}, deprecated)]",
+                "{}{}#[cfg_attr({}, deprecated = \"Since {}\")]",
                 tabs(indent),
                 comment,
                 v.to_cfg(),
+                v,
             )
-        })
-    }
+        }
+    })
 }
 
 pub fn version_condition(

--- a/src/codegen/object.rs
+++ b/src/codegen/object.rs
@@ -386,6 +386,10 @@ pub fn generate_reexports(
     if let Some(cfg) = general::version_condition_string(env, analysis.version, false, 0) {
         cfgs.push(cfg);
     }
+    if let Some(cfg) = general::cfg_deprecated_string(env, analysis.deprecated_version, false, 0) {
+        cfgs.push(cfg);
+    }
+
     contents.push("".to_owned());
     contents.extend_from_slice(&cfgs);
     contents.push(format!("mod {};", module_name));


### PR DESCRIPTION
This started as an effort to get rid of the `[Deprecated since XXX]` and `# Deprecated` in the documentation in favour of cleaner and more obvious:

![image](https://user-images.githubusercontent.com/2325264/112763767-28952a80-9006-11eb-8381-59be323cac44.png)

Unfortunately that doesn't show unless the docs are compiled with at least that version - which only seems to be happening in GStreamer thus far.

---

Also emit the missing `#[deprecated]` notice for objects, right into the `mod.rs` file. Is it missing anywhere else?

**TODO**: Probably need the same deduplication for these attributes as we had for the features in #1080. Right now it shows multiple times, even though deprecation of a type should also hold for all members and functions. Unlike `doc(cfg())` features (see #1080 for example) `rustdoc` does not seem to coalesce these:

![image](https://user-images.githubusercontent.com/2325264/112763955-d99bc500-9006-11eb-81c6-3c66a8c74abb.png)
