### PR TITLE
[1/3] Emit intra-doc links for self (`@`) references

### DIFF
--- a/src/analysis/symbols.rs
+++ b/src/analysis/symbols.rs
@@ -38,6 +38,10 @@ impl Symbol {
     pub fn crate_name(&self) -> Option<&String> {
         self.crate_name.as_ref()
     }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
 }
 
 #[derive(Debug)]

--- a/src/analysis/symbols.rs
+++ b/src/analysis/symbols.rs
@@ -16,7 +16,11 @@ impl Symbol {
     pub fn full_rust_name(&self) -> String {
         let mut ret = String::new();
         if let Some(ref s) = self.crate_name {
-            ret.push_str(s);
+            if s == "gobject" {
+                ret.push_str("glib::object");
+            } else {
+                ret.push_str(s);
+            }
             ret.push_str("::");
         }
         if let Some(ref s) = self.owner_name {

--- a/src/analysis/symbols.rs
+++ b/src/analysis/symbols.rs
@@ -39,6 +39,10 @@ impl Symbol {
         self.crate_name.as_ref()
     }
 
+    pub fn owner_name(&self) -> Option<&str> {
+        self.owner_name.as_deref()
+    }
+
     pub fn name(&self) -> &str {
         &self.name
     }

--- a/src/codegen/doc/mod.rs
+++ b/src/codegen/doc/mod.rs
@@ -637,7 +637,6 @@ fn get_type_trait_for_implements(env: &Env, tid: TypeId) -> String {
         let mut full_trait_name = symbol.full_rust_name();
         let crate_path = if let Some(crate_name) = symbol.crate_name() {
             if crate_name == "gobject" {
-                full_trait_name = full_trait_name.replace("gobject", "glib::object");
                 "../glib/object".to_owned()
             } else {
                 format!("../{}", crate_name)

--- a/src/codegen/doc/mod.rs
+++ b/src/codegen/doc/mod.rs
@@ -202,12 +202,12 @@ fn create_object_doc(w: &mut dyn Write, env: &Env, info: &analysis::object::Info
             write!(w, "`[Deprecated since {}]` ", ver)?;
         }
         if let Some(doc) = doc_deprecated {
-            writeln!(w, "{}", reformat_doc(doc, &symbols))?;
+            writeln!(w, "{}", reformat_doc(doc, &symbols, &info.name))?;
         } else if doc_deprecated.is_some() {
             write!(w, "`[Deprecated]` ")?;
         }
         if let Some(doc) = doc {
-            writeln!(w, "{}", reformat_doc(doc, &symbols))?;
+            writeln!(w, "{}", reformat_doc(doc, &symbols, &info.name))?;
         } else {
             writeln!(w)?;
         }
@@ -345,7 +345,7 @@ fn create_record_doc(w: &mut dyn Write, env: &Env, info: &analysis::record::Info
             if let Some(ver) = info.deprecated_version {
                 write!(w, "`[Deprecated since {}]` ", ver)?;
             }
-            writeln!(w, "{}", reformat_doc(doc, &symbols))?;
+            writeln!(w, "{}", reformat_doc(doc, &symbols, &info.name))?;
         }
         if let Some(ver) = info.deprecated_version {
             writeln!(w, "\n# Deprecated since {}\n", ver)?;
@@ -353,7 +353,7 @@ fn create_record_doc(w: &mut dyn Write, env: &Env, info: &analysis::record::Info
             writeln!(w, "\n# Deprecated\n")?;
         }
         if let Some(ref doc) = record.doc_deprecated {
-            writeln!(w, "{}", reformat_doc(doc, &symbols))?;
+            writeln!(w, "{}", reformat_doc(doc, &symbols, &info.name))?;
         }
         if let Some(version) = info.version {
             writeln!(w, "\nFeature: `{}`", version.to_feature())?;
@@ -377,7 +377,7 @@ fn create_enum_doc(w: &mut dyn Write, env: &Env, enum_: &Enumeration) -> Result<
 
     write_item_doc(w, &ty, |w| {
         if let Some(ref doc) = enum_.doc {
-            writeln!(w, "{}", reformat_doc(doc, &symbols))?;
+            writeln!(w, "{}", reformat_doc(doc, &symbols, &enum_.name))?;
         }
         if let Some(ver) = enum_.deprecated_version {
             writeln!(w, "\n# Deprecated since {}\n", ver)?;
@@ -385,7 +385,7 @@ fn create_enum_doc(w: &mut dyn Write, env: &Env, enum_: &Enumeration) -> Result<
             writeln!(w, "\n# Deprecated\n")?;
         }
         if let Some(ref doc) = enum_.doc_deprecated {
-            writeln!(w, "{}", reformat_doc(doc, &symbols))?;
+            writeln!(w, "{}", reformat_doc(doc, &symbols, &enum_.name))?;
         }
         Ok(())
     })?;
@@ -400,7 +400,7 @@ fn create_enum_doc(w: &mut dyn Write, env: &Env, enum_: &Enumeration) -> Result<
             };
             write_item_doc(w, &sub_ty, |w| {
                 if let Some(ref doc) = member.doc {
-                    writeln!(w, "{}", reformat_doc(doc, &symbols))?;
+                    writeln!(w, "{}", reformat_doc(doc, &symbols, &enum_.name))?;
                 }
                 Ok(())
             })?;
@@ -421,7 +421,7 @@ fn create_bitfield_doc(w: &mut dyn Write, env: &Env, bitfield: &Bitfield) -> Res
 
     write_item_doc(w, &ty, |w| {
         if let Some(ref doc) = bitfield.doc {
-            writeln!(w, "{}", reformat_doc(doc, &symbols))?;
+            writeln!(w, "{}", reformat_doc(doc, &symbols, &bitfield.name))?;
         }
         if let Some(ver) = bitfield.deprecated_version {
             writeln!(w, "\n# Deprecated since {}\n", ver)?;
@@ -429,7 +429,7 @@ fn create_bitfield_doc(w: &mut dyn Write, env: &Env, bitfield: &Bitfield) -> Res
             writeln!(w, "\n# Deprecated\n")?;
         }
         if let Some(ref doc) = bitfield.doc_deprecated {
-            writeln!(w, "{}", reformat_doc(doc, &symbols))?;
+            writeln!(w, "{}", reformat_doc(doc, &symbols, &bitfield.name))?;
         }
         Ok(())
     })?;
@@ -444,7 +444,7 @@ fn create_bitfield_doc(w: &mut dyn Write, env: &Env, bitfield: &Bitfield) -> Res
             };
             write_item_doc(w, &sub_ty, |w| {
                 if let Some(ref doc) = member.doc {
-                    writeln!(w, "{}", reformat_doc(doc, &symbols))?;
+                    writeln!(w, "{}", reformat_doc(doc, &symbols, &bitfield.name))?;
                 }
                 Ok(())
             })?;
@@ -493,6 +493,8 @@ where
         return Ok(());
     }
 
+    let parent_name = parent.as_ref().map_or("", |p| &p.name).to_owned();
+
     let symbols = env.symbols.borrow();
     let mut st = fn_.to_stripper_type();
     if let Some(name_override) = name_override {
@@ -510,7 +512,7 @@ where
             writeln!(
                 w,
                 "{}",
-                reformat_doc(&fix_param_names(doc, &self_name), &symbols)
+                reformat_doc(&fix_param_names(doc, &self_name), &symbols, &parent_name)
             )?;
         }
         if let Some(version) = *fn_.version() {
@@ -527,7 +529,7 @@ where
             writeln!(
                 w,
                 "{}",
-                reformat_doc(&fix_param_names(doc, &self_name), &symbols)
+                reformat_doc(&fix_param_names(doc, &self_name), &symbols, &parent_name)
             )?;
         }
 
@@ -540,7 +542,7 @@ where
                 writeln!(
                     w,
                     "{}",
-                    reformat_doc(&fix_param_names(doc, &self_name), &symbols)
+                    reformat_doc(&fix_param_names(doc, &self_name), &symbols, &parent_name)
                 )?;
             }
         }
@@ -550,7 +552,7 @@ where
             writeln!(
                 w,
                 "{}",
-                reformat_doc(&fix_param_names(doc, &self_name), &symbols)
+                reformat_doc(&fix_param_names(doc, &self_name), &symbols, &parent_name)
             )?;
         }
         Ok(())
@@ -572,6 +574,7 @@ fn create_property_doc(
     {
         return Ok(());
     }
+    let parent_name = parent.as_ref().map_or("", |p| &p.name).to_owned();
     let name_for_func = nameutil::signal_to_snake(&property.name);
     let mut v = Vec::with_capacity(2);
 
@@ -595,7 +598,7 @@ fn create_property_doc(
                 writeln!(
                     w,
                     "{}",
-                    reformat_doc(&fix_param_names(doc, &None), &symbols)
+                    reformat_doc(&fix_param_names(doc, &None), &symbols, &parent_name)
                 )?;
             }
             if let Some(version) = property.version {
@@ -612,7 +615,7 @@ fn create_property_doc(
                 writeln!(
                     w,
                     "{}",
-                    reformat_doc(&fix_param_names(doc, &None), &symbols)
+                    reformat_doc(&fix_param_names(doc, &None), &symbols, &parent_name)
                 )?;
             }
             Ok(())


### PR DESCRIPTION
Or self-dubbed intra-docs lite (wrt gir). This PR is the safest of the bunch: `@` is only used in limited quantities and pretty much every C symbol (in GStreamer) links to a valid item. There's even extra validation to ensure that the type/parent name of the symbol matches that of the type the docs are generated for!

We still have the debate about seeing or hiding `crate::` and `Self::` in the generated HTML docs going on: https://github.com/gtk-rs/gir/pull/1085#issuecomment-810171414. @GuillaumeGomez doesn't mind and prefers shorter gir and markdown code, what do the other maintainers think? See the screenshots how having `crate::` and `Self::` in the HTML looks.