### PR TITLE
[2/3] Emit intra-doc links for function references

### DIFF
--- a/src/codegen/doc/format.rs
+++ b/src/codegen/doc/format.rs
@@ -1,6 +1,6 @@
 use crate::analysis::symbols;
 use once_cell::sync::Lazy;
-use regex::{Captures, Regex};
+use regex::{Captures, Match, Regex};
 
 const LANGUAGE_SEP_BEGIN: &str = "<!-- language=\"";
 const LANGUAGE_SEP_END: &str = "\" -->";
@@ -78,7 +78,8 @@ fn format(mut input: &str, symbols: &symbols::Info, in_type: &str) -> String {
 
 static SYMBOL: Lazy<Regex> =
     Lazy::new(|| Regex::new(r"(^|[^\\])([@#%])(\w+\b)([:.]+[\w-]+\b)?").unwrap());
-static FUNCTION: Lazy<Regex> = Lazy::new(|| Regex::new(r"(\b[a-z0-9_]+)\(\)").unwrap());
+static FUNCTION: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"([@#%])?(\w+\b[:.]+)?(\b[a-z0-9_]+)\(\)").unwrap());
 static GDK_GTK: Lazy<Regex> = Lazy::new(|| Regex::new(r"G[dt]k[A-Z]\w+\b").unwrap());
 static TAGS: Lazy<Regex> = Lazy::new(|| Regex::new(r"<[\w/-]+>").unwrap());
 static SPACES: Lazy<Regex> = Lazy::new(|| Regex::new(r"[ ]{2,}").unwrap());
@@ -91,7 +92,46 @@ fn replace_c_types(entry: &str, symbols: &symbols::Info, in_type: &str) -> Strin
             .unwrap_or_else(|| s.into())
     };
 
-    let out = SYMBOL.replace_all(entry, |caps: &Captures<'_>| {
+    let out = FUNCTION.replace_all(entry, |caps: &Captures<'_>| {
+        let name = &caps[3];
+        let sym = symbols.by_c_name(name);
+
+        if let Some(sym) = sym {
+            if sym.owner_name() == Some(in_type) {
+                // `#` or `%` symbols should probably have been `@` to denote
+                // that it is a reference within the current type.
+                format!("[`{f}()`](Self::{f}())", f = sym.name())
+            } else {
+                match caps.get(1).as_ref().map(Match::as_str) {
+                    // Catch invalid @ references that have a C symbol available but do not belong
+                    // to the current type (and can hence not use `Self::`). For now generate XXX
+                    // but with a valid global link so that the can be easily spotted in the code.
+                    // assert_eq!(sym.owner_name(), Some(in_type));
+                    Some("@") => format!(
+                        "[`crate::{}()`] (XXX: @-reference does not belong to {}!)",
+                        sym.full_rust_name(),
+                        in_type,
+                    ),
+                    Some("#") | None => {
+                        format!("[`{f}()`](crate::{f}())", f = sym.full_rust_name())
+                    }
+                    Some("%") => panic!("% not allowed for {:?}", caps),
+                    Some(c) => panic!("Unknown symbol reference {}", c),
+                }
+            }
+        } else if let Some(typ) = caps.get(2) {
+            let typ = typ.as_str();
+            if typ == in_type {
+                format!("[`{f}()`](Self::{f}())", f = name)
+            } else {
+                format!("[`{t}{f}()`](crate::{t}{f}())", t = typ, f = name)
+            }
+        } else {
+            format!("`{}()`", name)
+        }
+    });
+
+    let out = SYMBOL.replace_all(&out, |caps: &Captures<'_>| {
         let member = caps.get(4).map(|m| m.as_str()).unwrap_or("");
         let sym = symbols.by_c_name(&caps[3]);
         match &caps[2] {
@@ -136,17 +176,6 @@ fn replace_c_types(entry: &str, symbols: &symbols::Info, in_type: &str) -> Strin
     });
     let out = GDK_GTK.replace_all(&out, |caps: &Captures<'_>| {
         format!("`{}`", lookup(&caps[0]))
-    });
-    let out = FUNCTION.replace_all(&out, |caps: &Captures<'_>| {
-        if let Some(sym) = symbols.by_c_name(&caps[1]) {
-            if sym.owner_name() == Some(in_type) {
-                format!("[`{f}()`](Self::{f}())", f = sym.name())
-            } else {
-                format!("[`{f}()`](crate::{f}())", f = sym.full_rust_name())
-            }
-        } else {
-            format!("`{}()`", &caps[1])
-        }
     });
     let out = TAGS.replace_all(&out, "`$0`");
     SPACES.replace_all(&out, " ").into_owned()

--- a/src/codegen/doc/format.rs
+++ b/src/codegen/doc/format.rs
@@ -138,7 +138,7 @@ fn replace_c_types(entry: &str, symbols: &symbols::Info, in_type: &str) -> Strin
         format!("`{}`", lookup(&caps[0]))
     });
     let out = FUNCTION.replace_all(&out, |caps: &Captures<'_>| {
-        format!("`{}`", lookup(&caps[1]))
+        format!("`{}()`", lookup(&caps[1]))
     });
     let out = TAGS.replace_all(&out, "`$0`");
     SPACES.replace_all(&out, " ").into_owned()

--- a/src/codegen/doc/format.rs
+++ b/src/codegen/doc/format.rs
@@ -138,7 +138,15 @@ fn replace_c_types(entry: &str, symbols: &symbols::Info, in_type: &str) -> Strin
         format!("`{}`", lookup(&caps[0]))
     });
     let out = FUNCTION.replace_all(&out, |caps: &Captures<'_>| {
-        format!("`{}()`", lookup(&caps[1]))
+        if let Some(sym) = symbols.by_c_name(&caps[1]) {
+            if sym.owner_name() == Some(in_type) {
+                format!("[`{f}()`](Self::{f}())", f = sym.name())
+            } else {
+                format!("[`{f}()`](crate::{f}())", f = sym.full_rust_name())
+            }
+        } else {
+            format!("`{}()`", &caps[1])
+        }
     });
     let out = TAGS.replace_all(&out, "`$0`");
     SPACES.replace_all(&out, " ").into_owned()


### PR DESCRIPTION
The same as #1088 but for functions. This one is more tricky since not all functions (ie. memory management functions like `free` and `unref`) are generated, hence result in invalid links.  Certain functions are implemented manually and do not exist under `<type>Ext` but `<type>ExtManual` - this might be a shortcoming of the existing C symbol mapping that should simply not map those functions to an `Ext` type. Other than that the gains in GStreamer are massive over the few tens of broken links.