### PR TITLE
config: Normalize submodule path before looking it up in .gitmodules

### DIFF
--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -67,14 +67,15 @@ pub struct GirVersion {
 }
 
 impl GirVersion {
-    fn new(gir_dir: &Path) -> Self {
+    fn new(gir_dir: impl AsRef<Path>) -> Self {
+        let gir_dir = normalize_path(gir_dir);
         Self {
-            gir_dir: normalize_path(gir_dir),
             file_name: gir_dir
                 .file_name()
                 .map(|s| s.to_str().expect("OsStr::to_str failed").to_owned()),
-            hash: repo_hash(gir_dir),
-            url: repo_remote_url(gir_dir),
+            hash: repo_hash(&gir_dir),
+            url: repo_remote_url(&gir_dir),
+            gir_dir,
         }
     }
 
@@ -195,10 +196,7 @@ impl Config {
                 girs_dirs.push(config_dir.join(dir));
             }
         }
-        let mut girs_version = girs_dirs
-            .iter()
-            .map(|d| GirVersion::new(d))
-            .collect::<Vec<_>>();
+        let mut girs_version = girs_dirs.iter().map(GirVersion::new).collect::<Vec<_>>();
         girs_version.sort_by(|a, b| a.gir_dir.partial_cmp(&b.gir_dir).unwrap());
 
         let (library_name, library_version) = match (library_name.into(), library_version.into()) {


### PR DESCRIPTION
`normalize_path` was introduced in [1] for pretty-printing relative paths with `../` ParentDir components.  It was not intended for use outside of displaying scenarios but thanks to tests we can safely use it to solve a mismatch [2] when searching for submodule paths in `.gitmodules`.

This functionality introduced with [3] finds the submodule associated with a path based on string matching in order to pull out the URL, but was only tested with GStreamer-rs where "clean" paths are passed in through gir's `-d` option.  Gtk-rs and gtk4-rs use `girs_directories =` in `Gir.toml` with relative paths like `gtk4/../gir-files`: these cannot be found in `.gitmodules` with simple string matching and need the path simplified first.

[1]: https://github.com/gtk-rs/gir/pull/1075
[2]: https://github.com/gtk-rs/gtk4-rs/pull/251#discussion_r606147518
[3]: https://github.com/gtk-rs/gir/pull/1068
