### PR TITLE
TryFromGlib support

### DIFF
--- a/src/analysis/bounds.rs
+++ b/src/analysis/bounds.rs
@@ -4,8 +4,8 @@ use crate::{
         functions::{find_function, find_index_to_ignore, finish_function_name},
         imports::Imports,
         out_parameters::use_function_return_for_result,
-        rust_type::{bounds_rust_type, rust_type, rust_type_nullable, rust_type_with_scope},
-        try_from_glib::TryFromGlib,
+        ref_mode::RefMode,
+        rust_type::RustType,
     },
     config,
     consts::TYPE_PARAMETERS_START,
@@ -82,7 +82,9 @@ impl Bounds {
         concurrency: Concurrency,
         configured_functions: &[&config::functions::Function],
     ) -> (Option<String>, Option<CallbackInfo>) {
-        let type_name = bounds_rust_type(env, par.typ);
+        let type_name = RustType::builder(env, par.typ)
+            .with_ref_mode(RefMode::ByRefFake)
+            .try_build();
         if (r#async && async_param_to_remove(&par.name)) || type_name.is_err() {
             return (None, None);
         }
@@ -110,14 +112,11 @@ impl Bounds {
                         ) {
                             out_parameters.insert(
                                 0,
-                                rust_type_nullable(
-                                    env,
-                                    function.ret.typ,
-                                    function.ret.direction,
-                                    function.ret.nullable,
-                                    &TryFromGlib::default(),
-                                )
-                                .into_string(),
+                                RustType::builder(env, function.ret.typ)
+                                    .with_direction(function.ret.direction)
+                                    .with_nullable(function.ret.nullable)
+                                    .try_build()
+                                    .into_string(),
                             );
                         }
                         let parameters = format_out_parameters(&out_parameters);
@@ -138,15 +137,13 @@ impl Bounds {
                 {
                     need_is_into_check = par.c_type != "GDestroyNotify";
                     if let Type::Function(_) = env.library.type_(par.typ) {
-                        type_string = rust_type_with_scope(
-                            env,
-                            par.typ,
-                            par.direction,
-                            par.scope,
-                            concurrency,
-                            &par.try_from_glib,
-                        )
-                        .into_string();
+                        type_string = RustType::builder(env, par.typ)
+                            .with_direction(par.direction)
+                            .with_scope(par.scope)
+                            .with_concurrency(concurrency)
+                            .with_try_from_glib(&par.try_from_glib)
+                            .try_build()
+                            .into_string();
                         let bound_name = *self.unused.front().unwrap();
                         callback_info = Some(CallbackInfo {
                             callback_type: type_string.clone(),
@@ -313,7 +310,10 @@ impl PropertyBound {
         }
         Some(PropertyBound {
             alias: TYPE_PARAMETERS_START,
-            type_str: bounds_rust_type(env, type_id).into_string(),
+            type_str: RustType::builder(env, type_id)
+                .with_ref_mode(RefMode::ByRefFake)
+                .try_build()
+                .into_string(),
         })
     }
 }
@@ -341,14 +341,11 @@ fn find_out_parameters(
                 .find_map(|f| f.parameters.iter().find_map(|p| p.nullable))
                 .unwrap_or(param.nullable);
 
-            rust_type_nullable(
-                env,
-                param.typ,
-                param.direction,
-                nullable,
-                &TryFromGlib::default(),
-            )
-            .into_string()
+            RustType::builder(env, param.typ)
+                .with_direction(param.direction)
+                .with_nullable(nullable)
+                .try_build()
+                .into_string()
         })
         .collect()
 }
@@ -368,13 +365,10 @@ fn find_error_type(env: &Env, function: &Function) -> String {
         .find(|param| param.direction == ParameterDirection::Out && param.name == "error")
         .expect("error type");
     if let Type::Record(_) = *env.type_(error_param.typ) {
-        return rust_type(
-            env,
-            error_param.typ,
-            error_param.direction,
-            &TryFromGlib::default(),
-        )
-        .into_string();
+        return RustType::builder(env, error_param.typ)
+            .with_direction(error_param.direction)
+            .try_build()
+            .into_string();
     }
     panic!("cannot find error type")
 }

--- a/src/analysis/child_properties.rs
+++ b/src/analysis/child_properties.rs
@@ -1,9 +1,13 @@
 use crate::{
-    analysis::{bounds::Bounds, imports::Imports, ref_mode::RefMode, rust_type::*},
+    analysis::{
+        bounds::Bounds, imports::Imports, ref_mode::RefMode, rust_type::*,
+        try_from_glib::TryFromGlib,
+    },
     codegen::function,
     config,
     env::Env,
-    library, nameutil,
+    library::{self, ParameterDirection},
+    nameutil,
     traits::*,
 };
 use log::error;
@@ -48,7 +52,7 @@ pub fn analyze(
         .as_ref()
         .and_then(|name| env.library.find_type(0, name));
     if config.child_type.is_some() && child_type.is_none() {
-        let owner_name = rust_type(env, type_tid).into_string();
+        let owner_name = rust_type_default(env, type_tid).into_string();
         let child_type: &str = config.child_type.as_ref().unwrap();
         error!("Bad child type `{}` for `{}`", child_type, owner_name);
         return properties;
@@ -64,8 +68,16 @@ pub fn analyze(
 
     if !properties.is_empty() {
         imports.add("glib::object::IsA");
-        if let Some(s) = child_type.and_then(|typ| used_rust_type(env, typ, true).ok()) {
-            imports.add_used_type(&s);
+        if let Some(rust_type) = child_type.and_then(|typ| {
+            used_rust_type(
+                env,
+                typ,
+                ParameterDirection::Return,
+                &TryFromGlib::default(),
+            )
+            .ok()
+        }) {
+            imports.add_used_types(rust_type.used_types());
         }
     }
 
@@ -95,8 +107,10 @@ fn analyze_property(
         let doc_hidden = prop.doc_hidden;
 
         imports.add("glib::StaticType");
-        if let Ok(s) = used_rust_type(env, typ, false) {
-            imports.add_used_type(&s);
+        if let Ok(rust_type) =
+            used_rust_type(env, typ, ParameterDirection::In, &TryFromGlib::default())
+        {
+            imports.add_used_types(rust_type.used_types());
         }
 
         let get_out_ref_mode = RefMode::of(env, typ, library::ParameterDirection::Return);
@@ -116,7 +130,7 @@ fn analyze_property(
         let nullable = library::Nullable(set_in_ref_mode.is_ref());
 
         let mut bounds_str = String::new();
-        let dir = library::ParameterDirection::In;
+        let dir = ParameterDirection::In;
         let set_params = if let Some(bound) = Bounds::type_for(env, typ, nullable) {
             let r_type = bounds_rust_type(env, typ).into_string();
             let mut bounds = Bounds::default();
@@ -137,7 +151,8 @@ fn analyze_property(
                     dir,
                     nullable,
                     set_in_ref_mode,
-                    library::ParameterScope::None
+                    library::ParameterScope::None,
+                    &TryFromGlib::from_type_defaults(env, typ),
                 )
                 .into_string()
             )
@@ -159,7 +174,7 @@ fn analyze_property(
             to_glib_extra: String::new(),
         })
     } else {
-        let owner_name = rust_type(env, type_tid).into_string();
+        let owner_name = rust_type_default(env, type_tid).into_string();
         error!(
             "Bad type `{}` of child property `{}` for `{}`",
             &prop.type_name, name, owner_name

--- a/src/analysis/class_builder.rs
+++ b/src/analysis/class_builder.rs
@@ -3,8 +3,7 @@ use crate::{
         bounds::Bounds,
         imports::Imports,
         properties::{get_property_ref_modes, Property},
-        rust_type::*,
-        try_from_glib::TryFromGlib,
+        rust_type::RustType,
     },
     config::{self, GObject},
     env::Env,
@@ -102,12 +101,7 @@ fn analyze_property(
         return None;
     }
     let imports = &mut imports.with_defaults(prop_version, &None);
-    let rust_type_res = used_rust_type(
-        env,
-        prop.typ,
-        library::ParameterDirection::Out,
-        &TryFromGlib::default(),
-    );
+    let rust_type_res = RustType::try_new(env, prop.typ);
     if let Ok(ref rust_type) = rust_type_res {
         if !rust_type.as_str().contains("GString") {
             imports.add_used_types(rust_type.used_types());

--- a/src/analysis/constants.rs
+++ b/src/analysis/constants.rs
@@ -47,8 +47,7 @@ pub fn analyze<F: Borrow<library::Constant>>(
         let deprecated_version = constant.deprecated_version;
         let cfg_condition = configured_constants
             .iter()
-            .filter_map(|c| c.cfg_condition.clone())
-            .next();
+            .find_map(|c| c.cfg_condition.clone());
 
         let name = nameutil::mangle_keywords(&*constant.name).into_owned();
 

--- a/src/analysis/function_parameters.rs
+++ b/src/analysis/function_parameters.rs
@@ -1,7 +1,7 @@
 use super::{
     conversion_type::ConversionType, out_parameters::can_as_return,
-    override_string_type::override_string_type_parameter, ref_mode::RefMode,
-    rust_type::rust_type_default, try_from_glib::TryFromGlib,
+    override_string_type::override_string_type_parameter, ref_mode::RefMode, rust_type::RustType,
+    try_from_glib::TryFromGlib,
 };
 use crate::{
     analysis,
@@ -219,6 +219,9 @@ pub fn analyze(
             library::ParameterDirection::In | library::ParameterDirection::InOut => true,
             library::ParameterDirection::Return => false,
             library::ParameterDirection::Out => !can_as_return(env, par) && !async_func,
+            library::ParameterDirection::None => {
+                panic!("undefined direction for parameter {:?}", par)
+            }
         };
 
         if async_func && async_param_to_remove(&par.name) {
@@ -382,7 +385,7 @@ fn get_length_type(
     length_name: &str,
     length_typ: TypeId,
 ) -> TransformationType {
-    let array_length_type = rust_type_default(env, length_typ).into_string();
+    let array_length_type = RustType::try_new(env, length_typ).into_string();
     TransformationType::Length {
         array_name: array_name.to_string(),
         array_length_name: length_name.to_string(),

--- a/src/analysis/function_parameters.rs
+++ b/src/analysis/function_parameters.rs
@@ -192,8 +192,7 @@ pub fn analyze(
 
         let mut array_name = configured_parameters
             .iter()
-            .filter_map(|p| p.length_of.as_ref())
-            .next();
+            .find_map(|p| p.length_of.as_ref());
         if array_name.is_none() {
             array_name = array_lengths.get(&(pos as u32))
         }
@@ -225,10 +224,7 @@ pub fn analyze(
         let ref_mode =
             RefMode::without_unneeded_mut(env, par, immutable, in_trait && par.instance_parameter);
 
-        let nullable_override = configured_parameters
-            .iter()
-            .filter_map(|p| p.nullable)
-            .next();
+        let nullable_override = configured_parameters.iter().find_map(|p| p.nullable);
         let nullable = nullable_override.unwrap_or(par.nullable);
 
         let c_par = CParameter {

--- a/src/analysis/functions.rs
+++ b/src/analysis/functions.rs
@@ -571,6 +571,7 @@ fn analyze_function(
         .filter_map(|f| f.version)
         .min()
         .or(func.version);
+
     let version = env.config.filter_version(version);
     let deprecated_version = func.deprecated_version;
     let cfg_condition = configured_functions

--- a/src/analysis/functions.rs
+++ b/src/analysis/functions.rs
@@ -7,6 +7,7 @@
 
 use crate::{
     analysis::{
+        self,
         bounds::{Bounds, CallbackInfo},
         function_parameters::{self, CParameter, Parameters, Transformation, TransformationType},
         imports::Imports,
@@ -18,10 +19,13 @@ use crate::{
         safety_assertion_mode::SafetyAssertionMode,
         signatures::{Signature, Signatures},
         trampolines::Trampoline,
+        try_from_glib::TryFromGlib,
     },
     config::{self, gobjects::GStatus},
     env::Env,
-    library::{self, Function, FunctionKind, Nullable, Parameter, ParameterScope, Transfer, Type},
+    library::{
+        self, Function, FunctionKind, Nullable, ParameterDirection, ParameterScope, Transfer, Type,
+    },
     nameutil,
     traits::*,
     version::Version,
@@ -55,8 +59,8 @@ pub struct AsyncTrampoline {
     pub finish_func_name: String,
     pub callback_type: String,
     pub bound_name: char,
-    pub output_params: Vec<Parameter>,
-    pub ffi_ret: Option<Parameter>,
+    pub output_params: Vec<analysis::Parameter>,
+    pub ffi_ret: Option<analysis::Parameter>,
 }
 
 #[derive(Clone, Debug)]
@@ -209,7 +213,7 @@ fn fixup_gpointer_parameter(
             transfer: Transfer::None,
             ref_mode: RefMode::ByRef,
             to_glib_extra: String::new(),
-            explicit_target_type: format!("{} {}", pointer_type, ffi_name),
+            explicit_target_type: format!("{} {}", pointer_type, ffi_name.as_str()),
             pointer_cast: format!(
                 " as {}",
                 nameutil::use_glib_if_needed(env, "ffi::gconstpointer")
@@ -273,7 +277,7 @@ fn analyze_callbacks(
     imports: &mut Imports,
     destroys: &mut Vec<Trampoline>,
     callbacks: &mut Vec<Trampoline>,
-    params: &mut Vec<Parameter>,
+    params: &mut Vec<library::Parameter>,
     configured_functions: &[&config::functions::Function],
     disable_length_detect: bool,
     in_trait: bool,
@@ -312,8 +316,8 @@ fn analyze_callbacks(
                 "Wrong instance parameter in {}",
                 func.c_identifier.as_ref().unwrap()
             );
-            if let Ok(s) = used_rust_type(env, par.typ, !par.direction.is_out()) {
-                used_types.push(s);
+            if let Ok(rust_type) = used_rust_type(env, par.typ, par.direction, &par.try_from_glib) {
+                used_types.extend(rust_type.into_used_types());
             }
             let rust_type = env.library.type_(par.typ);
             let callback_info = if !*par.nullable || !rust_type.is_function() {
@@ -412,6 +416,7 @@ fn analyze_callbacks(
                     Nullable(false),
                     RefMode::None,
                     par.scope,
+                    &par.try_from_glib,
                 )
                 .is_err();
             }
@@ -608,7 +613,7 @@ fn analyze_function(
     parameters.analyze_return(env, &ret.parameter);
 
     if let Some(ref f) = ret.parameter {
-        if let Type::Function(_) = env.library.type_(f.typ) {
+        if let Type::Function(_) = env.library.type_(f.lib_par.typ) {
             if env.config.work_mode.is_normal() {
                 warn!("Function \"{}\" returns callback", func.name);
                 commented = true;
@@ -636,9 +641,11 @@ fn analyze_function(
                     "Wrong instance parameter in {}",
                     func.c_identifier.as_ref().unwrap()
                 );
-                if let Ok(s) = used_rust_type(env, par.typ, !par.direction.is_out()) {
-                    if !s.ends_with("GString") || par.c_type == "gchar***" {
-                        used_types.push(s);
+                if let Ok(rust_type) =
+                    used_rust_type(env, par.typ, par.direction, &par.try_from_glib)
+                {
+                    if !rust_type.as_str().ends_with("GString") || par.c_type == "gchar***" {
+                        used_types.extend(rust_type.into_used_types());
                     }
                 }
                 let (to_glib_extra, callback_info) = bounds.add_for_parameter(
@@ -675,6 +682,7 @@ fn analyze_function(
                         Nullable(false),
                         RefMode::None,
                         par.scope,
+                        &par.try_from_glib,
                     )
                     .is_err();
                 if type_error {
@@ -750,7 +758,11 @@ fn analyze_function(
             ref output_params, ..
         }) = trampoline
         {
-            out_parameters::analyze_imports(env, output_params, imports);
+            out_parameters::analyze_imports(
+                env,
+                output_params.iter().map(|out| &out.lib_par),
+                imports,
+            );
         }
     }
 
@@ -760,14 +772,24 @@ fn analyze_function(
         imports.add("std::pin::Pin");
 
         if let Some(ref trampoline) = trampoline {
-            for par in &trampoline.output_params {
-                if let Ok(s) = used_rust_type(env, par.typ, false) {
-                    used_types.push(s);
+            for out in &trampoline.output_params {
+                if let Ok(rust_type) = used_rust_type(
+                    env,
+                    out.lib_par.typ,
+                    ParameterDirection::Out,
+                    &TryFromGlib::default(),
+                ) {
+                    used_types.extend(rust_type.into_used_types());
                 }
             }
-            if let Some(ref par) = trampoline.ffi_ret {
-                if let Ok(s) = used_rust_type(env, par.typ, false) {
-                    used_types.push(s);
+            if let Some(ref out) = trampoline.ffi_ret {
+                if let Ok(rust_type) = used_rust_type(
+                    env,
+                    out.lib_par.typ,
+                    ParameterDirection::Return,
+                    &TryFromGlib::default(),
+                ) {
+                    used_types.extend(rust_type.into_used_types());
                 }
             }
         }
@@ -816,7 +838,8 @@ fn analyze_function(
         status,
         kind: func.kind,
         visibility,
-        type_name: rust_type(env, type_tid),
+        // FIXME what is this type?
+        type_name: rust_type_default(env, type_tid),
         parameters,
         ret,
         bounds,
@@ -886,14 +909,24 @@ fn analyze_async(
                 &func.name,
                 configured_functions,
             ) {
-                ffi_ret = Some(function.ret.clone());
+                ffi_ret = Some(analysis::Parameter::from_return_value(
+                    env,
+                    &function.ret,
+                    &configured_functions,
+                ));
             }
 
-            output_params.extend(function.parameters.clone());
-            for param in &mut output_params {
+            for param in &function.parameters {
+                let mut lib_par = param.clone();
                 if nameutil::needs_mangling(&param.name) {
-                    param.name = nameutil::mangle_keywords(&*param.name).into_owned();
+                    lib_par.name = nameutil::mangle_keywords(&*param.name).into_owned();
                 }
+                let configured_parameters = configured_functions.matched_parameters(&lib_par.name);
+                output_params.push(analysis::Parameter::from_parameter(
+                    env,
+                    &lib_par,
+                    &configured_parameters,
+                ));
             }
         }
         if trampoline.is_some() || async_future.is_some() {
@@ -1049,13 +1082,18 @@ fn analyze_callback(
             });
         }
         for p in parameters.rust_parameters.iter() {
-            if let Ok(s) = used_rust_type(env, p.typ, false) {
-                imports_to_add.push(s);
+            if let Ok(rust_type) = used_rust_type(env, p.typ, p.direction, &p.try_from_glib) {
+                imports_to_add.extend(rust_type.into_used_types());
             }
         }
-        if let Ok(s) = used_rust_type(env, func.ret.typ, false) {
-            if !s.ends_with("GString") {
-                imports_to_add.push(s);
+        if let Ok(rust_type) = used_rust_type(
+            env,
+            func.ret.typ,
+            ParameterDirection::Return,
+            &TryFromGlib::default(),
+        ) {
+            if !rust_type.as_str().ends_with("GString") {
+                imports_to_add.extend(rust_type.into_used_types());
             }
         }
         let user_data_index = par.user_data_index.unwrap_or(0);
@@ -1096,12 +1134,14 @@ fn analyze_callback(
                         None => match rust_type_full(
                             env,
                             par.typ,
+                            par.direction,
                             par.nullable,
                             RefMode::None,
                             par.scope,
                             library::Concurrency::None,
+                            &TryFromGlib::default(),
                         ) {
-                            Ok(s) => s,
+                            Ok(rust_type) => rust_type.into_string(),
                             Err(_) => {
                                 warn_main!(type_tid, "`{}`: unknown type", func.name);
                                 return None;
@@ -1174,9 +1214,12 @@ pub fn finish_function_name(mut func_name: &str) -> String {
     format!("{}_finish", &func_name)
 }
 
-pub fn find_index_to_ignore(parameters: &[Parameter], ret: Option<&Parameter>) -> Option<usize> {
+pub fn find_index_to_ignore<'a>(
+    parameters: impl IntoIterator<Item = &'a library::Parameter>,
+    ret: Option<&'a library::Parameter>,
+) -> Option<usize> {
     parameters
-        .iter()
+        .into_iter()
         .chain(ret)
         .find(|param| param.array_length.is_some())
         .and_then(|param| param.array_length.map(|length| length as usize))

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -17,6 +17,7 @@ pub mod enums;
 pub mod ffi_type;
 pub mod flags;
 pub mod function_parameters;
+pub use function_parameters::Parameter;
 pub mod functions;
 pub mod general;
 pub mod imports;
@@ -39,6 +40,7 @@ pub mod supertypes;
 pub mod symbols;
 pub mod trampoline_parameters;
 pub mod trampolines;
+pub mod try_from_glib;
 pub mod types;
 
 #[derive(Debug, Default)]

--- a/src/analysis/out_parameters.rs
+++ b/src/analysis/out_parameters.rs
@@ -54,10 +54,7 @@ pub fn analyze(
     let mut info: Info = Default::default();
     let mut unsupported_outs = false;
 
-    let nullable_override = configured_functions
-        .iter()
-        .filter_map(|f| f.ret.nullable)
-        .next();
+    let nullable_override = configured_functions.iter().find_map(|f| f.ret.nullable);
     if func.throws {
         let use_ret = use_return_value_for_result(env, func_ret, &func.name, configured_functions);
         info.mode = Mode::Throws(use_ret);
@@ -182,8 +179,7 @@ pub fn use_function_return_for_result(
     // Configuration takes precendence over everything.
     let use_return_for_result = configured_functions
         .iter()
-        .filter_map(|f| f.ret.use_return_for_result.as_ref())
-        .next();
+        .find_map(|f| f.ret.use_return_for_result.as_ref());
     if let Some(use_return_for_result) = use_return_for_result {
         if typ == Default::default() {
             error!("Function \"{}\": use_return_for_result set to true, but function has no return value", func_name);

--- a/src/analysis/out_parameters.rs
+++ b/src/analysis/out_parameters.rs
@@ -1,8 +1,8 @@
 use crate::{
     analysis::{
         self, conversion_type::ConversionType, function_parameters::CParameter,
-        functions::is_carray_with_direct_elements, imports::Imports, ref_mode::RefMode,
-        return_value, rust_type::parameter_rust_type, try_from_glib::TryFromGlib,
+        functions::is_carray_with_direct_elements, imports::Imports, return_value,
+        rust_type::RustType,
     },
     config::{self, parameter_matchable::ParameterMatchable},
     env::Env,
@@ -162,16 +162,11 @@ pub fn can_as_return(env: &Env, par: &library::Parameter) -> bool {
                 return false;
             }
 
-            parameter_rust_type(
-                env,
-                par.typ,
-                ParameterDirection::Out,
-                Nullable(false),
-                RefMode::None,
-                par.scope,
-                &TryFromGlib::default(),
-            )
-            .is_ok()
+            RustType::builder(env, par.typ)
+                .with_direction(ParameterDirection::Out)
+                .with_scope(par.scope)
+                .try_build_param()
+                .is_ok()
         }
         Borrow => false,
         Unknown => false,

--- a/src/analysis/override_string_type.rs
+++ b/src/analysis/override_string_type.rs
@@ -6,10 +6,7 @@ pub fn override_string_type_parameter(
     typ: TypeId,
     configured_parameters: &[&config::functions::Parameter],
 ) -> TypeId {
-    let string_type = configured_parameters
-        .iter()
-        .filter_map(|p| p.string_type)
-        .next();
+    let string_type = configured_parameters.iter().find_map(|p| p.string_type);
     apply(env, typ, string_type)
 }
 
@@ -18,10 +15,7 @@ pub fn override_string_type_return(
     typ: TypeId,
     configured_functions: &[&config::functions::Function],
 ) -> TypeId {
-    let string_type = configured_functions
-        .iter()
-        .filter_map(|f| f.ret.string_type)
-        .next();
+    let string_type = configured_functions.iter().find_map(|f| f.ret.string_type);
     apply(env, typ, string_type)
 }
 

--- a/src/analysis/properties.rs
+++ b/src/analysis/properties.rs
@@ -106,10 +106,7 @@ fn analyze_property(
         .min()
         .or(prop.version)
         .or(Some(env.config.min_cfg_version));
-    let generate = configured_properties
-        .iter()
-        .filter_map(|f| f.generate)
-        .next();
+    let generate = configured_properties.iter().find_map(|f| f.generate);
     let generate_set = generate.is_some();
     let generate = generate.unwrap_or_else(PropertyGenerateFlags::all);
 

--- a/src/analysis/properties.rs
+++ b/src/analysis/properties.rs
@@ -3,11 +3,10 @@ use crate::{
         bounds::{Bounds, PropertyBound},
         imports::Imports,
         ref_mode::RefMode,
-        rust_type::*,
+        rust_type::RustType,
         signals,
         signatures::{Signature, Signatures},
         trampolines,
-        try_from_glib::TryFromGlib,
     },
     config::{self, GObject, PropertyGenerateFlags},
     env::Env,
@@ -114,7 +113,7 @@ fn analyze_property(
     let imports = &mut imports.with_defaults(prop_version, &None);
     imports.add("glib::translate::*");
 
-    let type_string = rust_type_default(env, prop.typ);
+    let type_string = RustType::try_new(env, prop.typ);
     let name_for_func = nameutil::signal_to_snake(&name);
 
     let mut get_prop_name = Some(format!("get_property_{}", name_for_func));
@@ -207,12 +206,10 @@ fn analyze_property(
     let (get_out_ref_mode, set_in_ref_mode, nullable) = get_property_ref_modes(env, prop);
 
     let getter = if readable {
-        if let Ok(rust_type) = used_rust_type(
-            env,
-            prop.typ,
-            library::ParameterDirection::Out,
-            &TryFromGlib::default(),
-        ) {
+        if let Ok(rust_type) = RustType::builder(env, prop.typ)
+            .with_direction(library::ParameterDirection::Out)
+            .try_build()
+        {
             imports.add_used_types(rust_type.used_types());
         }
         if type_string.is_ok() {
@@ -239,12 +236,10 @@ fn analyze_property(
     };
 
     let setter = if writable {
-        if let Ok(rust_type) = used_rust_type(
-            env,
-            prop.typ,
-            library::ParameterDirection::In,
-            &TryFromGlib::default(),
-        ) {
+        if let Ok(rust_type) = RustType::builder(env, prop.typ)
+            .with_direction(library::ParameterDirection::In)
+            .try_build()
+        {
             imports.add_used_types(rust_type.used_types());
         }
         if type_string.is_ok() {

--- a/src/analysis/return_value.rs
+++ b/src/analysis/return_value.rs
@@ -29,8 +29,7 @@ pub fn analyze(
 ) -> Info {
     let typ = configured_functions
         .iter()
-        .filter_map(|f| f.ret.type_name.as_ref())
-        .next()
+        .find_map(|f| f.ret.type_name.as_ref())
         .and_then(|typ| env.library.find_type(0, typ))
         .unwrap_or_else(|| override_string_type_return(env, func.ret.typ, configured_functions));
     let mut parameter = if typ == Default::default() {
@@ -49,10 +48,7 @@ pub fn analyze(
             }
         }
 
-        let nullable_override = configured_functions
-            .iter()
-            .filter_map(|f| f.ret.nullable)
-            .next();
+        let nullable_override = configured_functions.iter().find_map(|f| f.ret.nullable);
         if let Some(val) = nullable_override {
             nullable = val;
         }
@@ -79,8 +75,7 @@ pub fn analyze(
 
     let bool_return_is_error = configured_functions
         .iter()
-        .filter_map(|f| f.ret.bool_return_is_error.as_ref())
-        .next();
+        .find_map(|f| f.ret.bool_return_is_error.as_ref());
     let bool_return_error_message = bool_return_is_error.and_then(|m| {
         if typ != TypeId::tid_bool() {
             error!(
@@ -102,8 +97,7 @@ pub fn analyze(
 
     let nullable_return_is_error = configured_functions
         .iter()
-        .filter_map(|f| f.ret.nullable_return_is_error.as_ref())
-        .next();
+        .find_map(|f| f.ret.nullable_return_is_error.as_ref());
     let nullable_return_error_message = nullable_return_is_error.and_then(|m| {
         if let Some(library::Parameter { nullable: Nullable(false), ..}) = parameter {
             error!(
@@ -127,10 +121,7 @@ pub fn analyze(
 
     if func.kind == library::FunctionKind::Constructor {
         if let Some(par) = parameter {
-            let nullable_override = configured_functions
-                .iter()
-                .filter_map(|f| f.ret.nullable)
-                .next();
+            let nullable_override = configured_functions.iter().find_map(|f| f.ret.nullable);
             if par.typ != type_tid {
                 base_tid = Some(par.typ);
             }

--- a/src/analysis/rust_type.rs
+++ b/src/analysis/rust_type.rs
@@ -16,6 +16,7 @@ pub enum TypeError {
     Unimplemented(String),
 }
 
+/// A `RustType` definition and its associated types to be `use`d.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct RustType {
     inner: String,
@@ -23,6 +24,16 @@ pub struct RustType {
 }
 
 impl RustType {
+    /// Try building the `RustType` with no specific additional configuration.
+    pub fn try_new(env: &Env, type_id: library::TypeId) -> Result {
+        RustTypeBuilder::new(env, type_id).try_build()
+    }
+
+    /// Create a `RustTypeBuilder` which allows specifying additional configuration.
+    pub fn builder(env: &Env, type_id: library::TypeId) -> RustTypeBuilder<'_> {
+        RustTypeBuilder::new(env, type_id)
+    }
+
     fn new_and_use(rust_type: impl ToString) -> Self {
         RustType {
             inner: rust_type.to_string(),
@@ -169,534 +180,473 @@ impl MapAny<RustType> for Result {
     }
 }
 
-pub fn rust_type(
-    env: &Env,
-    type_id: library::TypeId,
-    direction: ParameterDirection,
-    // FIXME probably could just use ConversionType
-    // and embed TryFromGlib in it so that would be easier to evolve
-    try_from_glib: &TryFromGlib,
-) -> Result {
-    rust_type_full(
-        env,
-        type_id,
-        direction,
-        Nullable(false),
-        RefMode::None,
-        ParameterScope::None,
-        library::Concurrency::None,
-        try_from_glib,
-    )
-}
-
-pub fn rust_type_default(env: &Env, type_id: library::TypeId) -> Result {
-    rust_type_full(
-        env,
-        type_id,
-        ParameterDirection::InOut,
-        Nullable(false),
-        RefMode::None,
-        ParameterScope::None,
-        library::Concurrency::None,
-        &TryFromGlib::default(),
-    )
-}
-
-pub fn rust_type_nullable(
-    env: &Env,
-    type_id: library::TypeId,
-    direction: ParameterDirection,
-    nullable: Nullable,
-    try_from_glib: &TryFromGlib,
-) -> Result {
-    rust_type_full(
-        env,
-        type_id,
-        direction,
-        nullable,
-        RefMode::None,
-        ParameterScope::None,
-        library::Concurrency::None,
-        try_from_glib,
-    )
-}
-
-pub fn rust_type_with_scope(
-    env: &Env,
-    type_id: library::TypeId,
-    direction: ParameterDirection,
-    scope: ParameterScope,
-    concurrency: library::Concurrency,
-    try_from_glib: &TryFromGlib,
-) -> Result {
-    rust_type_full(
-        env,
-        type_id,
-        // FIXME could be default()?
-        direction,
-        Nullable(false),
-        RefMode::None,
-        scope,
-        concurrency,
-        try_from_glib,
-    )
-}
-
-pub fn bounds_rust_type(env: &Env, type_id: library::TypeId) -> Result {
-    rust_type_full(
-        env,
-        type_id,
-        ParameterDirection::InOut,
-        Nullable(false),
-        RefMode::ByRefFake,
-        ParameterScope::None,
-        library::Concurrency::None,
-        &TryFromGlib::default(),
-    )
-}
-
-pub fn rust_type_full(
-    env: &Env,
+pub struct RustTypeBuilder<'env> {
+    env: &'env Env,
     type_id: library::TypeId,
     direction: ParameterDirection,
     nullable: Nullable,
     ref_mode: RefMode,
     scope: ParameterScope,
     concurrency: library::Concurrency,
-    // FIXME probably could just use ConversionType
-    // and embed TryFromGlib in it so that would be easier to evolve
-    try_from_glib: &TryFromGlib,
-) -> Result {
-    use crate::library::{Fundamental::*, Type::*};
-    let ok = |s: &str| Ok(RustType::from(s));
-    let ok_and_use = |s: &str| Ok(RustType::new_and_use(s));
-    let err = |s: &str| Err(TypeError::Unimplemented(s.into()));
-    let mut skip_option = false;
-    let type_ = env.library.type_(type_id);
-    let mut rust_type = match *type_ {
-        Fundamental(fund) => {
-            match fund {
-                None => err("()"),
-                Boolean => ok("bool"),
-                Int8 => ok("i8"),
-                UInt8 => ok("u8"),
-                Int16 => ok("i16"),
-                UInt16 => ok("u16"),
-                Int32 => ok("i32"),
-                UInt32 => ok("u32"),
-                Int64 => ok("i64"),
-                UInt64 => ok("u64"),
+    try_from_glib: TryFromGlib,
+}
 
-                Int => ok("i32"),  //maybe dependent on target system
-                UInt => ok("u32"), //maybe dependent on target system
+impl<'env> RustTypeBuilder<'env> {
+    fn new(env: &'env Env, type_id: library::TypeId) -> Self {
+        RustTypeBuilder {
+            env,
+            type_id,
+            direction: ParameterDirection::None,
+            nullable: Nullable(false),
+            ref_mode: RefMode::None,
+            scope: ParameterScope::None,
+            concurrency: library::Concurrency::None,
+            try_from_glib: TryFromGlib::default(),
+        }
+    }
 
-                Short => ok_and_use("libc::c_short"), //depends of target system
-                UShort => ok_and_use("libc::c_ushort"), //depends o f target system
-                Long => ok_and_use("libc::c_long"),   //depends of target system
-                ULong => ok_and_use("libc::c_ulong"), //depends of target system
+    pub fn with_direction(mut self, direction: ParameterDirection) -> Self {
+        self.direction = direction;
+        self
+    }
 
-                Size => ok("usize"),  //depends of target system
-                SSize => ok("isize"), //depends of target system
+    pub fn with_nullable(mut self, nullable: Nullable) -> Self {
+        self.nullable = nullable;
+        self
+    }
 
-                Float => ok("f32"),
-                Double => ok("f64"),
+    pub fn with_ref_mode(mut self, ref_mode: RefMode) -> Self {
+        self.ref_mode = ref_mode;
+        self
+    }
 
-                UniChar => ok("char"),
-                Utf8 => {
-                    if ref_mode.is_ref() {
-                        ok("str")
-                    } else {
-                        ok_and_use(&use_glib_type(env, "GString"))
+    pub fn with_scope(mut self, scope: ParameterScope) -> Self {
+        self.scope = scope;
+        self
+    }
+
+    pub fn with_concurrency(mut self, concurrency: library::Concurrency) -> Self {
+        self.concurrency = concurrency;
+        self
+    }
+
+    pub fn with_try_from_glib(mut self, try_from_glib: &TryFromGlib) -> Self {
+        self.try_from_glib = try_from_glib.clone();
+        self
+    }
+
+    pub fn try_build(self) -> Result {
+        use crate::library::{Fundamental::*, Type::*};
+        let ok = |s: &str| Ok(RustType::from(s));
+        let ok_and_use = |s: &str| Ok(RustType::new_and_use(s));
+        let err = |s: &str| Err(TypeError::Unimplemented(s.into()));
+        let mut skip_option = false;
+        let type_ = self.env.library.type_(self.type_id);
+        let mut rust_type = match *type_ {
+            Fundamental(fund) => {
+                match fund {
+                    None => err("()"),
+                    Boolean => ok("bool"),
+                    Int8 => ok("i8"),
+                    UInt8 => ok("u8"),
+                    Int16 => ok("i16"),
+                    UInt16 => ok("u16"),
+                    Int32 => ok("i32"),
+                    UInt32 => ok("u32"),
+                    Int64 => ok("i64"),
+                    UInt64 => ok("u64"),
+
+                    Int => ok("i32"),  //maybe dependent on target system
+                    UInt => ok("u32"), //maybe dependent on target system
+
+                    Short => ok_and_use("libc::c_short"), //depends of target system
+                    UShort => ok_and_use("libc::c_ushort"), //depends o f target system
+                    Long => ok_and_use("libc::c_long"),   //depends of target system
+                    ULong => ok_and_use("libc::c_ulong"), //depends of target system
+
+                    Size => ok("usize"),  //depends of target system
+                    SSize => ok("isize"), //depends of target system
+
+                    Float => ok("f32"),
+                    Double => ok("f64"),
+
+                    UniChar => ok("char"),
+                    Utf8 => {
+                        if self.ref_mode.is_ref() {
+                            ok("str")
+                        } else {
+                            ok_and_use(&use_glib_type(&self.env, "GString"))
+                        }
                     }
-                }
-                Filename => {
-                    if ref_mode.is_ref() {
-                        ok_and_use("std::path::Path")
-                    } else {
-                        ok_and_use("std::path::PathBuf")
+                    Filename => {
+                        if self.ref_mode.is_ref() {
+                            ok_and_use("std::path::Path")
+                        } else {
+                            ok_and_use("std::path::PathBuf")
+                        }
                     }
-                }
-                OsString => {
-                    if ref_mode.is_ref() {
-                        ok_and_use("std::ffi::OsStr")
-                    } else {
-                        ok_and_use("std::ffi::OsString")
+                    OsString => {
+                        if self.ref_mode.is_ref() {
+                            ok_and_use("std::ffi::OsStr")
+                        } else {
+                            ok_and_use("std::ffi::OsString")
+                        }
                     }
+                    Type => ok_and_use(&use_glib_type(self.env, "types::Type")),
+                    Char => ok_and_use(&use_glib_type(self.env, "Char")),
+                    UChar => ok_and_use(&use_glib_type(self.env, "UChar")),
+                    Unsupported => err("Unsupported"),
+                    _ => err(&format!("Fundamental: {:?}", fund)),
                 }
-                Type => ok_and_use(&use_glib_type(env, "types::Type")),
-                Char => ok_and_use(&use_glib_type(env, "Char")),
-                UChar => ok_and_use(&use_glib_type(env, "UChar")),
-                Unsupported => err("Unsupported"),
-                _ => err(&format!("Fundamental: {:?}", fund)),
             }
-        }
-        Alias(ref alias) => {
-            RustType::try_new_and_use(env, type_id)
-                .and_then(|alias_rust_type| {
-                    rust_type_full(
-                        env,
-                        alias.typ,
-                        direction,
-                        nullable,
-                        ref_mode,
-                        scope,
-                        concurrency,
-                        try_from_glib,
-                    ).map_any(|_| alias_rust_type)
+            Alias(ref alias) => {
+                RustType::try_new_and_use(self.env, self.type_id).and_then(|alias_rust_type| {
+                    RustType::builder(&self.env, alias.typ)
+                        .with_direction(self.direction)
+                        .with_nullable(self.nullable)
+                        .with_ref_mode(self.ref_mode)
+                        .with_scope(self.scope)
+                        .with_concurrency(self.concurrency)
+                        .with_try_from_glib(&self.try_from_glib)
+                        .try_build()
+                        .map_any(|_| alias_rust_type)
                 })
-        }
-        Record(library::Record { ref c_type, .. }) if c_type == "GVariantType" => {
-            let type_name = if ref_mode.is_ref() {
-                "VariantTy"
-            } else {
-                "VariantType"
-            };
-            RustType::try_new_and_use_with_name(env, type_id, type_name)
-        }
-        Enumeration(..) | Bitfield(..) | Record(..) | Union(..) | Class(..) | Interface(..) => {
-            RustType::try_new_and_use(env, type_id)
-                .and_then(|rust_type| {
-                    if env.type_status(&type_id.full_name(&env.library)).ignored() {
+            }
+            Record(library::Record { ref c_type, .. }) if c_type == "GVariantType" => {
+                let type_name = if self.ref_mode.is_ref() {
+                    "VariantTy"
+                } else {
+                    "VariantType"
+                };
+                RustType::try_new_and_use_with_name(self.env, self.type_id, type_name)
+            }
+            Enumeration(..) | Bitfield(..) | Record(..) | Union(..) | Class(..) | Interface(..) => {
+                RustType::try_new_and_use(self.env, self.type_id).and_then(|rust_type| {
+                    if self
+                        .env
+                        .type_status(&self.type_id.full_name(&self.env.library))
+                        .ignored()
+                    {
                         Err(TypeError::Ignored(rust_type.into_string()))
                     } else {
                         Ok(rust_type)
                     }
                 })
-        }
-        List(inner_tid) | SList(inner_tid) | CArray(inner_tid) | PtrArray(inner_tid)
-            // FIXME these invocations of ConversionType::of could use the provided argument
-            if ConversionType::of(env, inner_tid) == ConversionType::Pointer =>
-        {
-            skip_option = true;
-            let inner_ref_mode = match *env.library.type_(inner_tid) {
-                Class(..) | Interface(..) => RefMode::None,
-                _ => ref_mode,
-            };
-            rust_type_full(
-                env,
-                inner_tid,
-                direction,
-                Nullable(false),
-                inner_ref_mode,
-                scope,
-                concurrency,
-                &TryFromGlib::default(),
-            )
-            .map_any(|rust_type| {
-                if ref_mode.is_ref() {
-                    format!("[{}]", rust_type.as_str()).into()
-                } else {
-                    format!("Vec<{}>", rust_type.as_str()).into()
-                }
-            })
-        }
-        CArray(inner_tid) if ConversionType::of(env, inner_tid) == ConversionType::Direct => {
-            if let Fundamental(fund) = *env.library.type_(inner_tid) {
-                let array_type = match fund {
-                    Int8 => Some("i8"),
-                    UInt8 => Some("u8"),
-                    Int16 => Some("i16"),
-                    UInt16 => Some("u16"),
-                    Int32 => Some("i32"),
-                    UInt32 => Some("u32"),
-                    Int64 => Some("i64"),
-                    UInt64 => Some("u64"),
-
-                    Int => Some("i32"),  //maybe dependent on target system
-                    UInt => Some("u32"), //maybe dependent on target system
-
-                    Float => Some("f32"),
-                    Double => Some("f64"),
-                    _ => Option::None,
+            }
+            List(inner_tid) | SList(inner_tid) | CArray(inner_tid) | PtrArray(inner_tid)
+                if ConversionType::of(self.env, inner_tid) == ConversionType::Pointer =>
+            {
+                skip_option = true;
+                let inner_ref_mode = match *self.env.library.type_(inner_tid) {
+                    Class(..) | Interface(..) => RefMode::None,
+                    _ => self.ref_mode,
                 };
+                RustType::builder(&self.env, inner_tid)
+                    .with_ref_mode(inner_ref_mode)
+                    .with_scope(self.scope)
+                    .with_concurrency(self.concurrency)
+                    .try_build()
+                    .map_any(|rust_type| {
+                        rust_type.alter_type(|typ| {
+                            if self.ref_mode.is_ref() {
+                                format!("[{}]", typ)
+                            } else {
+                                format!("Vec<{}>", typ)
+                            }
+                        })
+                    })
+            }
+            CArray(inner_tid)
+                if ConversionType::of(self.env, inner_tid) == ConversionType::Direct =>
+            {
+                if let Fundamental(fund) = *self.env.library.type_(inner_tid) {
+                    let array_type = match fund {
+                        Int8 => Some("i8"),
+                        UInt8 => Some("u8"),
+                        Int16 => Some("i16"),
+                        UInt16 => Some("u16"),
+                        Int32 => Some("i32"),
+                        UInt32 => Some("u32"),
+                        Int64 => Some("i64"),
+                        UInt64 => Some("u64"),
 
-                if let Some(s) = array_type {
-                    skip_option = true;
-                    if ref_mode.is_ref() {
-                        Ok(format!("[{}]", s).into())
+                        Int => Some("i32"),  //maybe dependent on target system
+                        UInt => Some("u32"), //maybe dependent on target system
+
+                        Float => Some("f32"),
+                        Double => Some("f64"),
+                        _ => Option::None,
+                    };
+
+                    if let Some(s) = array_type {
+                        skip_option = true;
+                        if self.ref_mode.is_ref() {
+                            Ok(format!("[{}]", s).into())
+                        } else {
+                            Ok(format!("Vec<{}>", s).into())
+                        }
                     } else {
-                        Ok(format!("Vec<{}>", s).into())
+                        Err(TypeError::Unimplemented(type_.get_name()))
                     }
                 } else {
                     Err(TypeError::Unimplemented(type_.get_name()))
                 }
-            } else {
-                Err(TypeError::Unimplemented(type_.get_name()))
             }
-        }
-        Custom(library::Custom { ref name, .. }) => RustType::try_new_and_use_with_name(env, type_id, name),
-        Function(ref f) => {
-            let concurrency = match concurrency {
-                _ if scope.is_call() => "",
-                library::Concurrency::Send | library::Concurrency::SendUnique => " + Send",
-                // If an object is Sync, it can be shared between threads, and as
-                // such our callback can be called from arbitrary threads and needs
-                // to be Send *AND* Sync
-                library::Concurrency::SendSync => " + Send + Sync",
-                library::Concurrency::None => "",
-            };
+            Custom(library::Custom { ref name, .. }) => {
+                RustType::try_new_and_use_with_name(&self.env, self.type_id, name)
+            }
+            Function(ref f) => {
+                let concurrency = match self.concurrency {
+                    _ if self.scope.is_call() => "",
+                    library::Concurrency::Send | library::Concurrency::SendUnique => " + Send",
+                    // If an object is Sync, it can be shared between threads, and as
+                    // such our callback can be called from arbitrary threads and needs
+                    // to be Send *AND* Sync
+                    library::Concurrency::SendSync => " + Send + Sync",
+                    library::Concurrency::None => "",
+                };
 
-            let full_name = type_id.full_name(&env.library);
-            if full_name == "Gio.AsyncReadyCallback" {
-                // FIXME need to use the result from use_glib_type(env, "Error")?
-                return Ok(format!(
-                    "FnOnce(Result<(), {}>) + 'static",
-                    use_glib_type(env, "Error"),
-                ).into());
-            } else if full_name == "GLib.DestroyNotify" {
-                return Ok(format!("Fn(){} + 'static", concurrency).into());
-            }
-            let mut params = Vec::with_capacity(f.parameters.len());
-            let mut err = false;
-            for p in f.parameters.iter() {
-                if p.closure.is_some() {
-                    continue;
+                let full_name = self.type_id.full_name(&self.env.library);
+                if full_name == "Gio.AsyncReadyCallback" {
+                    // FIXME need to use the result from use_glib_type(&self.env, "Error")?
+                    return Ok(format!(
+                        "FnOnce(Result<(), {}>) + 'static",
+                        use_glib_type(&self.env, "Error"),
+                    )
+                    .into());
+                } else if full_name == "GLib.DestroyNotify" {
+                    return Ok(format!("Fn(){} + 'static", concurrency).into());
                 }
-                match rust_type_nullable(env, p.typ, p.direction, p.nullable, &TryFromGlib::default()) {
-                    Ok(p_rust_type) => {
-                        let is_fundamental = p.typ.is_fundamental_type(env);
-                        let y = rust_type_default(env, p.typ).unwrap_or_else(|_| RustType::default());
-                        params.push(format!(
-                            "{}{}",
-                            if is_fundamental || *p.nullable {
-                                ""
-                            } else {
-                                "&"
-                            },
-                            if !is_gstring(y.as_str()) {
-                                if !is_fundamental && *p.nullable {
-                                    p_rust_type.into_string().replace("Option<", "Option<&")
+                let mut params = Vec::with_capacity(f.parameters.len());
+                let mut err = false;
+                for p in f.parameters.iter() {
+                    if p.closure.is_some() {
+                        continue;
+                    }
+
+                    let p_res = RustType::builder(&self.env, p.typ)
+                        .with_direction(p.direction)
+                        .with_nullable(p.nullable)
+                        .try_build();
+                    match p_res {
+                        Ok(p_rust_type) => {
+                            let is_fundamental = p.typ.is_fundamental_type(&self.env);
+                            let y = RustType::try_new(&self.env, p.typ)
+                                .unwrap_or_else(|_| RustType::default());
+                            params.push(format!(
+                                "{}{}",
+                                if is_fundamental || *p.nullable {
+                                    ""
                                 } else {
-                                    p_rust_type.into_string()
+                                    "&"
+                                },
+                                if !is_gstring(y.as_str()) {
+                                    if !is_fundamental && *p.nullable {
+                                        p_rust_type.into_string().replace("Option<", "Option<&")
+                                    } else {
+                                        p_rust_type.into_string()
+                                    }
+                                } else if *p.nullable {
+                                    "Option<&str>".to_owned()
+                                } else {
+                                    "&str".to_owned()
                                 }
-                            } else if *p.nullable {
-                                "Option<&str>".to_owned()
+                            ));
+                        }
+                        e => {
+                            err = true;
+                            params.push(e.into_string());
+                        }
+                    }
+                }
+                let closure_kind = if self.scope.is_call() {
+                    "FnMut"
+                } else if self.scope.is_async() {
+                    "FnOnce"
+                } else {
+                    "Fn"
+                };
+                let ret_res = RustType::builder(&self.env, f.ret.typ)
+                    .with_direction(f.ret.direction)
+                    .with_nullable(f.ret.nullable)
+                    .try_build();
+                let ret = match ret_res {
+                    Ok(ret_rust_type) => {
+                        let y = RustType::try_new(&self.env, f.ret.typ)
+                            .unwrap_or_else(|_| RustType::default());
+                        format!(
+                            "{}({}) -> {}{}",
+                            closure_kind,
+                            params.join(", "),
+                            if !is_gstring(&y.as_str()) {
+                                ret_rust_type.as_str()
+                            } else if *f.ret.nullable {
+                                "Option<String>"
                             } else {
-                                "&str".to_owned()
-                            }
-                        ));
+                                "String"
+                            },
+                            concurrency
+                        )
+                    }
+                    Err(TypeError::Unimplemented(ref x)) if x == "()" => {
+                        format!("{}({}){}", closure_kind, params.join(", "), concurrency)
                     }
                     e => {
                         err = true;
-                        params.push(e.into_string());
+                        format!(
+                            "{}({}) -> {}{}",
+                            closure_kind,
+                            params.join(", "),
+                            e.into_string(),
+                            concurrency
+                        )
                     }
+                };
+                if err {
+                    return Err(TypeError::Unimplemented(ret));
                 }
-            }
-            let closure_kind = if scope.is_call() {
-                "FnMut"
-            } else if scope.is_async() {
-                "FnOnce"
-            } else {
-                "Fn"
-            };
-            let ret = match rust_type_nullable(env, f.ret.typ, f.ret.direction, f.ret.nullable, &TryFromGlib::default()) {
-                Ok(ret_rust_type) => {
-                    let y = rust_type_default(env, f.ret.typ).unwrap_or_else(|_| RustType::default());
-                    format!(
-                        "{}({}) -> {}{}",
-                        closure_kind,
-                        params.join(", "),
-                        if !is_gstring(&y.as_str()) {
-                            ret_rust_type.as_str()
-                        } else if *f.ret.nullable {
-                            "Option<String>"
-                        } else {
-                            "String"
-                        },
-                        concurrency
-                    )
-                }
-                Err(TypeError::Unimplemented(ref x)) if x == "()" => {
-                    format!("{}({}){}", closure_kind, params.join(", "), concurrency)
-                }
-                e => {
-                    err = true;
-                    format!(
-                        "{}({}) -> {}{}",
-                        closure_kind,
-                        params.join(", "),
-                        e.into_string(),
-                        concurrency
-                    )
-                }
-            };
-            if err {
-                return Err(TypeError::Unimplemented(ret));
-            }
-            Ok(if *nullable {
-                if scope.is_call() {
-                    format!("Option<&mut dyn ({})>", ret)
+                Ok(if *self.nullable {
+                    if self.scope.is_call() {
+                        format!("Option<&mut dyn ({})>", ret)
+                    } else {
+                        format!("Option<Box_<dyn {} + 'static>>", ret)
+                    }
                 } else {
-                    format!("Option<Box_<dyn {} + 'static>>", ret)
+                    format!(
+                        "{}{}",
+                        ret,
+                        if self.scope.is_call() {
+                            ""
+                        } else {
+                            " + 'static"
+                        }
+                    )
                 }
-            } else {
-                format!("{}{}", ret, if scope.is_call() { "" } else { " + 'static" })
-            }.into())
-        }
-        _ => Err(TypeError::Unimplemented(type_.get_name())),
-    };
+                .into())
+            }
+            _ => Err(TypeError::Unimplemented(type_.get_name())),
+        };
 
-    match try_from_glib.or_type_defaults(env, type_id).borrow() {
-        TryFromGlib::Option => {
-            rust_type = rust_type.map_any(|rust_type| {
-                rust_type
-                    .alter_type(|typ_| format!("Option<{}>", typ_))
-                    .apply_ref_mode(ref_mode)
-            });
+        match self
+            .try_from_glib
+            .or_type_defaults(&self.env, self.type_id)
+            .borrow()
+        {
+            TryFromGlib::Option => {
+                rust_type = rust_type.map_any(|rust_type| {
+                    rust_type
+                        .alter_type(|typ_| format!("Option<{}>", typ_))
+                        .apply_ref_mode(self.ref_mode)
+                });
+            }
+            TryFromGlib::Result { ok_type, err_type } if !self.direction.is_in() => {
+                rust_type = rust_type.map_any(|_| {
+                    RustType::new_with_uses(
+                        format!("Result<{}, {}>", &ok_type, &err_type),
+                        &[ok_type, err_type],
+                    )
+                });
+            }
+            TryFromGlib::ResultInfallible { ok_type } => {
+                let new_rust_type = RustType::new_and_use(ok_type).apply_ref_mode(self.ref_mode);
+                rust_type = rust_type.map_any(|_| new_rust_type);
+            }
+            _ => {
+                rust_type = rust_type.map_any(|rust_type| rust_type.apply_ref_mode(self.ref_mode));
+            }
         }
-        TryFromGlib::Result { ok_type, err_type } if !direction.is_in() => {
-            rust_type = rust_type.map_any(|_| {
-                RustType::new_with_uses(
-                    format!("Result<{}, {}>", &ok_type, &err_type),
-                    &[ok_type, err_type],
-                )
-            });
+
+        if *self.nullable && !skip_option {
+            match ConversionType::of(&self.env, self.type_id) {
+                ConversionType::Pointer | ConversionType::Scalar => {
+                    rust_type = rust_type.map_any(|rust_type| {
+                        rust_type.alter_type(|typ_| format!("Option<{}>", typ_))
+                    });
+                }
+                _ => (),
+            }
         }
-        TryFromGlib::ResultInfallible { ok_type } => {
-            let new_rust_type = RustType::new_and_use(ok_type).apply_ref_mode(ref_mode);
-            rust_type = rust_type.map_any(|_| new_rust_type);
-        }
-        _ => {
-            rust_type = rust_type.map_any(|rust_type| rust_type.apply_ref_mode(ref_mode));
-        }
+
+        rust_type
     }
 
-    if *nullable && !skip_option {
-        match ConversionType::of(env, type_id) {
-            ConversionType::Pointer | ConversionType::Scalar => {
-                rust_type = rust_type
-                    .map_any(|rust_type| rust_type.alter_type(|typ_| format!("Option<{}>", typ_)));
+    pub fn try_build_param(self) -> Result {
+        use crate::library::Type::*;
+        let type_ = self.env.library.type_(self.type_id);
+
+        if self.direction == ParameterDirection::None {
+            panic!("undefined direction for parameter with type {:?}", type_);
+        }
+
+        let rust_type = RustType::builder(&self.env, self.type_id)
+            .with_direction(self.direction)
+            .with_nullable(self.nullable)
+            .with_ref_mode(self.ref_mode)
+            .with_scope(self.scope)
+            .with_try_from_glib(&self.try_from_glib)
+            .try_build();
+        match *type_ {
+            Fundamental(fund) => {
+                if (fund == library::Fundamental::Utf8
+                    || fund == library::Fundamental::OsString
+                    || fund == library::Fundamental::Filename)
+                    && (self.direction == ParameterDirection::InOut
+                        || (self.direction == ParameterDirection::Out
+                            && self.ref_mode == RefMode::ByRefMut))
+                {
+                    return Err(TypeError::Unimplemented(into_inner(rust_type)));
+                }
+                rust_type.map_any(|rust_type| rust_type.format_parameter(self.direction))
             }
-            _ => (),
-        }
-    }
 
-    rust_type
-}
+            Alias(ref alias) => rust_type
+                .and_then(|rust_type| {
+                    RustType::builder(&self.env, alias.typ)
+                        .with_direction(self.direction)
+                        .with_nullable(self.nullable)
+                        .with_ref_mode(self.ref_mode)
+                        .with_scope(self.scope)
+                        .with_try_from_glib(&self.try_from_glib)
+                        .try_build_param()
+                        .map_any(|_| rust_type)
+                })
+                .map_any(|rust_type| rust_type.format_parameter(self.direction)),
 
-// FIXME should be possible to get ride of this function in favor of rust_type
-pub fn used_rust_type(
-    env: &Env,
-    type_id: library::TypeId,
-    direction: ParameterDirection,
-    try_from_glib: &TryFromGlib,
-) -> Result {
-    use crate::library::Type::*;
-    match *env.library.type_(type_id) {
-        Fundamental(library::Fundamental::Type)
-        | Fundamental(library::Fundamental::Short)
-        | Fundamental(library::Fundamental::UShort)
-        | Fundamental(library::Fundamental::Long)
-        | Fundamental(library::Fundamental::ULong)
-        | Fundamental(library::Fundamental::Char)
-        | Fundamental(library::Fundamental::UChar)
-        | Fundamental(library::Fundamental::Filename)
-        | Fundamental(library::Fundamental::OsString)
-        | Alias(..)
-        | Bitfield(..)
-        | Record(..)
-        | Union(..)
-        | Class(..)
-        | Enumeration(..)
-        | Interface(..) => rust_type(env, type_id, direction, try_from_glib),
-        //process inner types as return parameters
-        List(inner_tid) | SList(inner_tid) | CArray(inner_tid) | PtrArray(inner_tid) => {
-            used_rust_type(
-                env,
-                inner_tid,
-                ParameterDirection::Out,
-                &TryFromGlib::default(),
-            )
-        }
-        Custom(..) => rust_type_default(env, type_id),
-        Fundamental(library::Fundamental::Utf8) if !direction.is_in() => {
-            Ok(use_glib_type(env, "GString").into())
-        }
-        _ => Err(TypeError::Ignored("Don't need use".to_owned())),
-    }
-}
-
-pub fn parameter_rust_type(
-    env: &Env,
-    type_id: library::TypeId,
-    direction: ParameterDirection,
-    nullable: Nullable,
-    ref_mode: RefMode,
-    scope: ParameterScope,
-    try_from_glib: &TryFromGlib,
-) -> Result {
-    use crate::library::Type::*;
-    let type_ = env.library.type_(type_id);
-    let rust_type = rust_type_full(
-        env,
-        type_id,
-        direction,
-        nullable,
-        ref_mode,
-        scope,
-        library::Concurrency::None,
-        try_from_glib,
-    );
-    match *type_ {
-        Fundamental(fund) => {
-            if (fund == library::Fundamental::Utf8
-                || fund == library::Fundamental::OsString
-                || fund == library::Fundamental::Filename)
-                && (direction == ParameterDirection::InOut
-                    || (direction == ParameterDirection::Out && ref_mode == RefMode::ByRefMut))
-            {
-                return Err(TypeError::Unimplemented(into_inner(rust_type)));
+            Enumeration(..) | Union(..) | Bitfield(..) => {
+                rust_type.map_any(|rust_type| rust_type.format_parameter(self.direction))
             }
-            rust_type.map_any(|rust_type| rust_type.format_parameter(direction))
-        }
 
-        Alias(ref alias) => rust_type
-            .and_then(|rust_type| {
-                parameter_rust_type(
-                    env,
-                    alias.typ,
-                    direction,
-                    nullable,
-                    ref_mode,
-                    scope,
-                    try_from_glib,
-                )
-                .map_any(|_| rust_type)
-            })
-            .map_any(|rust_type| rust_type.format_parameter(direction)),
-
-        Enumeration(..) | Union(..) | Bitfield(..) => {
-            rust_type.map_any(|rust_type| rust_type.format_parameter(direction))
-        }
-
-        Record(..) => {
-            if direction == ParameterDirection::InOut {
-                Err(TypeError::Unimplemented(into_inner(rust_type)))
-            } else {
-                rust_type
+            Record(..) => {
+                if self.direction == ParameterDirection::InOut {
+                    Err(TypeError::Unimplemented(into_inner(rust_type)))
+                } else {
+                    rust_type
+                }
             }
+
+            Class(..) | Interface(..) => match self.direction {
+                ParameterDirection::In | ParameterDirection::Out | ParameterDirection::Return => {
+                    rust_type
+                }
+                _ => Err(TypeError::Unimplemented(into_inner(rust_type))),
+            },
+
+            List(..) | SList(..) => match self.direction {
+                ParameterDirection::In | ParameterDirection::Return => rust_type,
+                _ => Err(TypeError::Unimplemented(into_inner(rust_type))),
+            },
+            CArray(..) | PtrArray(..) => match self.direction {
+                ParameterDirection::In | ParameterDirection::Out | ParameterDirection::Return => {
+                    rust_type
+                }
+                _ => Err(TypeError::Unimplemented(into_inner(rust_type))),
+            },
+            Function(ref func) if func.name == "AsyncReadyCallback" => {
+                Ok("AsyncReadyCallback".into())
+            }
+            Function(_) => rust_type,
+            Custom(..) => rust_type.map(|rust_type| rust_type.format_parameter(self.direction)),
+            _ => Err(TypeError::Unimplemented(type_.get_name())),
         }
-
-        Class(..) | Interface(..) => match direction {
-            ParameterDirection::In | ParameterDirection::Out | ParameterDirection::Return => {
-                rust_type
-            }
-            _ => Err(TypeError::Unimplemented(into_inner(rust_type))),
-        },
-
-        List(..) | SList(..) => match direction {
-            ParameterDirection::In | ParameterDirection::Return => rust_type,
-            _ => Err(TypeError::Unimplemented(into_inner(rust_type))),
-        },
-        CArray(..) | PtrArray(..) => match direction {
-            ParameterDirection::In | ParameterDirection::Out | ParameterDirection::Return => {
-                rust_type
-            }
-            _ => Err(TypeError::Unimplemented(into_inner(rust_type))),
-        },
-        Function(ref func) if func.name == "AsyncReadyCallback" => Ok("AsyncReadyCallback".into()),
-        Function(_) => rust_type,
-        Custom(..) => rust_type.map(|rust_type| rust_type.format_parameter(direction)),
-        _ => Err(TypeError::Unimplemented(type_.get_name())),
     }
 }

--- a/src/analysis/special_functions.rs
+++ b/src/analysis/special_functions.rs
@@ -97,7 +97,7 @@ fn is_stringify(func: &mut FuncInfo, parent_type: &LibType, obj: &GObject) -> bo
     }
 
     if let Some(ret) = func.ret.parameter.as_mut() {
-        if ret.typ != TypeId::tid_utf8() {
+        if ret.lib_par.typ != TypeId::tid_utf8() {
             return false;
         }
 
@@ -111,12 +111,12 @@ fn is_stringify(func: &mut FuncInfo, parent_type: &LibType, obj: &GObject) -> bo
             if !obj.trust_return_value_nullability
                 && !matches!(parent_type, LibType::Enumeration(_) | LibType::Bitfield(_))
             {
-                *ret.nullable = false;
+                *ret.lib_par.nullable = false;
             }
         }
 
         // Cannot generate Display implementation for Option<>
-        !*ret.nullable
+        !*ret.lib_par.nullable
     } else {
         false
     }
@@ -137,11 +137,9 @@ pub fn extract(functions: &mut Vec<FuncInfo>, parent_type: &LibType, obj: &GObje
 
     for (pos, func) in functions.iter_mut().enumerate() {
         if is_stringify(func, parent_type, obj) {
-            let return_transfer_none = func
-                .ret
-                .parameter
-                .as_ref()
-                .map_or(false, |ret| ret.transfer == crate::library::Transfer::None);
+            let return_transfer_none = func.ret.parameter.as_ref().map_or(false, |ret| {
+                ret.lib_par.transfer == crate::library::Transfer::None
+            });
 
             // Assume only enumerations and bitfields can return static strings
             let returns_static_ref = return_transfer_none

--- a/src/analysis/supertypes.rs
+++ b/src/analysis/supertypes.rs
@@ -1,8 +1,8 @@
-use super::{general::StatusedTypeId, imports::Imports, try_from_glib::TryFromGlib};
+use super::{general::StatusedTypeId, imports::Imports};
 use crate::{
-    analysis::{namespaces, rust_type::used_rust_type},
+    analysis::{namespaces, rust_type::RustType},
     env::Env,
-    library::{ParameterDirection, TypeId},
+    library::TypeId,
 };
 
 pub fn analyze(env: &Env, type_id: TypeId, imports: &mut Imports) -> Vec<StatusedTypeId> {
@@ -24,12 +24,7 @@ pub fn analyze(env: &Env, type_id: TypeId, imports: &mut Imports) -> Vec<Statuse
         });
 
         if !status.ignored() && super_tid.ns_id == namespaces::MAIN {
-            if let Ok(rust_type) = used_rust_type(
-                env,
-                super_tid,
-                ParameterDirection::In,
-                &TryFromGlib::default(),
-            ) {
+            if let Ok(rust_type) = RustType::try_new(env, super_tid) {
                 for import in rust_type.into_used_types() {
                     imports.add(&format!("crate::{}", import));
                 }

--- a/src/analysis/trampoline_parameters.rs
+++ b/src/analysis/trampoline_parameters.rs
@@ -139,8 +139,7 @@ pub fn analyze(
         let nullable_override = configured_signals
             .matched_parameters(&name)
             .iter()
-            .filter_map(|p| p.nullable)
-            .next();
+            .find_map(|p| p.nullable);
         let nullable = nullable_override.unwrap_or(par.nullable);
 
         let conversion_type = {
@@ -156,13 +155,11 @@ pub fn analyze(
         let new_name = configured_signals
             .matched_parameters(&name)
             .iter()
-            .filter_map(|p| p.new_name.clone())
-            .next();
+            .find_map(|p| p.new_name.clone());
         let transformation_override = configured_signals
             .matched_parameters(&name)
             .iter()
-            .filter_map(|p| p.transformation)
-            .next();
+            .find_map(|p| p.transformation);
 
         let mut transform = parameters.prepare_transformation(
             par.typ,

--- a/src/analysis/trampoline_parameters.rs
+++ b/src/analysis/trampoline_parameters.rs
@@ -1,7 +1,7 @@
 use super::{conversion_type::ConversionType, ref_mode::RefMode, try_from_glib::TryFromGlib};
 use crate::{
     analysis::is_gpointer,
-    analysis::rust_type::rust_type_default,
+    analysis::rust_type::RustType,
     config::{self, parameter_matchable::ParameterMatchable},
     env::Env,
     library, nameutil,
@@ -29,7 +29,7 @@ pub struct CParameter {
 
 impl CParameter {
     pub fn is_real_gpointer(&self, env: &Env) -> bool {
-        is_gpointer(&self.c_type) && rust_type_default(env, self.typ).is_err()
+        is_gpointer(&self.c_type) && RustType::try_new(env, self.typ).is_err()
     }
 }
 

--- a/src/analysis/trampoline_parameters.rs
+++ b/src/analysis/trampoline_parameters.rs
@@ -1,7 +1,7 @@
-use super::{conversion_type::ConversionType, ref_mode::RefMode};
+use super::{conversion_type::ConversionType, ref_mode::RefMode, try_from_glib::TryFromGlib};
 use crate::{
     analysis::is_gpointer,
-    analysis::rust_type::rust_type,
+    analysis::rust_type::rust_type_default,
     config::{self, parameter_matchable::ParameterMatchable},
     env::Env,
     library, nameutil,
@@ -17,6 +17,7 @@ pub struct RustParameter {
     pub direction: library::ParameterDirection,
     pub nullable: library::Nullable,
     pub ref_mode: RefMode,
+    pub try_from_glib: TryFromGlib,
 }
 
 #[derive(Clone, Debug)]
@@ -28,7 +29,7 @@ pub struct CParameter {
 
 impl CParameter {
     pub fn is_real_gpointer(&self, env: &Env) -> bool {
-        is_gpointer(&self.c_type) && rust_type(env, self.typ).is_err()
+        is_gpointer(&self.c_type) && rust_type_default(env, self.typ).is_err()
     }
 }
 
@@ -62,6 +63,7 @@ impl Parameters {
 
     pub fn prepare_transformation(
         &mut self,
+        env: &Env,
         type_tid: library::TypeId,
         name: String,
         c_type: String,
@@ -85,6 +87,7 @@ impl Parameters {
             direction,
             nullable,
             ref_mode,
+            try_from_glib: TryFromGlib::from_type_defaults(env, type_tid),
         };
         let ind_rust = self.rust_parameters.len();
         self.rust_parameters.push(rust_par);
@@ -120,6 +123,7 @@ pub fn analyze(
     let c_type = format!("{}*", owner.get_glib_name().unwrap());
 
     let transform = parameters.prepare_transformation(
+        env,
         type_tid,
         "this".to_owned(),
         c_type,
@@ -162,6 +166,7 @@ pub fn analyze(
             .find_map(|p| p.transformation);
 
         let mut transform = parameters.prepare_transformation(
+            env,
             par.typ,
             name,
             par.c_type.clone(),

--- a/src/analysis/trampolines.rs
+++ b/src/analysis/trampolines.rs
@@ -140,10 +140,7 @@ pub fn analyze(
             used_types.push(s);
         }
 
-        let nullable_override = configured_signals
-            .iter()
-            .filter_map(|f| f.ret.nullable)
-            .next();
+        let nullable_override = configured_signals.iter().find_map(|f| f.ret.nullable);
         if let Some(nullable) = nullable_override {
             ret_nullable = nullable;
         }

--- a/src/analysis/try_from_glib.rs
+++ b/src/analysis/try_from_glib.rs
@@ -1,0 +1,101 @@
+use std::{borrow::Cow, sync::Arc};
+
+use crate::{
+    analysis::conversion_type::ConversionType,
+    config,
+    library::{self, Infallible, Mandatory},
+    Env,
+};
+
+#[derive(Clone, Debug)]
+pub enum TryFromGlib {
+    Default,
+    NotImplemented,
+    Option,
+    OptionMandatory,
+    Result {
+        ok_type: Arc<str>,
+        err_type: Arc<str>,
+    },
+    ResultInfallible {
+        ok_type: Arc<str>,
+    },
+}
+
+impl Default for TryFromGlib {
+    fn default() -> Self {
+        TryFromGlib::Default
+    }
+}
+
+impl TryFromGlib {
+    fn _new(
+        env: &Env,
+        type_id: library::TypeId,
+        mut config_mandatory: impl Iterator<Item = Mandatory>,
+        mut config_infallible: impl Iterator<Item = Infallible>,
+    ) -> Self {
+        let conversion_type = ConversionType::of(env, type_id);
+        match conversion_type {
+            ConversionType::Option => {
+                if *config_mandatory.next().unwrap_or(Mandatory(false)) {
+                    TryFromGlib::OptionMandatory
+                } else {
+                    TryFromGlib::Option
+                }
+            }
+            ConversionType::Result { ok_type, err_type } => {
+                if *config_infallible.next().unwrap_or(Infallible(false)) {
+                    TryFromGlib::ResultInfallible {
+                        ok_type: Arc::clone(&ok_type),
+                    }
+                } else {
+                    TryFromGlib::Result {
+                        ok_type: Arc::clone(&ok_type),
+                        err_type: Arc::clone(&err_type),
+                    }
+                }
+            }
+            _ => TryFromGlib::NotImplemented,
+        }
+    }
+
+    pub fn from_type_defaults(env: &Env, type_id: library::TypeId) -> Self {
+        Self::_new(env, type_id, None.into_iter(), None.into_iter())
+    }
+
+    pub fn or_type_defaults(&self, env: &Env, type_id: library::TypeId) -> Cow<'_, Self> {
+        match self {
+            TryFromGlib::Default => Cow::Owned(Self::from_type_defaults(env, type_id)),
+            other => Cow::Borrowed(other),
+        }
+    }
+
+    pub fn from_parameter(
+        env: &Env,
+        type_id: library::TypeId,
+        configured_parameters: &[&config::functions::Parameter],
+    ) -> Self {
+        Self::_new(
+            env,
+            type_id,
+            configured_parameters.iter().filter_map(|par| par.mandatory),
+            configured_parameters
+                .iter()
+                .filter_map(|par| par.infallible),
+        )
+    }
+
+    pub fn from_return_value(
+        env: &Env,
+        type_id: library::TypeId,
+        configured_functions: &[&config::functions::Function],
+    ) -> Self {
+        Self::_new(
+            env,
+            type_id,
+            configured_functions.iter().filter_map(|f| f.ret.mandatory),
+            configured_functions.iter().filter_map(|f| f.ret.infallible),
+        )
+    }
+}

--- a/src/chunk/conversion_from_glib.rs
+++ b/src/chunk/conversion_from_glib.rs
@@ -1,29 +1,35 @@
 use super::parameter_ffi_call_out;
-use crate::library;
+use crate::{
+    analysis::{self, try_from_glib::TryFromGlib},
+    library,
+};
 
 #[derive(Clone, Debug)]
 pub struct Mode {
     pub typ: library::TypeId,
     pub transfer: library::Transfer,
     pub is_uninitialized: bool,
+    pub try_from_glib: TryFromGlib,
 }
 
-impl<'a> From<&'a parameter_ffi_call_out::Parameter> for Mode {
-    fn from(orig: &'a parameter_ffi_call_out::Parameter) -> Mode {
+impl From<&parameter_ffi_call_out::Parameter> for Mode {
+    fn from(orig: &parameter_ffi_call_out::Parameter) -> Mode {
         Mode {
             typ: orig.typ,
             transfer: orig.transfer,
             is_uninitialized: orig.is_uninitialized,
+            try_from_glib: orig.try_from_glib.clone(),
         }
     }
 }
 
-impl<'a> From<&'a library::Parameter> for Mode {
-    fn from(orig: &'a library::Parameter) -> Mode {
+impl From<&analysis::Parameter> for Mode {
+    fn from(orig: &analysis::Parameter) -> Mode {
         Mode {
-            typ: orig.typ,
-            transfer: orig.transfer,
+            typ: orig.lib_par.typ,
+            transfer: orig.lib_par.transfer,
             is_uninitialized: false,
+            try_from_glib: orig.try_from_glib.clone(),
         }
     }
 }

--- a/src/chunk/parameter_ffi_call_out.rs
+++ b/src/chunk/parameter_ffi_call_out.rs
@@ -1,4 +1,7 @@
-use crate::{analysis, library};
+use crate::{
+    analysis::{self, try_from_glib::TryFromGlib},
+    library,
+};
 
 #[derive(Clone, Debug)]
 pub struct Parameter {
@@ -8,6 +11,7 @@ pub struct Parameter {
     pub caller_allocates: bool,
     pub is_error: bool,
     pub is_uninitialized: bool,
+    pub try_from_glib: TryFromGlib,
 }
 
 impl Parameter {
@@ -22,19 +26,21 @@ impl Parameter {
             caller_allocates: orig.caller_allocates,
             is_error: orig.is_error,
             is_uninitialized,
+            try_from_glib: orig.try_from_glib.clone(),
         }
     }
 }
 
-impl<'a> From<&'a library::Parameter> for Parameter {
-    fn from(orig: &'a library::Parameter) -> Parameter {
+impl From<&analysis::Parameter> for Parameter {
+    fn from(orig: &analysis::Parameter) -> Parameter {
         Parameter {
-            name: orig.name.clone(),
-            typ: orig.typ,
-            transfer: orig.transfer,
-            caller_allocates: orig.caller_allocates,
-            is_error: orig.is_error,
+            name: orig.lib_par.name.clone(),
+            typ: orig.lib_par.typ,
+            transfer: orig.lib_par.transfer,
+            caller_allocates: orig.lib_par.caller_allocates,
+            is_error: orig.lib_par.is_error,
             is_uninitialized: false,
+            try_from_glib: orig.try_from_glib.clone(),
         }
     }
 }

--- a/src/codegen/alias.rs
+++ b/src/codegen/alias.rs
@@ -1,5 +1,5 @@
 use crate::{
-    analysis::{namespaces, rust_type::rust_type_default},
+    analysis::{namespaces, rust_type::RustType},
     codegen::general,
     config::gobjects::GObject,
     env::Env,
@@ -54,7 +54,7 @@ pub fn generate(env: &Env, root_path: &Path, mod_rs: &mut Vec<String>) {
 }
 
 fn generate_alias(env: &Env, w: &mut dyn Write, alias: &Alias, _: &GObject) -> Result<()> {
-    let typ = rust_type_default(env, alias.typ).into_string();
+    let typ = RustType::try_new(env, alias.typ).into_string();
     writeln!(w, "pub type {} = {};", alias.name, typ)?;
 
     Ok(())

--- a/src/codegen/alias.rs
+++ b/src/codegen/alias.rs
@@ -1,5 +1,5 @@
 use crate::{
-    analysis::{namespaces, rust_type::rust_type},
+    analysis::{namespaces, rust_type::rust_type_default},
     codegen::general,
     config::gobjects::GObject,
     env::Env,
@@ -54,7 +54,7 @@ pub fn generate(env: &Env, root_path: &Path, mod_rs: &mut Vec<String>) {
 }
 
 fn generate_alias(env: &Env, w: &mut dyn Write, alias: &Alias, _: &GObject) -> Result<()> {
-    let typ = rust_type(env, alias.typ).into_string();
+    let typ = rust_type_default(env, alias.typ).into_string();
     writeln!(w, "pub type {} = {};", alias.name, typ)?;
 
     Ok(())

--- a/src/codegen/child_properties.rs
+++ b/src/codegen/child_properties.rs
@@ -3,11 +3,7 @@ use super::{
     property_body,
 };
 use crate::{
-    analysis::{
-        child_properties::ChildProperty,
-        rust_type::{parameter_rust_type, rust_type_default},
-        try_from_glib::TryFromGlib,
-    },
+    analysis::{child_properties::ChildProperty, rust_type::RustType},
     chunk::Chunk,
     env::Env,
     library,
@@ -41,7 +37,7 @@ fn generate_func(
 ) -> Result<()> {
     let pub_prefix = if in_trait { "" } else { "pub " };
     let decl_suffix = if only_declaration { ";" } else { " {" };
-    let type_string = rust_type_default(env, prop.typ);
+    let type_string = RustType::try_new(env, prop.typ);
     let comment_prefix = if type_string.is_err() { "//" } else { "" };
 
     writeln!(w)?;
@@ -90,7 +86,7 @@ fn declaration(env: &Env, prop: &ChildProperty, is_get: bool) -> String {
         format!("set_{}_{}", prop.child_name, prop.prop_name)
     };
     let mut bounds = if let Some(typ) = prop.child_type {
-        let child_type = rust_type_default(env, typ).into_string();
+        let child_type = RustType::try_new(env, typ).into_string();
         format!("T: IsA<{}>", child_type)
     } else {
         "T: IsA<Widget>".to_string()
@@ -100,16 +96,12 @@ fn declaration(env: &Env, prop: &ChildProperty, is_get: bool) -> String {
     }
     let return_str = if is_get {
         let dir = library::ParameterDirection::Return;
-        let ret_type = parameter_rust_type(
-            env,
-            prop.typ,
-            dir,
-            prop.nullable,
-            prop.get_out_ref_mode,
-            library::ParameterScope::None,
-            &TryFromGlib::from_type_defaults(env, prop.typ),
-        )
-        .into_string();
+        let ret_type = RustType::builder(env, prop.typ)
+            .with_direction(dir)
+            .with_nullable(prop.nullable)
+            .with_ref_mode(prop.get_out_ref_mode)
+            .try_build_param()
+            .into_string();
         format!(" -> {}", ret_type)
     } else {
         "".to_string()
@@ -137,7 +129,7 @@ fn body(env: &Env, prop: &ChildProperty, in_trait: bool, is_get: bool) -> Chunk 
         .is_ref(prop.set_in_ref_mode.is_ref())
         .is_nullable(*prop.nullable);
 
-    if let Ok(type_) = rust_type_default(env, prop.typ) {
+    if let Ok(type_) = RustType::try_new(env, prop.typ) {
         builder.type_(type_.as_str());
     } else {
         builder.type_("/*Unknown type*/");

--- a/src/codegen/enums.rs
+++ b/src/codegen/enums.rs
@@ -75,11 +75,8 @@ fn generate_enum(
             continue;
         }
         vals.insert(member.value.clone());
-        let deprecated_version = member_config
-            .iter()
-            .filter_map(|m| m.deprecated_version)
-            .next();
-        let version = member_config.iter().filter_map(|m| m.version).next();
+        let deprecated_version = member_config.iter().find_map(|m| m.deprecated_version);
+        let version = member_config.iter().find_map(|m| m.version);
         members.push(Member {
             name: enum_member_name(&member.name),
             c_name: member.c_identifier.clone(),

--- a/src/codegen/flags.rs
+++ b/src/codegen/flags.rs
@@ -74,11 +74,8 @@ fn generate_flags(
 
         let name = bitfield_member_name(&member.name);
         let val: i64 = member.value.parse().unwrap();
-        let deprecated_version = member_config
-            .iter()
-            .filter_map(|m| m.deprecated_version)
-            .next();
-        let version = member_config.iter().filter_map(|m| m.version).next();
+        let deprecated_version = member_config.iter().find_map(|m| m.deprecated_version);
+        let version = member_config.iter().find_map(|m| m.version);
         cfg_deprecated(w, env, deprecated_version, false, 2)?;
         version_condition(w, env, version, false, 2)?;
         writeln!(w, "\t\tconst {} = {};", name, val as u32)?;

--- a/src/codegen/function_body_chunk.rs
+++ b/src/codegen/function_body_chunk.rs
@@ -8,7 +8,7 @@ use crate::{
         functions::{find_index_to_ignore, AsyncTrampoline},
         out_parameters::Mode,
         return_value,
-        rust_type::rust_type_default,
+        rust_type::RustType,
         safety_assertion_mode::SafetyAssertionMode,
         trampoline_parameters,
         trampolines::Trampoline,
@@ -413,7 +413,7 @@ impl Builder {
             {
                 continue;
             }
-            let ty_name = match rust_type_default(env, par.typ) {
+            let ty_name = match RustType::try_new(env, par.typ) {
                 Ok(x) => x.into_string(),
                 _ => String::new(),
             };
@@ -1258,7 +1258,7 @@ fn c_type_mem_mode_lib(
     match ConversionType::of(env, typ) {
         ConversionType::Pointer => {
             if caller_allocates {
-                UninitializedNamed(rust_type_default(env, typ).unwrap().into_string())
+                UninitializedNamed(RustType::try_new(env, typ).unwrap().into_string())
             } else {
                 use crate::library::Type::*;
                 let type_ = env.library.type_(typ);
@@ -1296,7 +1296,7 @@ fn type_mem_mode(env: &Env, parameter: &library::Parameter) -> Chunk {
         ConversionType::Pointer => {
             if parameter.caller_allocates {
                 Chunk::UninitializedNamed {
-                    name: rust_type_default(env, parameter.typ).unwrap().into_string(),
+                    name: RustType::try_new(env, parameter.typ).unwrap().into_string(),
                 }
             } else {
                 use crate::library::Type::*;

--- a/src/codegen/function_body_chunk.rs
+++ b/src/codegen/function_body_chunk.rs
@@ -1,5 +1,6 @@
 use crate::{
     analysis::{
+        self,
         conversion_type::ConversionType,
         function_parameters::{
             CParameter as AnalysisCParameter, Transformation, TransformationType,
@@ -7,7 +8,7 @@ use crate::{
         functions::{find_index_to_ignore, AsyncTrampoline},
         out_parameters::Mode,
         return_value,
-        rust_type::rust_type,
+        rust_type::rust_type_default,
         safety_assertion_mode::SafetyAssertionMode,
         trampoline_parameters,
         trampolines::Trampoline,
@@ -16,6 +17,7 @@ use crate::{
     env::Env,
     library::{self, ParameterDirection, TypeId},
     nameutil::{is_gstring, use_gio_type, use_glib_if_needed, use_glib_type},
+    traits::*,
 };
 use std::collections::{hash_map::Entry, BTreeMap, HashMap};
 
@@ -411,8 +413,8 @@ impl Builder {
             {
                 continue;
             }
-            let ty_name = match rust_type(env, par.typ) {
-                Ok(ref x) => x.clone(),
+            let ty_name = match rust_type_default(env, par.typ) {
+                Ok(x) => x.into_string(),
                 _ => String::new(),
             };
             let nullable = trampoline.parameters.rust_parameters[par.ind_rust].nullable;
@@ -662,7 +664,8 @@ impl Builder {
                         Param {
                             name: p.name.clone(),
                             typ: crate::analysis::ffi_type::ffi_type(env, p.typ, &p.c_type)
-                                .expect("failed to write c_type"),
+                                .expect("failed to write c_type")
+                                .into_string(),
                         }
                     }
                 })
@@ -672,7 +675,8 @@ impl Builder {
                 let p = &trampoline.ret;
                 Some(
                     crate::analysis::ffi_type::ffi_type(env, p.typ, &p.c_type)
-                        .expect("failed to write c_type"),
+                        .expect("failed to write c_type")
+                        .into_string(),
                 )
             } else {
                 None
@@ -735,22 +739,22 @@ impl Builder {
             trampoline
                 .output_params
                 .iter()
-                .filter(|param| {
-                    param.direction == ParameterDirection::Out
-                        || param.typ.full_name(&env.library) == "Gio.AsyncResult"
+                .filter(|out| {
+                    out.lib_par.direction == ParameterDirection::Out
+                        || out.lib_par.typ.full_name(&env.library) == "Gio.AsyncResult"
                 })
-                .map(|param| {
-                    if param.typ.full_name(&env.library) == "Gio.AsyncResult" {
+                .map(|out| {
+                    if out.lib_par.typ.full_name(&env.library) == "Gio.AsyncResult" {
                         found_async_result = true;
                         return Chunk::Name("res".to_string());
                     }
-                    let kind = type_mem_mode(env, param);
-                    let mut par: parameter_ffi_call_out::Parameter = param.into();
+                    let kind = type_mem_mode(env, &out.lib_par);
+                    let mut par: parameter_ffi_call_out::Parameter = out.into();
                     if kind.is_uninitialized() {
                         par.is_uninitialized = true;
                         uninitialized_vars.push((
-                            param.name.clone(),
-                            self.check_if_need_glib_conversion(env, param.typ),
+                            out.lib_par.name.clone(),
+                            self.check_if_need_glib_conversion(env, out.lib_par.typ),
                         ));
                     }
                     Chunk::FfiCallOutParameter { par }
@@ -760,28 +764,34 @@ impl Builder {
             found_async_result,
             "The check *wasn't* performed in analysis part: Guillaume was wrong!"
         );
-        let index_to_ignore =
-            find_index_to_ignore(&trampoline.output_params, trampoline.ffi_ret.as_ref());
+        let index_to_ignore = find_index_to_ignore(
+            trampoline.output_params.iter().map(|par| &par.lib_par),
+            trampoline.ffi_ret.as_ref().map(|ret| &ret.lib_par),
+        );
         let mut result: Vec<_> = trampoline
             .output_params
             .iter()
             .enumerate()
-            .filter(|&(index, param)| {
-                param.direction == ParameterDirection::Out
-                    && param.name != "error"
+            .filter(|&(index, out)| {
+                out.lib_par.direction == ParameterDirection::Out
+                    && out.lib_par.name != "error"
                     && Some(index) != index_to_ignore
             })
-            .map(|(_, param)| {
-                let value = Chunk::Custom(param.name.clone());
-                let mem_mode =
-                    c_type_mem_mode_lib(env, param.typ, param.caller_allocates, param.transfer);
+            .map(|(_, out)| {
+                let value = Chunk::Custom(out.lib_par.name.clone());
+                let mem_mode = c_type_mem_mode_lib(
+                    env,
+                    out.lib_par.typ,
+                    out.lib_par.caller_allocates,
+                    out.lib_par.transfer,
+                );
                 if let OutMemMode::UninitializedNamed(_) = mem_mode {
                     value
                 } else {
-                    let array_length_name = self.array_length(param).cloned();
+                    let array_length_name = self.array_length(&out).cloned();
                     self.remove_extra_assume_init(&array_length_name, &mut uninitialized_vars);
                     Chunk::FromGlibConversion {
-                        mode: param.into(),
+                        mode: out.into(),
                         array_length_name,
                         value: Box::new(value),
                     }
@@ -790,8 +800,12 @@ impl Builder {
             .collect();
 
         if let Some(ref ffi_ret) = trampoline.ffi_ret {
-            let mem_mode =
-                c_type_mem_mode_lib(env, ffi_ret.typ, ffi_ret.caller_allocates, ffi_ret.transfer);
+            let mem_mode = c_type_mem_mode_lib(
+                env,
+                ffi_ret.lib_par.typ,
+                ffi_ret.lib_par.caller_allocates,
+                ffi_ret.lib_par.transfer,
+            );
             let value = Chunk::Name("ret".to_string());
             if let OutMemMode::UninitializedNamed(_) = mem_mode {
                 result.insert(0, value);
@@ -819,12 +833,13 @@ impl Builder {
         let output_vars = trampoline
             .output_params
             .iter()
-            .filter(|param| param.direction == ParameterDirection::Out && param.name != "error")
-            .map(|param| (param, type_mem_mode(env, param)))
-            .map(|(param, mode)| Chunk::Let {
-                name: param.name.clone(),
+            .filter(|out| {
+                out.lib_par.direction == ParameterDirection::Out && out.lib_par.name != "error"
+            })
+            .map(|out| Chunk::Let {
+                name: out.lib_par.name.clone(),
                 is_mut: true,
-                value: Box::new(mode),
+                value: Box::new(type_mem_mode(env, &out.lib_par)),
                 type_: None,
             });
         body.extend(output_vars);
@@ -904,11 +919,12 @@ impl Builder {
         chunks.push(chunk);
     }
 
-    fn array_length(&self, param: &library::Parameter) -> Option<&String> {
+    fn array_length(&self, param: &analysis::Parameter) -> Option<&String> {
         self.async_trampoline.as_ref().and_then(|trampoline| {
             param
+                .lib_par
                 .array_length
-                .map(|index| &trampoline.output_params[index as usize].name)
+                .map(|index| &trampoline.output_params[index as usize].lib_par.name)
         })
     }
 
@@ -1242,7 +1258,7 @@ fn c_type_mem_mode_lib(
     match ConversionType::of(env, typ) {
         ConversionType::Pointer => {
             if caller_allocates {
-                UninitializedNamed(rust_type(env, typ).unwrap())
+                UninitializedNamed(rust_type_default(env, typ).unwrap().into_string())
             } else {
                 use crate::library::Type::*;
                 let type_ = env.library.type_(typ);
@@ -1280,7 +1296,7 @@ fn type_mem_mode(env: &Env, parameter: &library::Parameter) -> Chunk {
         ConversionType::Pointer => {
             if parameter.caller_allocates {
                 Chunk::UninitializedNamed {
-                    name: rust_type(env, parameter.typ).unwrap(),
+                    name: rust_type_default(env, parameter.typ).unwrap().into_string(),
                 }
             } else {
                 use crate::library::Type::*;

--- a/src/codegen/function_body_chunk.rs
+++ b/src/codegen/function_body_chunk.rs
@@ -1213,25 +1213,22 @@ impl Builder {
     }
 
     fn find_array_length_name(&self, array_name_: &str) -> Option<String> {
-        self.transformations
-            .iter()
-            .filter_map(|tr| {
-                if let TransformationType::Length {
-                    ref array_name,
-                    ref array_length_name,
-                    ..
-                } = tr.transformation_type
-                {
-                    if array_name == array_name_ {
-                        Some(array_length_name.clone())
-                    } else {
-                        None
-                    }
+        self.transformations.iter().find_map(|tr| {
+            if let TransformationType::Length {
+                ref array_name,
+                ref array_length_name,
+                ..
+            } = tr.transformation_type
+            {
+                if array_name == array_name_ {
+                    Some(array_length_name.clone())
                 } else {
                     None
                 }
-            })
-            .next()
+            } else {
+                None
+            }
+        })
     }
 }
 

--- a/src/codegen/parameter.rs
+++ b/src/codegen/parameter.rs
@@ -4,7 +4,7 @@ use crate::{
         conversion_type::ConversionType,
         function_parameters::CParameter,
         ref_mode::RefMode,
-        rust_type::parameter_rust_type,
+        rust_type::RustType,
     },
     env::Env,
     traits::*,
@@ -35,16 +35,14 @@ impl ToParameter for CParameter {
                     BoundType::AsRef(_) => type_str = t.to_string(),
                 },
                 None => {
-                    let rust_type = parameter_rust_type(
-                        env,
-                        self.typ,
-                        self.direction,
-                        self.nullable,
-                        self.ref_mode,
-                        self.scope,
-                        &self.try_from_glib,
-                    );
-                    let type_name = rust_type.into_string();
+                    let type_name = RustType::builder(env, self.typ)
+                        .with_direction(self.direction)
+                        .with_nullable(self.nullable)
+                        .with_ref_mode(self.ref_mode)
+                        .with_scope(self.scope)
+                        .with_try_from_glib(&self.try_from_glib)
+                        .try_build_param()
+                        .into_string();
                     type_str = match ConversionType::of(env, self.typ) {
                         ConversionType::Unknown => format!("/*Unknown conversion*/{}", type_name),
                         _ => type_name,

--- a/src/codegen/parameter.rs
+++ b/src/codegen/parameter.rs
@@ -42,6 +42,7 @@ impl ToParameter for CParameter {
                         self.nullable,
                         self.ref_mode,
                         self.scope,
+                        &self.try_from_glib,
                     );
                     let type_name = rust_type.into_string();
                     type_str = match ConversionType::of(env, self.typ) {

--- a/src/codegen/property_body.rs
+++ b/src/codegen/property_body.rs
@@ -122,13 +122,6 @@ impl<'a> Builder<'a> {
 
         let mut body = Vec::new();
 
-        let return_info = analysis::return_value::Info {
-            parameter: None,
-            base_tid: None,
-            commented: false,
-            bool_return_is_error: None,
-            nullable_return_is_error: None,
-        };
         let ffi_call = Chunk::FfiCall {
             name: self.get_ffi_func(),
             params,
@@ -145,7 +138,7 @@ impl<'a> Builder<'a> {
         });
 
         body.push(Chunk::FfiCallConversion {
-            ret: return_info,
+            ret: analysis::return_value::Info::default(),
             array_length_name: None,
             call: Box::new(ffi_call),
         });
@@ -196,15 +189,8 @@ impl<'a> Builder<'a> {
             name: self.set_ffi_func(),
             params,
         };
-        let return_info = analysis::return_value::Info {
-            parameter: None,
-            base_tid: None,
-            commented: false,
-            bool_return_is_error: None,
-            nullable_return_is_error: None,
-        };
         body.push(Chunk::FfiCallConversion {
-            ret: return_info,
+            ret: analysis::return_value::Info::default(),
             array_length_name: None,
             call: Box::new(ffi_call),
         });

--- a/src/codegen/return_value.rs
+++ b/src/codegen/return_value.rs
@@ -143,14 +143,13 @@ pub fn out_parameters_as_return(env: &Env, analysis: &analysis::functions::Info)
                 .c_parameters
                 .iter()
                 .enumerate()
-                .filter_map(|(pos, orig_par)| {
+                .find_map(|(pos, orig_par)| {
                     if orig_par.name == mangled_par_name {
                         Some(pos)
                     } else {
                         None
                     }
                 })
-                .next()
                 .unwrap();
             if array_lengths.contains(&(param_pos as u32)) {
                 skip += 1;

--- a/src/codegen/return_value.rs
+++ b/src/codegen/return_value.rs
@@ -1,7 +1,7 @@
 use crate::{
     analysis::{
         self, conversion_type::ConversionType, namespaces, ref_mode::RefMode,
-        rust_type::parameter_rust_type,
+        rust_type::parameter_rust_type, try_from_glib::TryFromGlib,
     },
     env::Env,
     library::{self, ParameterDirection},
@@ -11,11 +11,21 @@ use crate::{
 use std::cmp;
 
 pub trait ToReturnValue {
-    fn to_return_value(&self, env: &Env, is_trampoline: bool) -> String;
+    fn to_return_value(
+        &self,
+        env: &Env,
+        try_from_glib: &TryFromGlib,
+        is_trampoline: bool,
+    ) -> Option<String>;
 }
 
 impl ToReturnValue for library::Parameter {
-    fn to_return_value(&self, env: &Env, is_trampoline: bool) -> String {
+    fn to_return_value(
+        &self,
+        env: &Env,
+        try_from_glib: &TryFromGlib,
+        is_trampoline: bool,
+    ) -> Option<String> {
         let rust_type = parameter_rust_type(
             env,
             self.typ,
@@ -23,6 +33,7 @@ impl ToReturnValue for library::Parameter {
             self.nullable,
             RefMode::None,
             self.scope,
+            try_from_glib,
         );
         let mut name = rust_type.into_string();
         if is_trampoline
@@ -36,20 +47,27 @@ impl ToReturnValue for library::Parameter {
             //TODO: records as in gtk_container_get_path_for_child
             _ => name,
         };
-        format!(" -> {}", type_str)
+
+        Some(type_str)
     }
 }
 
 impl ToReturnValue for analysis::return_value::Info {
-    fn to_return_value(&self, env: &Env, is_trampoline: bool) -> String {
-        match self.parameter {
-            Some(ref par) => {
-                let name = par.to_return_value(env, is_trampoline);
-                if self.nullable_return_is_error.is_some() && name.starts_with(" -> Option<") {
-                    // Change ` -> Option<T>` to ` -> Result<T, glib::BoolError>`
+    fn to_return_value(
+        &self,
+        env: &Env,
+        try_from_glib: &TryFromGlib,
+        is_trampoline: bool,
+    ) -> Option<String> {
+        let par = self.parameter.as_ref()?;
+        par.lib_par
+            .to_return_value(env, try_from_glib, is_trampoline)
+            .map(|type_name| {
+                if self.nullable_return_is_error.is_some() && type_name.starts_with("Option<") {
+                    // Change `Option<T>` to `Result<T, glib::BoolError>`
                     format!(
-                        " -> Result<{}, {}BoolError>",
-                        &name[11..(name.len() - 1)],
+                        "Result<{}, {}BoolError>",
+                        &type_name[7..(type_name.len() - 1)],
                         if env.namespaces.glib_ns_id == namespaces::MAIN {
                             ""
                         } else {
@@ -57,11 +75,9 @@ impl ToReturnValue for analysis::return_value::Info {
                         }
                     )
                 } else {
-                    name
+                    type_name
                 }
-            }
-            None => String::new(),
-        }
+            })
     }
 }
 
@@ -73,12 +89,12 @@ fn out_parameter_as_return_parts(
     let num_out_args = analysis
         .outs
         .iter()
-        .filter(|p| p.array_length.is_none())
+        .filter(|out| out.lib_par.array_length.is_none())
         .count();
     let num_out_sizes = analysis
         .outs
         .iter()
-        .filter(|p| p.array_length.is_some())
+        .filter(|out| out.lib_par.array_length.is_some())
         .count();
     // We need to differentiate between array(s)'s size arguments and normal ones. If we have 2
     // "normal" arguments and one "size" argument, we still need to wrap them into "()" so we take
@@ -130,14 +146,19 @@ pub fn out_parameters_as_return(env: &Env, analysis: &analysis::functions::Info)
     let array_lengths: Vec<_> = analysis
         .outs
         .iter()
-        .filter_map(|p| p.array_length)
+        .filter_map(|out| out.lib_par.array_length)
         .collect();
 
     let mut skip = 0;
-    for (pos, par) in analysis.outs.iter().filter(|par| !par.is_error).enumerate() {
+    for (pos, out) in analysis
+        .outs
+        .iter()
+        .filter(|out| !out.lib_par.is_error)
+        .enumerate()
+    {
         // The actual return value is inserted with an empty name at position 0
-        if !par.name.is_empty() {
-            let mangled_par_name = mangle_keywords(par.name.as_str());
+        if !out.lib_par.name.is_empty() {
+            let mangled_par_name = mangle_keywords(out.lib_par.name.as_str());
             let param_pos = analysis
                 .parameters
                 .c_parameters
@@ -160,25 +181,26 @@ pub fn out_parameters_as_return(env: &Env, analysis: &analysis::functions::Info)
         if pos > skip {
             return_str.push_str(", ")
         }
-        let s = out_parameter_as_return(par, env);
+        let s = out_parameter_as_return(out, env);
         return_str.push_str(&s);
     }
     return_str.push_str(&suffix);
     return_str
 }
 
-fn out_parameter_as_return(par: &library::Parameter, env: &Env) -> String {
+fn out_parameter_as_return(out: &analysis::Parameter, env: &Env) -> String {
     //TODO: upcasts?
     let rust_type = parameter_rust_type(
         env,
-        par.typ,
+        out.lib_par.typ,
         ParameterDirection::Return,
-        par.nullable,
+        out.lib_par.nullable,
         RefMode::None,
-        par.scope,
+        out.lib_par.scope,
+        &out.try_from_glib,
     );
     let name = rust_type.into_string();
-    match ConversionType::of(env, par.typ) {
+    match ConversionType::of(env, out.lib_par.typ) {
         ConversionType::Unknown => format!("/*Unknown conversion*/{}", name),
         _ => name,
     }

--- a/src/codegen/sys/fields.rs
+++ b/src/codegen/sys/fields.rs
@@ -128,7 +128,7 @@ fn analyze_fields(
 
         infos.push(FieldInfo {
             name: field.name.clone(),
-            typ,
+            typ: typ.into_string(),
             debug,
             unsafe_access,
         });
@@ -152,7 +152,7 @@ fn field_ffi_type(env: &Env, field: &Field) -> Result {
         if failure {
             Err(TypeError::Unimplemented(signature))
         } else {
-            Ok(signature)
+            Ok(signature.into())
         }
     } else {
         Err(TypeError::Ignored(format!(

--- a/src/codegen/sys/functions.rs
+++ b/src/codegen/sys/functions.rs
@@ -180,8 +180,7 @@ fn generate_cfg_configure(
 ) -> Result<()> {
     let cfg_condition_ = configured_functions
         .iter()
-        .filter_map(|f| f.cfg_condition.clone())
-        .next();
+        .find_map(|f| f.cfg_condition.clone());
     cfg_condition(w, &cfg_condition_, commented, 1)?;
     Ok(())
 }

--- a/src/codegen/sys/lib_.rs
+++ b/src/codegen/sys/lib_.rs
@@ -197,7 +197,7 @@ fn generate_bitfields(w: &mut dyn Write, env: &Env, items: &[&Bitfield]) -> Resu
                 .as_ref()
                 .map(|c| c.members.matched(&member.name))
                 .unwrap_or_else(Vec::new);
-            let version = member_config.iter().filter_map(|m| m.version).next();
+            let version = member_config.iter().find_map(|m| m.version);
 
             let val: i64 = member.value.parse().unwrap();
 
@@ -221,8 +221,7 @@ fn generate_constant_cfg_configure(
 ) -> Result<()> {
     let cfg_condition_ = configured_constants
         .iter()
-        .filter_map(|f| f.cfg_condition.clone())
-        .next();
+        .find_map(|f| f.cfg_condition.clone());
     cfg_condition(w, &cfg_condition_, commented, 1)?;
     Ok(())
 }
@@ -299,7 +298,7 @@ fn generate_enums(w: &mut dyn Write, env: &Env, items: &[&Enumeration]) -> Resul
                 .map(|c| c.members.matched(&member.name))
                 .unwrap_or_else(Vec::new);
             let is_alias = member_config.iter().any(|m| m.alias);
-            let version = member_config.iter().filter_map(|m| m.version).next();
+            let version = member_config.iter().find_map(|m| m.version);
 
             if is_alias {
                 continue;

--- a/src/codegen/sys/lib_.rs
+++ b/src/codegen/sys/lib_.rs
@@ -169,7 +169,7 @@ fn generate_aliases(w: &mut dyn Write, env: &Env, items: &[&Alias]) -> Result<()
             continue;
         }
         let (comment, c_type) = match ffi_type(env, item.typ, &item.target_c_type) {
-            Ok(x) => ("", x),
+            Ok(x) => ("", x.into_string()),
             x @ Err(..) => ("//", x.into_string()),
         };
         writeln!(w, "{}pub type {} = {};", comment, item.c_identifier, c_type)?;
@@ -237,7 +237,7 @@ fn generate_constants(w: &mut dyn Write, env: &Env, constants: &[Constant]) -> R
             continue;
         }
         let (comment, mut type_) = match ffi_type(env, constant.typ, &constant.c_type) {
-            Ok(x) => ("", x),
+            Ok(x) => ("", x.into_string()),
             x @ Err(..) => ("//", x.into_string()),
         };
         let mut value = constant.value.clone();

--- a/src/codegen/trampoline.rs
+++ b/src/codegen/trampoline.rs
@@ -7,7 +7,7 @@ use crate::{
         bounds::{BoundType, Bounds},
         ffi_type::ffi_type,
         ref_mode::RefMode,
-        rust_type::parameter_rust_type,
+        rust_type::RustType,
         trampoline_parameters::*,
         trampolines::Trampoline,
         try_from_glib::TryFromGlib,
@@ -160,19 +160,12 @@ fn func_parameter(
             }
             BoundType::AsRef(_) => t.to_string(),
         },
-        None => {
-            let rust_type = parameter_rust_type(
-                env,
-                par.typ,
-                par.direction,
-                par.nullable,
-                ref_mode,
-                library::ParameterScope::None,
-                &TryFromGlib::from_type_defaults(env, par.typ),
-            );
-
-            rust_type.into_string()
-        }
+        None => RustType::builder(env, par.typ)
+            .with_direction(par.direction)
+            .with_nullable(par.nullable)
+            .with_ref_mode(ref_mode)
+            .try_build_param()
+            .into_string(),
     }
 }
 

--- a/src/codegen/trampoline.rs
+++ b/src/codegen/trampoline.rs
@@ -10,6 +10,7 @@ use crate::{
         rust_type::parameter_rust_type,
         trampoline_parameters::*,
         trampolines::Trampoline,
+        try_from_glib::TryFromGlib,
     },
     consts::TYPE_PARAMETERS_START,
     env::Env,
@@ -167,7 +168,9 @@ fn func_parameter(
                 par.nullable,
                 ref_mode,
                 library::ParameterScope::None,
+                &TryFromGlib::from_type_defaults(env, par.typ),
             );
+
             rust_type.into_string()
         }
     }
@@ -178,8 +181,14 @@ fn func_returns(env: &Env, analysis: &Trampoline) -> String {
         String::new()
     } else if analysis.inhibit {
         " -> glib::signal::Inhibit".into()
+    } else if let Some(return_type) =
+        analysis
+            .ret
+            .to_return_value(env, &TryFromGlib::default(), true)
+    {
+        format!(" -> {}", return_type)
     } else {
-        analysis.ret.to_return_value(env, true)
+        String::new()
     }
 }
 

--- a/src/codegen/trampoline_from_glib.rs
+++ b/src/codegen/trampoline_from_glib.rs
@@ -1,5 +1,5 @@
 use crate::{
-    analysis::{rust_type::rust_type_default, trampoline_parameters::Transformation},
+    analysis::{rust_type::RustType, trampoline_parameters::Transformation},
     env::Env,
     library,
     nameutil::is_gstring,
@@ -21,7 +21,7 @@ impl TrampolineFromGlib for Transformation {
                 let is_borrow = self.conversion_type == Borrow;
                 let need_type_name = need_type_name || (is_borrow && nullable);
                 let (mut left, mut right) = from_glib_xxx(self.transfer, is_borrow);
-                let type_name = rust_type_default(env, self.typ).into_string();
+                let type_name = RustType::try_new(env, self.typ).into_string();
                 if need_type_name {
                     if is_borrow && nullable {
                         left = format!("Option::<{}>::{}", type_name, left);

--- a/src/codegen/trampoline_from_glib.rs
+++ b/src/codegen/trampoline_from_glib.rs
@@ -1,5 +1,5 @@
 use crate::{
-    analysis::{rust_type::rust_type, trampoline_parameters::Transformation},
+    analysis::{rust_type::rust_type_default, trampoline_parameters::Transformation},
     env::Env,
     library,
     nameutil::is_gstring,
@@ -16,12 +16,12 @@ impl TrampolineFromGlib for Transformation {
         let need_type_name = need_downcast || is_need_type_name(env, self.typ);
         match self.conversion_type {
             Direct => self.name.clone(),
-            Scalar => format!("from_glib({})", self.name),
+            Scalar | Option | Result { .. } => format!("from_glib({})", self.name),
             Borrow | Pointer => {
                 let is_borrow = self.conversion_type == Borrow;
                 let need_type_name = need_type_name || (is_borrow && nullable);
                 let (mut left, mut right) = from_glib_xxx(self.transfer, is_borrow);
-                let type_name = rust_type(env, self.typ).into_string();
+                let type_name = rust_type_default(env, self.typ).into_string();
                 if need_type_name {
                     if is_borrow && nullable {
                         left = format!("Option::<{}>::{}", type_name, left);

--- a/src/codegen/trampoline_to_glib.rs
+++ b/src/codegen/trampoline_to_glib.rs
@@ -9,7 +9,7 @@ impl TrampolineToGlib for library::Parameter {
         use crate::analysis::conversion_type::ConversionType::*;
         match ConversionType::of(env, self.typ) {
             Direct => String::new(),
-            Scalar => ".into_glib()".to_owned(),
+            Scalar | Option | Result { .. } => ".into_glib()".to_owned(),
             Pointer => to_glib_xxx(self.transfer).to_owned(),
             Borrow => "/*Not applicable conversion Borrow*/".to_owned(),
             Unknown => "/*Unknown conversion*/".to_owned(),

--- a/src/codegen/translate_from_glib.rs
+++ b/src/codegen/translate_from_glib.rs
@@ -1,6 +1,6 @@
 use crate::{
     analysis::{
-        self, conversion_type::ConversionType, rust_type::rust_type, try_from_glib::TryFromGlib,
+        self, conversion_type::ConversionType, rust_type::RustType, try_from_glib::TryFromGlib,
     },
     chunk::conversion_from_glib::Mode,
     env::Env,
@@ -88,7 +88,10 @@ impl TranslateFromGlib for analysis::return_value::Info {
         match self.parameter {
             Some(ref par) => match self.base_tid {
                 Some(tid) => {
-                    let rust_type = rust_type(env, tid, par.lib_par.direction, &par.try_from_glib);
+                    let rust_type = RustType::builder(env, tid)
+                        .with_direction(par.lib_par.direction)
+                        .with_try_from_glib(&par.try_from_glib)
+                        .try_build();
                     let from_glib_xxx = from_glib_xxx(par.lib_par.transfer, None);
 
                     let prefix = if *par.lib_par.nullable {

--- a/src/codegen/translate_to_glib.rs
+++ b/src/codegen/translate_to_glib.rs
@@ -12,7 +12,14 @@ impl TranslateToGlib for TransformationType {
         use self::TransformationType::*;
         match *self {
             ToGlibDirect { ref name } => name.clone(),
-            ToGlibScalar { ref name, .. } => format!("{}{}", name, ".into_glib()"),
+            ToGlibScalar {
+                ref name,
+                needs_into,
+                ..
+            } => {
+                let pre_into = if needs_into { ".into()" } else { "" };
+                format!("{}{}{}", name, pre_into, ".into_glib()")
+            }
             ToGlibPointer {
                 ref name,
                 instance_parameter,

--- a/src/library.rs
+++ b/src/library.rs
@@ -33,6 +33,7 @@ impl FromStr for Transfer {
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ParameterDirection {
+    None,
     In,
     Out,
     InOut,

--- a/src/library.rs
+++ b/src/library.rs
@@ -40,8 +40,12 @@ pub enum ParameterDirection {
 }
 
 impl ParameterDirection {
+    pub fn is_in(self) -> bool {
+        matches!(self, ParameterDirection::In | ParameterDirection::InOut)
+    }
+
     pub fn is_out(self) -> bool {
-        self == ParameterDirection::Out || self == ParameterDirection::InOut
+        matches!(self, ParameterDirection::Out | ParameterDirection::InOut)
     }
 }
 
@@ -126,6 +130,26 @@ impl Deref for Nullable {
 impl DerefMut for Nullable {
     fn deref_mut(&mut self) -> &mut bool {
         &mut self.0
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct Mandatory(pub bool);
+
+impl Deref for Mandatory {
+    type Target = bool;
+    fn deref(&self) -> &bool {
+        &self.0
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct Infallible(pub bool);
+
+impl Deref for Infallible {
+    type Target = bool;
+    fn deref(&self) -> &bool {
+        &self.0
     }
 }
 


### PR DESCRIPTION
This is the continuation of https://github.com/gtk-rs/gtk-rs/pull/11. See also details in https://gitlab.freedesktop.org/gstreamer/gstreamer-rs/-/issues/234.

This PR adds new variants to `conversion_type` so that `gir` can generate the types implementing `TryFromGlib` properly.

Note: since there is no identified implementer for `TryFromGlib<Error=GlibNoneOrInvalidError>` and to avoid introducing untested code, the `ResultOption` variant is not handled in this PR.

## conversion_type "Option"

The `Option` variant is available for types `T` implementing `TryFromGlib<Error=GlibNoneError>`. As a reminder, this allows implementing `FromGlib` for `Option<T>` and `ToGlib` for both `T` and `Option<T>`. In this case, `Option<T>` will be used for return values (including ffi output arguments). For in-arguments, except if the parameter is declared `mandatory`, `impl Into<Option<T>>` so that either an `Option<T>` or `T` can be used.

Ex. from `gstreamer-rs`:

``` rust
[[object]]
name = "Gst.ClockTime"
status = "manual"
conversion_type = "Option"
```

The type `ClockTime` implements `TryFromGlib<Error=GlibNoneError>` (and `OptionToGlib`), which means that its Rust representation can take advantage of `Option<ClockTime>`.

Additionally, the user can instruct `gir` to `expect` `Some` or `Ok` results for specific arguments or return values. E.g.:

``` rust
[[object]]
name = "Gst.Clock"
status = "generate"
manual_traits = ["ClockExtManual"]
    [[object.function]]
    name = "get_calibration"
        [[object.function.parameter]]
        name = "internal"
        mandatory = true
```

In the above example, the user instructs gir to consider the `internal` argument (which also happens to be an out argument) with type gir `Gst.ClockTime` can be represented as a `ClockTime` without the `Option`. This argument is actually part of a set of output arguments. With the above gir declaration, the generated signature is the following (the implementation takes care of `expect`ing the value to be defined):

``` rust
    fn get_calibration(
        &self,
    ) -> (
        ClockTime,
        Option<ClockTime>,
        Option<ClockTime>,
        Option<ClockTime>,
    );
```

For a return value, the mandatory declaration reads:

``` rust
    [[object.function]]
    name = "util_get_timestamp"
    /.../
        [object.function.return]
        # always returns a value
        mandatory = true
```

Note: these examples are presented for illustration purposes only and are intended at testing the mechanism for now, the identification of the actual candidates for mandatory arguments and return values in `gstreamer-rs` is a work in progress.

See resulting code generations for [the out argument](https://gitlab.freedesktop.org/fengalin/gstreamer-rs/-/blob/opt-int-types-rework/gstreamer/src/auto/clock.rs#L273) (see also [`this example`](https://gitlab.freedesktop.org/fengalin/gstreamer-rs/-/blob/opt-int-types-rework/gstreamer/src/auto/clock.rs#L264) for an in argument) and for the [return value](https://gitlab.freedesktop.org/fengalin/gstreamer-rs/-/blob/opt-int-types-rework/gstreamer/src/auto/functions.rs#L269). This is part of a [`gstreamer-rs` branch](https://gitlab.freedesktop.org/fengalin/gstreamer-rs/-/tree/opt-int-types-rework) aiming at implementing https://gitlab.freedesktop.org/gstreamer/gstreamer-rs/-/issues/234.

## conversion_type "Result"

The `Result` variant is available for types `T` implementing `TryFromGlib<Error=Err>` where `Err` is neither `GlibNoneError` nor `GlibNoneOrInvalidError`. In this case, `Result<T, ErrorType>` will be used for return values (including ffi output arguments) and the type itself in argument position.

In `gstreamer-rs`, the C type `GstStateChangeReturn` can represent both a successful or an error return value. In Rust, the `Result` `enum` is the idiomatic way of returning an error. In `gstreamer-rs`, bindings to functions returning `GstStateChangeReturn` had to be manually implemented so as to return `Result<StateChangeSuccess, StateChangeError>`. Note that in this case, the type implementing `TryFromGlib` is `StateChangeSuccess` and not `GstStateChangeReturn`. Thanks to this PR, these functions can now be auto-generated.

``` rust
[[object]]
name = "Gst.StateChangeReturn"
status = "generate"
must_use = true
    [object.conversion_type]
    variant = "Result"
    ok_type = "StateChangeSuccess"
    err_type = "StateChangeError"
```

See [`gst::Element::change_state`]()https://gitlab.freedesktop.org/fengalin/gstreamer-rs/-/blob/opt-int-types-rework/gstreamer/src/auto/element.rs#L77) auto-generation as an example.

For in-arguments user can either use `StateChangeReturn` directly, the `Result` variants or even `StateChangeSuccess` / `StateChangeError` directly. See the [generated code for `gst::Element::continue_state`](https://gitlab.freedesktop.org/fengalin/gstreamer-rs/-/blob/d80d282895fcfb40b8a0b5770105bf516416672b/gstreamer/src/auto/element.rs#L81).

## Non-regression

- [`gtk-rs` regen](https://github.com/fengalin/gtk-rs/tree/try_from_glib-improvement).
- [`gtk4-rs` regen](https://github.com/fengalin/gtk4-rs/tree/try_from_glib-improvement).
- [`gstreamer-rs` regen](https://gitlab.freedesktop.org/fengalin/gstreamer-rs/-/tree/test-regen-try_from_glib).

I didn't write documentation for this yet. It was already more involving than I thought it would be. I'll had an entry in the README once the solution gets accepted.