### PR TITLE
Fix renamed functions not being documented

### DIFF
--- a/src/analysis/functions.rs
+++ b/src/analysis/functions.rs
@@ -500,7 +500,7 @@ fn try_getter_rename(func: &library::Function, name: &str) -> Option<String> {
 fn analyze_function(
     env: &Env,
     obj: &config::gobjects::GObject,
-    mut name: String,
+    name: String,
     status: GStatus,
     func: &library::Function,
     type_tid: library::TypeId,
@@ -551,10 +551,7 @@ fn analyze_function(
         commented = true;
     }
 
-    let mut new_name = configured_functions
-        .iter()
-        .filter_map(|f| f.rename.clone())
-        .next();
+    let mut new_name = configured_functions.iter().find_map(|f| f.rename.clone());
 
     let bypass_auto_rename = configured_functions.iter().any(|f| f.bypass_auto_rename);
     if !bypass_auto_rename && new_name.is_none() {
@@ -567,7 +564,7 @@ fn analyze_function(
                     || name.starts_with("new_with")
                     || name.starts_with("new_for")
                 {
-                    name = name[4..].to_string();
+                    new_name = Some(name[4..].to_string());
                 }
             }
             _ => (),
@@ -583,16 +580,12 @@ fn analyze_function(
     let deprecated_version = func.deprecated_version;
     let cfg_condition = configured_functions
         .iter()
-        .filter_map(|f| f.cfg_condition.clone())
-        .next();
+        .find_map(|f| f.cfg_condition.clone());
     let doc_hidden = configured_functions.iter().any(|f| f.doc_hidden);
     let disable_length_detect = configured_functions.iter().any(|f| f.disable_length_detect);
     let no_future = configured_functions.iter().any(|f| f.no_future);
     let unsafe_ = configured_functions.iter().any(|f| f.unsafe_);
-    let assertion = configured_functions
-        .iter()
-        .filter_map(|f| f.assertion)
-        .next();
+    let assertion = configured_functions.iter().find_map(|f| f.assertion);
 
     let imports = &mut imports.with_defaults(version, &cfg_condition);
 

--- a/src/codegen/doc/mod.rs
+++ b/src/codegen/doc/mod.rs
@@ -281,8 +281,7 @@ fn create_object_doc(w: &mut dyn Write, env: &Env, info: &analysis::object::Info
             // field could have been renamed.
             if let Some(trait_name) = configured_functions
                 .iter()
-                .filter_map(|f| f.doc_trait_name.as_ref())
-                .next()
+                .find_map(|f| f.doc_trait_name.as_ref())
             {
                 TypeStruct::new(SType::Trait, trait_name)
             } else {
@@ -291,20 +290,22 @@ fn create_object_doc(w: &mut dyn Write, env: &Env, info: &analysis::object::Info
         } else {
             ty.clone()
         };
-        let fn_name = configured_functions
-            .iter()
-            .filter_map(|f| f.rename.as_ref())
-            .next()
-            .cloned();
-        create_fn_doc(w, env, function, Some(Box::new(ty)), fn_name)?;
+        if let Some(c_identifier) = &function.c_identifier {
+            // Retrieve the new_name computed during analysis, if any
+            let fn_new_name = info
+                .functions
+                .iter()
+                .find(|f| &f.glib_name == c_identifier)
+                .and_then(|analysed_f| analysed_f.new_name.clone());
+            create_fn_doc(w, env, function, Some(Box::new(ty)), fn_new_name)?;
+        }
     }
     for signal in signals {
         let ty = if has_trait {
             let configured_signals = obj.signals.matched(&signal.name);
             if let Some(trait_name) = configured_signals
                 .iter()
-                .filter_map(|f| f.doc_trait_name.as_ref())
-                .next()
+                .find_map(|f| f.doc_trait_name.as_ref())
             {
                 TypeStruct::new(SType::Trait, trait_name)
             } else {
@@ -320,8 +321,7 @@ fn create_object_doc(w: &mut dyn Write, env: &Env, info: &analysis::object::Info
             let configured_properties = obj.properties.matched(&property.name);
             if let Some(trait_name) = configured_properties
                 .iter()
-                .filter_map(|f| f.doc_trait_name.as_ref())
-                .next()
+                .find_map(|f| f.doc_trait_name.as_ref())
             {
                 TypeStruct::new(SType::Trait, trait_name)
             } else {


### PR DESCRIPTION
This is a workaround for renamed functions not being matched during doc generation. A better solution would require a rework of `gir` so that codegen processes "analysis augmented" items everywhere.

It's not enough to check the `configured_functions` for a `rename`d value since, among others, final renaming uses heuristics and performs name conflict resolution against existing methods and properties. The renaming logic is implemented in `analysis::functions`. The workaround consists in retrieving the `analysis::functions::Info` to get the `new_name`, if any.

This allows generating new `*.md` files with the expected names. Currently, these files are stored in https://github.com/gtk-rs/lgpl-docs. However, they are only updated when a new version is released. Discussions are in progress so as to generate these files locally on the fly. In the meantime, the result of this PR can only be tested locally by generating the `md` files and applying them using `rustdoc-stripper`, or by relying on a custom branch of https://github.com/gtk-rs/lgpl-docs and patching the target crate's workspace to select this branch.

Fixes https://github.com/gtk-rs/gir/issues/936