### PR TITLE
config,git: Omit gir directory hash and URL if not a submodule

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,7 @@
 use std::{fs::File, io::Write};
 
+// Build.rs does not use all provided functions
+#[allow(dead_code)]
 #[path = "src/git.rs"]
 mod git;
 

--- a/src/codegen/general.rs
+++ b/src/codegen/general.rs
@@ -52,14 +52,19 @@ pub fn single_version_file(w: &mut dyn Write, conf: &Config, prefix: &str) -> Re
         conf.girs_version
             .iter()
             .map(|info| {
-                format!(
-                    "{}from {} ({}@ {})\n",
-                    prefix,
-                    info.gir_dir.display(),
-                    info.get_repository_url()
-                        .map_or_else(String::new, |u| format!("{} ", u)),
-                    info.get_hash(),
-                )
+                match (info.get_repository_url(), info.get_hash()) {
+                    (Some(url), Some(hash)) => format!(
+                        "{}from {} ({} @ {})\n",
+                        prefix,
+                        info.gir_dir.display(),
+                        url,
+                        hash,
+                    ),
+                    (None, Some(hash)) => {
+                        format!("{}from {} (@ {})\n", prefix, info.gir_dir.display(), hash,)
+                    }
+                    _ => format!("{}from {}\n", prefix, info.gir_dir.display()),
+                }
             })
             .collect::<String>(),
     )


### PR DESCRIPTION
Intially plaguing GStreamer-rs this code grabs the git hash from the root repository if the specified gir directory is not a submodule.  GStreamer-rs since moved all gir files to subdirectories (because it is possible to have multiple now) but various external projects have a single gir file checked in to the root repo and do not want to see all generated files change the hash after every regeneration while the root repository is checked out on a different commit.

This change uses `git rev-parse --show-toplevel` to resolve where the repository (folder containing `.git`) for a given directory lives and ignores the hash and URL if that is equivalent to the canonical path of the root.

CC @sophie-h for requesting this :)