### PR TITLE
analysis/record: Do not bail on missing memory functions

### DIFF
--- a/src/analysis/record.rs
+++ b/src/analysis/record.rs
@@ -180,7 +180,6 @@ pub fn new(env: &Env, obj: &GObject) -> Option<Info> {
             }
         } else {
             error!("Missing memory management functions for {}", full_name);
-            return None;
         }
     }
 

--- a/src/codegen/record.rs
+++ b/src/codegen/record.rs
@@ -73,8 +73,7 @@ pub fn generate(w: &mut dyn Write, env: &Env, analysis: &analysis::record::Info)
             &analysis.derives,
         )?;
     } else {
-        // This is checked in analysis::record already
-        unreachable!(
+        panic!(
             "Missing memory management functions for {}",
             analysis.full_name
         );


### PR DESCRIPTION
This constraint is already enforced with a `panic!` during codegen,
effectively disallowing Gir.toml from specifying objects that cannot be
generated.  It is now more obvious instead of being just an error line
in the (already pretty spammy) logs.

Furthermore analysis is also used to generate documentation, including
those for manual types.  Bailing here means no analysis for the type
is available leading to missing documentation.  After this change we get
a bunch of missing text to show up in `docs.md` in GStreamer for the
manual types that lack memory functions.

See also #1094

---

I have been thinking about wrapping `return None;` in `needs_generate()` but that seems such an unnecessary and arbitrary constraint, let's catch it in codegen instead.