### PR TITLE
WIP: builder: prefix properties of parent class interfaces with the crate …

### DIFF
--- a/src/analysis/class_builder.rs
+++ b/src/analysis/class_builder.rs
@@ -101,8 +101,7 @@ fn analyze_property(
         .iter()
         .filter_map(|f| f.version)
         .min()
-        .or(prop.version)
-        .or(Some(env.config.min_cfg_version));
+        .or(prop.version);
 
     let for_builder = prop.construct_only || prop.construct || prop.writable;
     if !for_builder {

--- a/src/analysis/properties.rs
+++ b/src/analysis/properties.rs
@@ -31,6 +31,18 @@ pub struct Property {
     pub set_bound: Option<PropertyBound>,
     pub version: Option<Version>,
     pub deprecated_version: Option<Version>,
+    pub parent_crate: Option<String>,
+}
+
+impl Property {
+    pub fn parent_crate_feature(&self) -> Option<String> {
+        if let Some(parent_crate) = &self.parent_crate {
+            self.version
+                .map(|v| format!("feature = \"{}_{}\"", parent_crate, v.to_feature()))
+        } else {
+            None
+        }
+    }
 }
 
 pub fn analyze(
@@ -106,6 +118,7 @@ fn analyze_property(
         .min()
         .or(prop.version)
         .or(Some(env.config.min_cfg_version));
+
     let generate = configured_properties
         .iter()
         .filter_map(|f| f.generate)
@@ -230,6 +243,7 @@ fn analyze_property(
             bounds: Bounds::default(),
             version: prop_version,
             deprecated_version: prop.deprecated_version,
+            parent_crate: None,
         })
     } else {
         None
@@ -265,6 +279,7 @@ fn analyze_property(
             bounds: Bounds::default(),
             version: prop_version,
             deprecated_version: prop.deprecated_version,
+            parent_crate: None,
         })
     } else {
         None

--- a/src/codegen/properties.rs
+++ b/src/codegen/properties.rs
@@ -1,5 +1,5 @@
 use super::{
-    general::{cfg_deprecated, doc_alias, version_condition},
+    general::{cfg_condition_string, cfg_deprecated, doc_alias, version_condition},
     property_body,
 };
 use crate::{
@@ -49,7 +49,14 @@ fn generate_prop_func(
     if !in_trait || only_declaration {
         cfg_deprecated(w, env, prop.deprecated_version, commented, indent)?;
     }
-    version_condition(w, env, prop.version, commented, indent)?;
+    // In case the property is originated from a parent class/interface from another library
+    if let Some(cfg_condition) = prop.parent_crate_feature() {
+        if let Some(s) = cfg_condition_string(&Some(cfg_condition), commented, indent) {
+            writeln!(w, "{}", s)?
+        }
+    } else {
+        version_condition(w, env, prop.version, commented, indent)?;
+    }
     if !in_trait || only_declaration {
         if let Some(func_name_alias) = prop.func_name_alias.as_ref() {
             doc_alias(w, func_name_alias, comment_prefix, indent)?;


### PR DESCRIPTION
…name

this only should be done if the props are from a different library
fixes #1099

Before: it would generate something like
```rust
    #[cfg(any(feature = "v3_0", feature = "dox"))]
    #[cfg_attr(feature = "dox", doc(cfg(feature = "v3_0")))]
    hexpand_set: Option<bool>,
    #[cfg(any(feature = "v1_0", feature = "dox"))]
    #[cfg_attr(feature = "dox", doc(cfg(feature = "v1_0")))]
```

after:
```rust
    #[cfg(any(feature = "gtk_v3_0", feature = "dox"))]
    #[cfg_attr(feature = "dox", doc(cfg(feature = "gtk_v3_0")))]
    hexpand_set: Option<bool>,
    #[cfg(any(feature = "gtk_v1_0", feature = "dox"))]
    #[cfg_attr(feature = "dox", doc(cfg(feature = "gtk_v1_0")))]
```