### PR TITLE
doc: Always consider `trait_name` from `Gir.toml` in implementation docs

### DIFF
--- a/src/analysis/symbols.rs
+++ b/src/analysis/symbols.rs
@@ -13,7 +13,7 @@ pub struct Symbol {
 }
 
 impl Symbol {
-    pub fn full_rust_name(&self) -> String {
+    pub fn parent(&self) -> String {
         let mut ret = String::new();
         if let Some(ref s) = self.crate_name {
             if s == "gobject" {
@@ -27,6 +27,11 @@ impl Symbol {
             ret.push_str(s);
             ret.push_str("::");
         }
+        ret
+    }
+
+    pub fn full_rust_name(&self) -> String {
+        let mut ret = self.parent();
         ret.push_str(&self.name);
         ret
     }

--- a/src/codegen/doc/mod.rs
+++ b/src/codegen/doc/mod.rs
@@ -637,8 +637,7 @@ fn get_type_trait_for_implements(env: &Env, tid: TypeId) -> String {
     if tid.ns_id == MAIN_NAMESPACE {
         format!("[`{n}`](trait@crate::{n})", n = &trait_name)
     } else if let Some(symbol) = env.symbols.borrow().by_tid(tid) {
-        let full_trait_name = symbol.full_rust_name();
-        format!("[`trait@{}Ext`]", &full_trait_name)
+        format!("[`trait@{}{}`]", &symbol.parent(), trait_name)
     } else {
         error!("Type {} doesn't have crate", tid.full_name(&env.library));
         format!("`{}`", trait_name)


### PR DESCRIPTION
Some types have their trait name overridden for clarity, but this is not always conveyed in the docs.  This bit of code partially solves a case in GStreamer-rs where links show up to `gst::ObjectExt` that should have been `gst::GstObjectExt` instead, as per `trait_name = "GstObjectExt"`.

---

CC @slomo: This doesn't fix our `GstObjectExt` mismatch in GStreamer-rs _yet_! For that we'll have to replicate the override in every `Gir.toml` that uses the type:

```toml
[[object]]
name = "Gst.Object"
status = "manual"
trait_name = "GstObjectExt"
```

Do we have a smarter way of doing so, as well as for the other `trait_name =` overrides?