### PR TITLE
codegen/object: Only re-export traits from `traits`/`prelude` module

### DIFF
--- a/src/codegen/object.rs
+++ b/src/codegen/object.rs
@@ -402,15 +402,13 @@ pub fn generate_reexports(
         module_name, analysis.name, none_type
     ));
     if need_generate_trait(analysis) {
-        contents.extend_from_slice(&cfgs);
-        contents.push(format!(
-            "pub use self::{}::{};",
-            module_name, analysis.trait_name
-        ));
         for cfg in &cfgs {
             traits.push(format!("\t{}", cfg));
         }
-        traits.push(format!("\tpub use super::{};", analysis.trait_name));
+        traits.push(format!(
+            "\tpub use super::{}::{};",
+            module_name, analysis.trait_name
+        ));
     }
 
     if !analysis.builder_properties.is_empty() {


### PR DESCRIPTION
Following a discussion in [1] we have decided to remove all trait exports - both manual and automatic - from the crate root in favour of having them available to crate users in `prelude` only, as per the intended design.  It was inconsistent to have ExtManual traits available in `prelude` only (and some randomly in the crate root in GStreamer-rs) whereas all automatic traits were re-exported through the crate root as well.

[1]: https://github.com/gtk-rs/gir/pull/1111

CC @bilelmoussaoui
