### PR TITLE
ci: Symlink gir directory to ourselves to find generator.py

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -168,6 +168,10 @@ jobs:
           ref: master
           path: gtk-rs
         if: matrix.os == 'ubuntu-20.04'
+      - name: "Symlink `gir` in GTK"
+        run: |
+          rmdir gtk-rs/gir
+          ln -sf .. gtk-rs/gir
       - name: "Attempt to rebuild GTK gir"
         run: cd gtk-rs && python3 generator.py --no-fmt --gir-path ../target/release/gir --gir-files-directories ../tests/gir-files/ && rm ../Cargo.* && cargo build
         if: matrix.os == 'ubuntu-20.04'


### PR DESCRIPTION
`generator.py` moved into this repository, and gtk-rs (and friends) now symlink to `gir/generator.py`.  We could simply call `../generator.py` instead, but this make sure the symlink is actually valid.
