### PR TITLE
Add rename doc aliases

### DIFF
--- a/src/analysis/functions.rs
+++ b/src/analysis/functions.rs
@@ -71,6 +71,7 @@ pub struct AsyncFuture {
 #[derive(Debug)]
 pub struct Info {
     pub name: String,
+    pub func_name: String,
     pub new_name: Option<String>,
     pub glib_name: String,
     pub status: GStatus,
@@ -163,6 +164,7 @@ pub fn analyze<F: Borrow<library::Function>>(
         let mut info = analyze_function(
             env,
             obj,
+            &func.name,
             name,
             status,
             func,
@@ -482,6 +484,7 @@ fn analyze_callbacks(
 fn analyze_function(
     env: &Env,
     obj: &config::gobjects::GObject,
+    func_name: &str,
     name: String,
     status: GStatus,
     func: &library::Function,
@@ -806,6 +809,7 @@ fn analyze_function(
 
     Info {
         name,
+        func_name: func_name.to_string(),
         new_name,
         glib_name: func.c_identifier.as_ref().unwrap().clone(),
         status,

--- a/src/analysis/properties.rs
+++ b/src/analysis/properties.rs
@@ -331,7 +331,7 @@ fn analyze_property(
             imports.add("std::boxed::Box as Box_");
 
             Some(signals::Info {
-                connect_name: format!("connect_property_{}_notify", name_for_func),
+                connect_name: format!("connect_{}_notify", name_for_func),
                 signal_name: format!("notify::{}", name),
                 trampoline,
                 action_emit_name: None,

--- a/src/analysis/properties.rs
+++ b/src/analysis/properties.rs
@@ -218,7 +218,7 @@ fn analyze_property(
 
         Some(Property {
             name: name.clone(),
-            var_name: String::new(),
+            var_name: nameutil::mangle_keywords(&*name_for_func).into_owned(),
             typ: prop.typ,
             is_get: true,
             func_name: get_func_name,

--- a/src/codegen/child_properties.rs
+++ b/src/codegen/child_properties.rs
@@ -1,4 +1,7 @@
-use super::{general::doc_hidden, property_body};
+use super::{
+    general::{doc_alias, doc_hidden},
+    property_body,
+};
 use crate::{
     analysis::{
         child_properties::ChildProperty,
@@ -43,8 +46,22 @@ fn generate_func(
     writeln!(w)?;
 
     doc_hidden(w, prop.doc_hidden, comment_prefix, indent)?;
-    // FIXME handle doc alias
     let decl = declaration(env, prop, is_get);
+    if !in_trait || only_declaration {
+        let add_doc_alias = if is_get {
+            prop.name != prop.getter_name && prop.name != prop.prop_name
+        } else {
+            prop.name != prop.prop_name
+        };
+        if add_doc_alias {
+            doc_alias(
+                w,
+                &format!("{}.{}", &prop.child_name, &prop.name),
+                comment_prefix,
+                indent,
+            )?;
+        }
+    }
     writeln!(
         w,
         "{}{}{}{}{}",

--- a/src/codegen/child_properties.rs
+++ b/src/codegen/child_properties.rs
@@ -43,6 +43,7 @@ fn generate_func(
     writeln!(w)?;
 
     doc_hidden(w, prop.doc_hidden, comment_prefix, indent)?;
+    // FIXME handle doc alias
     let decl = declaration(env, prop, is_get);
     writeln!(
         w,

--- a/src/codegen/function.rs
+++ b/src/codegen/function.rs
@@ -89,6 +89,9 @@ pub fn generate(
     doc_hidden(w, analysis.doc_hidden, comment_prefix, indent)?;
     if !in_trait || only_declaration {
         doc_alias(w, &analysis.glib_name, comment_prefix, indent)?;
+        if analysis.codegen_name() != analysis.func_name {
+            doc_alias(w, &analysis.func_name, comment_prefix, indent)?;
+        }
     }
     writeln!(
         w,

--- a/src/codegen/properties.rs
+++ b/src/codegen/properties.rs
@@ -51,8 +51,13 @@ fn generate_prop_func(
     }
     version_condition(w, env, prop.version, commented, indent)?;
     if !in_trait || only_declaration {
-        if let Some(func_name_alias) = prop.func_name_alias.as_ref() {
-            doc_alias(w, func_name_alias, comment_prefix, indent)?;
+        let add_doc_alias = if let Some(func_name_alias) = prop.func_name_alias.as_ref() {
+            &prop.name != func_name_alias && prop.name != prop.var_name
+        } else {
+            prop.name != prop.var_name
+        };
+        if add_doc_alias {
+            doc_alias(w, &prop.name, comment_prefix, indent)?;
         }
     }
     writeln!(

--- a/src/codegen/signal.rs
+++ b/src/codegen/signal.rs
@@ -1,5 +1,5 @@
 use super::{
-    general::{cfg_deprecated, doc_hidden, version_condition},
+    general::{cfg_deprecated, doc_alias, doc_hidden, version_condition},
     signal_body,
     trampoline::{self, func_string},
 };
@@ -35,6 +35,14 @@ pub fn generate(
     }
     version_condition(w, env, analysis.version, commented, indent)?;
     doc_hidden(w, analysis.doc_hidden, comment_prefix, indent)?;
+    // Strip the "prefix" from "prefix::prop-name", if any.
+    // Ex.: "notify::is-locked".
+    doc_alias(
+        w,
+        analysis.signal_name.splitn(2, "::").last().unwrap(),
+        comment_prefix,
+        indent,
+    )?;
     writeln!(
         w,
         "{}{}{}{}{}",


### PR DESCRIPTION
This is an attempt at fixing gtk-rs/gir#1105. See also [the result for `gtk-rs`](https://github.com/gtk-rs/gtk-rs/pull/490).

It also addresses concerns described by @sdroege regarding some doc aliases which didn't match the name in upstream doc due to name mangling or property naming conventions. It also adds doc aliases for child properties which were not generated before.

Note that aliases from properties are no longer generated when they match the final name, hence the reduction in the "prop name alias" step below.