### PR TITLE
analysis/properties: Remove unused ToValue import for property getters

### DIFF
--- a/src/analysis/properties.rs
+++ b/src/analysis/properties.rs
@@ -214,7 +214,6 @@ fn analyze_property(
         }
         if type_string.is_ok() {
             imports.add("glib::StaticType");
-            imports.add("glib::ToValue");
         }
 
         Some(Property {


### PR DESCRIPTION
Following [1] an unnecessary `glib::ToValue` import showed up in auto
code, which does not appear to be used in gtk-rs nor gstreamer-rs.
After all, getters convert from Values, not to Values.

Fixes: c6cacb0 ("Implement handling of new Value traits")

[1]: https://gitlab.freedesktop.org/gstreamer/gstreamer-rs/-/merge_requests/746#note_893561

---

Cc @sdroege, this seems correct. Unfortunately `gtk-rs` was already riddled with `#[allow(unused_imports)]`.