### PR TITLE
build: Rerun if git hash changed

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -6,6 +6,11 @@ use std::{fs::File, io::Write};
 mod git;
 
 fn main() {
+    let repo_path = git::git_dir(".").unwrap();
+    println!(
+        "cargo:rerun-if-changed={}",
+        repo_path.join("HEAD").display()
+    );
     let ver = git::repo_hash(".").unwrap_or_else(|| "???".into());
 
     File::create("src/gir_version.rs")

--- a/src/git.rs
+++ b/src/git.rs
@@ -52,8 +52,8 @@ fn gitmodules_config(subcommand: &[&str]) -> Option<String> {
     Some(result)
 }
 
-pub fn toplevel(path: impl AsRef<Path>) -> Option<PathBuf> {
-    let mut output = git_command(path, &["rev-parse", "--show-toplevel"]).ok()?;
+fn path_command(path: impl AsRef<Path>, subcommand: &[&str]) -> Option<PathBuf> {
+    let mut output = git_command(path, subcommand).ok()?;
 
     if !output.status.success() {
         return None;
@@ -69,6 +69,16 @@ pub fn toplevel(path: impl AsRef<Path>) -> Option<PathBuf> {
     );
     let toplevel = OsString::from_vec(output.stdout);
     Some(toplevel.into())
+}
+
+pub fn toplevel(path: impl AsRef<Path>) -> Option<PathBuf> {
+    path_command(path, &["rev-parse", "--show-toplevel"])
+}
+
+// Only build.rs uses this
+#[allow(dead_code)]
+pub fn git_dir(path: impl AsRef<Path>) -> Option<PathBuf> {
+    path_command(path, &["rev-parse", "--git-dir"])
 }
 
 pub(crate) fn repo_remote_url(path: impl AsRef<Path>) -> Option<String> {


### PR DESCRIPTION
`gir`'s hash in version files gets out of sync quite frequently with the hash of the submodule.  This happens when generating from a change locally, creating a PR and later regenerating on the merge commit.  When no file changes have been made `gir` doesn't get recompiled with the newer hash, but the submodule hash is still changed resulting in a mismatch.  It is usually caught later on another machine/checkout.

This change ensures `gir`'s hash is always updated when the checkout changes, even if no code changes have been made that would normally cause `cargo` to recompile it.
