### PR TITLE
doc: Link trait functions in `prelude`

### DIFF
--- a/src/analysis/symbols.rs
+++ b/src/analysis/symbols.rs
@@ -41,11 +41,22 @@ impl Symbol {
         ret
     }
 
-    pub fn make_trait_method(&mut self, trait_name: &str) {
+    fn make_in_prelude(&mut self) {
         if self.module_name.replace("prelude".to_string()).is_some() {
             // .expect_none is not stabilized yet
             panic!("{:?} already had a module name set!", self)
         }
+    }
+
+    /// Convert this symbol into a trait
+    pub fn make_trait(&mut self, trait_name: &str) {
+        self.make_in_prelude();
+        self.name = trait_name.into();
+    }
+
+    /// Convert this into a method of a trait
+    pub fn make_trait_method(&mut self, trait_name: &str) {
+        self.make_in_prelude();
         self.owner_name = Some(trait_name.into());
     }
 

--- a/src/codegen/doc/mod.rs
+++ b/src/codegen/doc/mod.rs
@@ -607,7 +607,9 @@ fn get_type_trait_for_implements(env: &Env, tid: TypeId) -> String {
     if tid.ns_id == MAIN_NAMESPACE {
         format!("[`{n}`](trait@crate::prelude::{n})", n = &trait_name)
     } else if let Some(symbol) = env.symbols.borrow().by_tid(tid) {
-        format!("[`trait@{}{}`]", &symbol.parent(), trait_name)
+        let mut symbol = symbol.clone();
+        symbol.make_trait(&trait_name);
+        format!("[`trait@{}`]", &symbol.full_rust_name())
     } else {
         error!("Type {} doesn't have crate", tid.full_name(&env.library));
         format!("`{}`", trait_name)


### PR DESCRIPTION
We recently removed all `Ext` and `ExtManual` traits from crate roots in favour of consistently exporting them from the prelude only, and at about the same time merged intradoc links for function symbols.  Both work as intended in isolation, but result in lots of broken links when put together because the documentation generator doesn't know about the existence of a `prelude` module.  This patch corrects the module path by leveraging existing `make_trait_method` machinery.

---
Old part of the comment, this is all fixed now:

~This breaks function references to "normal" `impl StructName` blocks. Could be a simple check for `Ext`/`ExtManual` suffix, but that's horrible.~

~All in all I'm really lost as to what the best way is to represent where a function lives, this should afaik be available in analysis and propagated into the documentation generator (through `symbol::Info`?). After all the name already contains `*Ext` or `*ExtManual` meaning an earlier step in the process is well aware of the type: this is where `prelude::` should likely be added, or otherwise through an `is_trait: bool` member. Sounds simple, but that has to wait until I have more time available - or someone else comes up with a nice solution :)~