### PR TITLE
Fix some clippy::use_self warnings in generated code

### DIFF
--- a/src/codegen/flags.rs
+++ b/src/codegen/flags.rs
@@ -169,8 +169,8 @@ impl IntoGlib for {name} {{
         w,
         "#[doc(hidden)]
 impl FromGlib<{sys_crate_name}::{ffi_name}> for {name} {{
-    unsafe fn from_glib(value: {sys_crate_name}::{ffi_name}) -> {name} {{
-        {assert}{name}::from_bits_truncate(value)
+    unsafe fn from_glib(value: {sys_crate_name}::{ffi_name}) -> Self {{
+        {assert}Self::from_bits_truncate(value)
     }}
 }}
 ",
@@ -235,7 +235,7 @@ impl FromGlib<{sys_crate_name}::{ffi_name}> for {name} {{
             w,
             "impl ToValue for {name} {{
     fn to_value(&self) -> {gvalue} {{
-        let mut value = {gvalue}::for_value_type::<{name}>();
+        let mut value = {gvalue}::for_value_type::<Self>();
         unsafe {{
             {glib}(value.to_glib_none_mut().0, self.into_glib());
         }}

--- a/src/codegen/sys/tests.rs
+++ b/src/codegen/sys/tests.rs
@@ -318,7 +318,7 @@ struct Compiler {
 }
 
 impl Compiler {
-    pub fn new() -> Result<Compiler, Box<dyn Error>> {
+    pub fn new() -> Result<Self, Box<dyn Error>> {
         let mut args = get_var("CC", "cc")?;
         args.push("-Wno-deprecated-declarations".to_owned());
         // For _Generic
@@ -328,7 +328,7 @@ impl Compiler {
         args.extend(get_var("CFLAGS", "")?);
         args.extend(get_var("CPPFLAGS", "")?);
         args.extend(pkg_config_cflags(PACKAGES)?);
-        Ok(Compiler { args })
+        Ok(Self { args })
     }
 
     pub fn compile(&self, src: &Path, out: &Path) -> Result<(), Box<dyn Error>> {


### PR DESCRIPTION
Some low-hanging fruit to shorten generated code and making it more readable at the same time.

This is only scratching the surface. If we really want to combat `use_self` we'd have to replace function arguments and return types, which is not worth it IMO. This was simple enough (simplifying the generator, too) that it should be okay to do.
