### PR TITLE
codegen/enums: Keep emitting name of `Self` in string literals

### DIFF
--- a/src/codegen/enums.rs
+++ b/src/codegen/enums.rs
@@ -164,9 +164,9 @@ fn generate_enum(
         version_condition(w, env, enum_.version, false, 0)?;
         writeln!(
             w,
-            "impl fmt::Display for {} {{\n\
+            "impl fmt::Display for {0} {{\n\
              \tfn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {{\n\
-             \t\twrite!(f, \"Self::{{}}\", match *self {{",
+             \t\twrite!(f, \"{0}::{{}}\", match *self {{",
             enum_.name
         )?;
         for member in &members {


### PR DESCRIPTION
Commit 3f36d06 ("Fix some clippy::use_self warnings in generated code") did away with repeating the surrounding type name in places where the `Self` keyword is preferred (`clippy::use_self`), but accidentally also replaced the type in a string literal used for formatting (first noticed in [1]).  When these enums are printed the logs will be filled with helpless `Self::<variant>` instead of `<type>::<variant>` which wasn't intended.

[1]: https://github.com/gtk-rs/gtk4-rs/pull/349/files#r625049878

---

Can anyone double-check aforementioned commit for more such mistakes.  I don't see any but I don't trust my eyes anymore :flushed:
