### PR TITLE
config/function: allow forcing 'constructor' annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,6 +484,17 @@ name = "Gtk.TextBuffer"
     bypass_auto_rename = true
 ```
 
+Some constructors are not annotated as `constructor` in the `gir` files. In
+order for the naming convention to be applied, you can force a function to be
+considered as a constructor:
+
+```toml
+[[object.function]]
+name = "new_for_path"
+# Not annotated as constructor in Gir => force it to apply naming convention
+constructor = true
+```
+
 #### conversion_type "Option"
 
 The `conversion_type` variant `Option` is available for types `T` implementing

--- a/src/config/functions.rs
+++ b/src/config/functions.rs
@@ -237,6 +237,7 @@ pub struct Function {
     pub unsafe_: bool,
     pub rename: Option<String>,
     pub bypass_auto_rename: bool,
+    pub is_constructor: Option<bool>,
     pub assertion: Option<SafetyAssertionMode>,
 }
 
@@ -270,6 +271,7 @@ impl Parse for Function {
                 "unsafe",
                 "rename",
                 "bypass_auto_rename",
+                "constructor",
                 "assertion",
             ],
             &format!("function {}", object_name),
@@ -330,14 +332,14 @@ impl Parse for Function {
             .lookup("rename")
             .and_then(Value::as_str)
             .map(ToOwned::to_owned);
+        if !check_rename(&rename, object_name, &ident) {
+            return None;
+        }
         let bypass_auto_rename = toml
             .lookup("bypass_auto_rename")
             .and_then(Value::as_bool)
             .unwrap_or(false);
-        if !check_rename(&rename, object_name, &ident) {
-            return None;
-        }
-
+        let is_constructor = toml.lookup("constructor").and_then(Value::as_bool);
         let assertion = toml
             .lookup("assertion")
             .and_then(Value::as_str)
@@ -363,6 +365,7 @@ impl Parse for Function {
             unsafe_,
             rename,
             bypass_auto_rename,
+            is_constructor,
             assertion,
         })
     }


### PR DESCRIPTION
Some `constructor`s are not annotated as such in `gir` files. This PR allows configuring a function as `constructor` so that it can be renamed according to the naming conventions for constructors.

Required for: https://github.com/gtk-rs/gtk-rs/pull/505