### PR TITLE
codegen: Emit `crate::` for all global `%` constants except from prelude

### DIFF
--- a/src/analysis/symbols.rs
+++ b/src/analysis/symbols.rs
@@ -11,6 +11,7 @@ pub struct Symbol {
     module_name: Option<String>,
     owner_name: Option<String>,
     name: String,
+    rust_prelude: bool,
 }
 
 impl Symbol {
@@ -71,6 +72,10 @@ impl Symbol {
     pub fn name(&self) -> &str {
         &self.name
     }
+
+    pub fn is_rust_prelude(&self) -> bool {
+        self.rust_prelude
+    }
 }
 
 #[derive(Debug)]
@@ -91,6 +96,7 @@ pub fn run(library: &Library, namespaces: &namespaces::Info) -> Info {
         "NULL",
         Symbol {
             name: "None".into(),
+            rust_prelude: true,
             ..Default::default()
         },
         None,
@@ -99,6 +105,7 @@ pub fn run(library: &Library, namespaces: &namespaces::Info) -> Info {
         "FALSE",
         Symbol {
             name: "false".into(),
+            rust_prelude: true,
             ..Default::default()
         },
         None,
@@ -107,6 +114,7 @@ pub fn run(library: &Library, namespaces: &namespaces::Info) -> Info {
         "TRUE",
         Symbol {
             name: "true".into(),
+            rust_prelude: true,
             ..Default::default()
         },
         None,

--- a/src/analysis/symbols.rs
+++ b/src/analysis/symbols.rs
@@ -41,11 +41,22 @@ impl Symbol {
         ret
     }
 
-    pub fn make_trait_method(&mut self, trait_name: &str) {
+    fn make_in_prelude(&mut self) {
         if self.module_name.replace("prelude".to_string()).is_some() {
             // .expect_none is not stabilized yet
             panic!("{:?} already had a module name set!", self)
         }
+    }
+
+    /// Convert this symbol into a trait
+    pub fn make_trait(&mut self, trait_name: &str) {
+        self.make_in_prelude();
+        self.name = trait_name.into();
+    }
+
+    /// Convert this into a method of a trait
+    pub fn make_trait_method(&mut self, trait_name: &str) {
+        self.make_in_prelude();
         self.owner_name = Some(trait_name.into());
     }
 

--- a/src/codegen/doc/format.rs
+++ b/src/codegen/doc/format.rs
@@ -158,13 +158,15 @@ fn replace_c_types(entry: &str, symbols: &symbols::Info, in_type: &str) -> Strin
                         member,
                         in_type,
                     ),
-                    "#" => format!(
+                    "%" if sym.is_rust_prelude() => {
+                        format!("{}[`{}{}`]", &caps[1], sym.full_rust_name(), member)
+                    }
+                    "#" | "%" => format!(
                         "{}[`{n}{m}`](crate::{n}{m})",
                         &caps[1],
                         n = sym.full_rust_name(),
-                        m = member,
+                        m = member
                     ),
-                    "%" => format!("{}[`{}{}`]", &caps[1], sym.full_rust_name(), member,),
                     c => panic!("Unknown symbol reference {}", c),
                 }
             }

--- a/src/codegen/doc/mod.rs
+++ b/src/codegen/doc/mod.rs
@@ -607,7 +607,9 @@ fn get_type_trait_for_implements(env: &Env, tid: TypeId) -> String {
     if tid.ns_id == MAIN_NAMESPACE {
         format!("[`{n}`](trait@crate::prelude::{n})", n = &trait_name)
     } else if let Some(symbol) = env.symbols.borrow().by_tid(tid) {
-        format!("[`trait@{}{}`]", &symbol.parent(), trait_name)
+        let mut symbol = symbol.clone();
+        symbol.make_trait(&trait_name);
+        format!("[`trait@{}`]", &symbol.full_rust_name())
     } else {
         error!("Type {} doesn't have crate", tid.full_name(&env.library));
         format!("`{}`", trait_name)


### PR DESCRIPTION
Depends on #1119.

Rust prelude symbols - `true`, `false` and `None` - are explicitly added to the list of symbols.  These are the only global constants/symbols that shouldn't receive a `crate::` prefix.  Everything else coming from the current or another crate must be imported from the root as it may reside in another file/module.
