### PR TITLE
[RFC] codegen/doc: Simplify links by allowing `Self::` and `crate::` prefix

### DIFF
--- a/src/codegen/doc/format.rs
+++ b/src/codegen/doc/format.rs
@@ -100,7 +100,7 @@ fn replace_c_types(entry: &str, symbols: &symbols::Info, in_type: &str) -> Strin
             if sym.owner_name() == Some(in_type) {
                 // `#` or `%` symbols should probably have been `@` to denote
                 // that it is a reference within the current type.
-                format!("[`{f}()`](Self::{f}())", f = sym.name())
+                format!("[`Self::{}()`]", sym.name())
             } else {
                 match caps.get(1).as_ref().map(Match::as_str) {
                     // Catch invalid @ references that have a C symbol available but do not belong
@@ -113,7 +113,7 @@ fn replace_c_types(entry: &str, symbols: &symbols::Info, in_type: &str) -> Strin
                         in_type,
                     ),
                     Some("#") | None => {
-                        format!("[`{f}()`](crate::{f}())", f = sym.full_rust_name())
+                        format!("[`crate::{}()`]", sym.full_rust_name())
                     }
                     Some("%") => panic!("% not allowed for {:?}", caps),
                     Some(c) => panic!("Unknown symbol reference {}", c),
@@ -122,9 +122,9 @@ fn replace_c_types(entry: &str, symbols: &symbols::Info, in_type: &str) -> Strin
         } else if let Some(typ) = caps.get(2) {
             let typ = typ.as_str();
             if typ == in_type {
-                format!("[`{f}()`](Self::{f}())", f = name)
+                format!("[`Self::{}()`]", name)
             } else {
-                format!("[`{t}{f}()`](crate::{t}{f}())", t = typ, f = name)
+                format!("[`crate::{}{}()`]", typ, name)
             }
         } else {
             format!("`{}()`", name)
@@ -139,12 +139,7 @@ fn replace_c_types(entry: &str, symbols: &symbols::Info, in_type: &str) -> Strin
             if sym.owner_name() == Some(in_type) {
                 // `#` or `%` symbols should probably have been `@` to denote
                 // that it is a reference within the current type.
-                format!(
-                    "{}[`{n}{m}`](Self::{n}{m})",
-                    &caps[1],
-                    n = sym.name(),
-                    m = member
-                )
+                format!("{}[`Self::{}{}`]", &caps[1], sym.name(), member)
             } else {
                 match &caps[2] {
                     // Catch invalid @ references that have a C symbol available but do not belong
@@ -161,12 +156,9 @@ fn replace_c_types(entry: &str, symbols: &symbols::Info, in_type: &str) -> Strin
                     "%" if sym.is_rust_prelude() => {
                         format!("{}[`{}{}`]", &caps[1], sym.full_rust_name(), member)
                     }
-                    "#" | "%" => format!(
-                        "{}[`{n}{m}`](crate::{n}{m})",
-                        &caps[1],
-                        n = sym.full_rust_name(),
-                        m = member
-                    ),
+                    "#" | "%" => {
+                        format!("{}[`crate::{}{}`]", &caps[1], sym.full_rust_name(), member)
+                    }
                     c => panic!("Unknown symbol reference {}", c),
                 }
             }

--- a/src/codegen/doc/mod.rs
+++ b/src/codegen/doc/mod.rs
@@ -247,12 +247,7 @@ fn create_object_doc(w: &mut dyn Write, env: &Env, info: &analysis::object::Info
                 .into_iter()
                 .chain(env.class_hierarchy.subtypes(info.type_id))
                 .filter(|&tid| !env.type_status(&tid.full_name(&env.library)).ignored())
-                .map(|tid| {
-                    format!(
-                        "[`{n}`](struct@crate::{n})",
-                        n = env.library.type_(tid).get_name()
-                    )
-                })
+                .map(|tid| format!("[`struct@crate::{}`]", env.library.type_(tid).get_name()))
                 .collect::<Vec<_>>();
             implementors.sort();
 
@@ -605,7 +600,7 @@ fn get_type_trait_for_implements(env: &Env, tid: TypeId) -> String {
         format!("{}Ext", env.library.type_(tid).get_name())
     };
     if tid.ns_id == MAIN_NAMESPACE {
-        format!("[`{n}`](trait@crate::prelude::{n})", n = &trait_name)
+        format!("[`trait@crate::prelude::{}`]", &trait_name)
     } else if let Some(symbol) = env.symbols.borrow().by_tid(tid) {
         let mut symbol = symbol.clone();
         symbol.make_trait(&trait_name);
@@ -636,6 +631,6 @@ pub fn get_type_manual_traits_for_implements(
     manual_trait_iters
         .into_iter()
         .flatten()
-        .map(|name| format!("[`{n}`](trait@crate::prelude::{n})", n = name))
+        .map(|name| format!("[`trait@crate::prelude::{}`]", name))
         .collect()
 }


### PR DESCRIPTION
A lot of effort was put in to hide these from the final documentation, by using `[]()` kind of links.  Unfortunately, for symbols that don't exist (broken references in g-ir documentation, types that haven't been implemented yet, functions related to lifetime management and cleanup that are implicit in Rust) these generate clickable links pointing to a Rust item path (`crate::Foo::bar`) which is inconvenient.  On the other hand, without `[]()` indirection but simple `[]` intradoc links rustdoc doesn't emit a link for unknown items at all, leaving a simple monospace Rust path surrounded by brackets.

---

CC @GuillaumeGomez: we discussed this on IRC and it should be a nice simplifications. Seeing `Self::` or `crate::` in docs shouldn't be too bad, on the contrary readers immediately know where to look for a type instead of having to click through to find out where it's at.

Additionally `prelude::` prefixes will also be emitted now (see #1119) which should otherwise be stripped off as well IMO, if we want to go for as concise docs as possible.
