### PR TITLE
funct async: use codegen name for _future funct

### DIFF
--- a/src/analysis/functions.rs
+++ b/src/analysis/functions.rs
@@ -668,6 +668,7 @@ fn analyze_function(
                     env,
                     func,
                     type_tid,
+                    new_name.as_ref().unwrap_or(&name),
                     callback_info,
                     &mut commented,
                     &mut trampoline,
@@ -876,6 +877,7 @@ fn analyze_async(
     env: &Env,
     func: &library::Function,
     type_tid: library::TypeId,
+    codegen_name: &str,
     callback_info: Option<CallbackInfo>,
     commented: &mut bool,
     trampoline: &mut Option<AsyncTrampoline>,
@@ -955,7 +957,7 @@ fn analyze_async(
 
         *trampoline = Some(AsyncTrampoline {
             is_method,
-            name: format!("{}_trampoline", func.name),
+            name: format!("{}_trampoline", codegen_name),
             finish_func_name: format!("{}::{}", env.main_sys_crate_name(), finish_func_name),
             callback_type,
             bound_name,
@@ -966,7 +968,7 @@ fn analyze_async(
         if !no_future {
             *async_future = Some(AsyncFuture {
                 is_method,
-                name: format!("{}_future", func.name),
+                name: format!("{}_future", codegen_name),
                 success_parameters,
                 error_parameters,
                 assertion: match SafetyAssertionMode::of(env, is_method, &parameters) {

--- a/src/codegen/function.rs
+++ b/src/codegen/function.rs
@@ -352,7 +352,7 @@ pub fn body_chunk(env: &Env, analysis: &analysis::functions::Info) -> Chunk {
         } else {
             warn!(
                 "Async function {} has no associated _finish function",
-                analysis.name
+                analysis.codegen_name(),
             );
         }
     } else {
@@ -451,11 +451,11 @@ pub fn body_chunk_futures(
         writeln!(body, "\tlet cancellable = Cancellable::new();")?;
     }
     if async_future.is_method {
-        writeln!(body, "\tobj.{}(", analysis.name)?;
+        writeln!(body, "\tobj.{}(", analysis.codegen_name())?;
     } else if analysis.type_name.is_ok() {
-        writeln!(body, "\tSelf::{}(", analysis.name)?;
+        writeln!(body, "\tSelf::{}(", analysis.codegen_name())?;
     } else {
-        writeln!(body, "\t{}(", analysis.name)?;
+        writeln!(body, "\t{}(", analysis.codegen_name())?;
     }
 
     // Skip the instance parameter


### PR DESCRIPTION
... otherwise we can't take advantage of config and auto-renaming
on non-future function.