### PR TITLE
Stop dereferencing followed by reborrowing in `match` and `if let`

### DIFF
--- a/src/analysis/class_hierarchy.rs
+++ b/src/analysis/class_hierarchy.rs
@@ -32,15 +32,11 @@ fn get_node<'a>(
         return hier.get_mut(&tid);
     }
 
-    let direct_supers: Vec<TypeId> = match *library.type_(tid) {
+    let direct_supers: Vec<TypeId> = match library.type_(tid) {
         Type::Class(Class {
-            ref parent,
-            ref implements,
-            ..
+            parent, implements, ..
         }) => parent.iter().chain(implements.iter()).cloned().collect(),
-        Type::Interface(Interface {
-            ref prerequisites, ..
-        }) => prerequisites.clone(),
+        Type::Interface(Interface { prerequisites, .. }) => prerequisites.clone(),
         _ => return None,
     };
 

--- a/src/analysis/constants.rs
+++ b/src/analysis/constants.rs
@@ -33,7 +33,7 @@ pub fn analyze<F: Borrow<library::Constant>>(
             continue;
         }
 
-        match *env.type_(constant.typ) {
+        match env.type_(constant.typ) {
             library::Type::Fundamental(library::Fundamental::Utf8) => (),
             _ => continue,
         }

--- a/src/analysis/conversion_type.rs
+++ b/src/analysis/conversion_type.rs
@@ -79,8 +79,8 @@ impl ConversionType {
                 UIntPtr => ConversionType::Direct,
                 Unsupported => ConversionType::Unknown,
             },
-            Alias(ref alias) if alias.c_identifier == "GQuark" => ConversionType::Scalar,
-            Alias(ref alias) => ConversionType::of(env, alias.typ),
+            Alias(alias) if alias.c_identifier == "GQuark" => ConversionType::Scalar,
+            Alias(alias) => ConversionType::of(env, alias.typ),
             Bitfield(_) => ConversionType::Scalar,
             Record(_) => ConversionType::Pointer,
             Union(_) => ConversionType::Pointer,
@@ -92,7 +92,7 @@ impl ConversionType {
             List(_) => ConversionType::Pointer,
             SList(_) => ConversionType::Pointer,
             PtrArray(_) => ConversionType::Pointer,
-            Function(super::library::Function { ref name, .. }) if name == "AsyncReadyCallback" => {
+            Function(super::library::Function { name, .. }) if name == "AsyncReadyCallback" => {
                 ConversionType::Direct
             }
             Function(_) => ConversionType::Direct,

--- a/src/analysis/ffi_type.rs
+++ b/src/analysis/ffi_type.rs
@@ -34,19 +34,17 @@ pub fn ffi_type(env: &Env, tid: TypeId, c_type: &str) -> Result {
                 .maybe_ref_as::<Fundamental>()
                 .is_some()
             {
-                match *env.library.type_(tid) {
+                match env.library.type_(tid) {
                     Type::FixedArray(_, size, _) => {
                         ffi_inner(env, c_tid, c_type).map_any(|rust_type| {
                             rust_type.alter_type(|typ_| format!("[{}; {}]", typ_, size))
                         })
                     }
                     Type::Class(Class {
-                        c_type: ref expected,
-                        ..
+                        c_type: expected, ..
                     })
                     | Type::Interface(Interface {
-                        c_type: ref expected,
-                        ..
+                        c_type: expected, ..
                     }) if is_gpointer(c_type) => {
                         info!("[c:type `gpointer` instead of `*mut {}`, fixing]", expected);
                         ffi_inner(env, tid, expected).map_any(|rust_type| {
@@ -174,7 +172,7 @@ fn ffi_inner(env: &Env, tid: TypeId, inner: &str) -> Result {
 
 fn fix_name(env: &Env, type_id: TypeId, name: &str) -> Result {
     if type_id.ns_id == INTERNAL_NAMESPACE {
-        match *env.library.type_(type_id) {
+        match env.library.type_(type_id) {
             Type::Array(..)
             | Type::PtrArray(..)
             | Type::List(..)

--- a/src/analysis/function_parameters.rs
+++ b/src/analysis/function_parameters.rs
@@ -125,11 +125,7 @@ impl TransformationType {
     }
 
     pub fn set_to_glib_extra(&mut self, to_glib_extra_: &str) {
-        if let TransformationType::ToGlibPointer {
-            ref mut to_glib_extra,
-            ..
-        } = *self
-        {
+        if let TransformationType::ToGlibPointer { to_glib_extra, .. } = self {
             *to_glib_extra = to_glib_extra_.to_owned();
         }
     }
@@ -458,7 +454,7 @@ fn is_length(par: &library::Parameter) -> bool {
 fn has_length(env: &Env, typ: TypeId) -> bool {
     use crate::library::Type;
     let typ = env.library.type_(typ);
-    match *typ {
+    match typ {
         Type::Fundamental(fund) => {
             use crate::library::Fundamental::*;
             matches!(fund, Utf8 | Filename | OsString)
@@ -470,7 +466,7 @@ fn has_length(env: &Env, typ: TypeId) -> bool {
         | Type::List(..)
         | Type::SList(..)
         | Type::HashTable(..) => true,
-        Type::Alias(ref alias) => has_length(env, alias.typ),
+        Type::Alias(alias) => has_length(env, alias.typ),
         _ => false,
     }
 }

--- a/src/analysis/functions.rs
+++ b/src/analysis/functions.rs
@@ -158,7 +158,7 @@ pub fn analyze<F: Borrow<library::Function>>(
                 }
             }
         }
-        if let Some(ref mut signatures) = signatures {
+        if let Some(signatures) = signatures.as_mut() {
             signatures.insert(name.clone(), signature_params);
         }
 
@@ -856,7 +856,7 @@ pub fn is_carray_with_direct_elements(env: &Env, typ: library::TypeId) -> bool {
     match *env.library.type_(typ) {
         Type::CArray(inner_tid) => {
             use super::conversion_type::ConversionType;
-            match *env.library.type_(inner_tid) {
+            match env.library.type_(inner_tid) {
                 Type::Fundamental(..)
                     if ConversionType::of(env, inner_tid) == ConversionType::Direct =>
                 {
@@ -994,7 +994,7 @@ fn analyze_callback(
 ) -> Option<(Trampoline, Option<usize>)> {
     let mut imports_to_add = Vec::new();
 
-    if let Type::Function(ref func) = rust_type {
+    if let Type::Function(func) = rust_type {
         if par.c_type != "GDestroyNotify" {
             if let Some(user_data) = par.user_data_index {
                 if user_data >= c_parameters.len() {
@@ -1182,11 +1182,11 @@ pub fn find_function<'a>(env: &'a Env, c_identifier: &str) -> Option<&'a Functio
             return Some(f);
         }
         for typ in &namespace.types {
-            if let Some(Type::Class(ref class)) = *typ {
+            if let Some(Type::Class(class)) = typ {
                 if let Some(f) = find(&class.functions) {
                     return Some(f);
                 }
-            } else if let Some(Type::Interface(ref interface)) = *typ {
+            } else if let Some(Type::Interface(interface)) = typ {
                 if let Some(f) = find(&interface.functions) {
                     return Some(f);
                 }

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -74,7 +74,7 @@ pub fn run(env: &mut Env) {
     while analyzed > 0 {
         analyzed = 0;
         let mut new_to_analyze: Vec<(TypeId, Vec<TypeId>)> = Vec::with_capacity(to_analyze.len());
-        for &(tid, ref deps) in &to_analyze {
+        for (tid, ref deps) in to_analyze {
             if !is_all_deps_analyzed(env, deps) {
                 new_to_analyze.push((tid, deps.clone()));
                 continue;
@@ -216,7 +216,7 @@ fn analyze(env: &mut Env, tid: TypeId, deps: &[TypeId]) {
         Some(obj) => obj,
         None => return,
     };
-    match *env.library.type_(tid) {
+    match env.library.type_(tid) {
         Type::Class(_) => {
             if let Some(info) = object::class(env, obj, deps) {
                 env.analysis.objects.insert(full_name, info);

--- a/src/analysis/out_parameters.rs
+++ b/src/analysis/out_parameters.rs
@@ -131,13 +131,14 @@ pub fn analyze_imports<'a>(
 }
 
 fn analyze_type_imports(env: &Env, typ: TypeId, caller_allocates: bool, imports: &mut Imports) {
-    match *env.library.type_(typ) {
-        Type::Alias(ref alias) => analyze_type_imports(env, alias.typ, caller_allocates, imports),
+    match env.library.type_(typ) {
+        Type::Alias(alias) => analyze_type_imports(env, alias.typ, caller_allocates, imports),
         Type::Bitfield(..) | Type::Enumeration(..) => imports.add("std::mem"),
         Type::Fundamental(fund)
-            if fund != Fundamental::Utf8
-                && fund != Fundamental::OsString
-                && fund != Fundamental::Filename =>
+            if !matches!(
+                fund,
+                Fundamental::Utf8 | Fundamental::OsString | Fundamental::Filename
+            ) =>
         {
             imports.add("std::mem")
         }

--- a/src/analysis/ref_mode.rs
+++ b/src/analysis/ref_mode.rs
@@ -33,7 +33,7 @@ impl RefMode {
         }
 
         use crate::library::Type::*;
-        match *library.type_(tid) {
+        match library.type_(tid) {
             Fundamental(library::Fundamental::Utf8)
             | Fundamental(library::Fundamental::Filename)
             | Fundamental(library::Fundamental::OsString)
@@ -49,7 +49,7 @@ impl RefMode {
                     RefMode::None
                 }
             }
-            Record(ref record) => {
+            Record(record) => {
                 if direction == library::ParameterDirection::In {
                     if let RecordType::Refcounted = RecordType::of(record) {
                         RefMode::ByRef
@@ -67,7 +67,7 @@ impl RefMode {
                     RefMode::None
                 }
             }
-            Alias(ref alias) => RefMode::of(env, alias.typ, direction),
+            Alias(alias) => RefMode::of(env, alias.typ, direction),
             _ => RefMode::None,
         }
     }

--- a/src/analysis/return_value.rs
+++ b/src/analysis/return_value.rs
@@ -147,9 +147,9 @@ pub fn analyze(
 
 fn can_be_nullable_return(env: &Env, type_id: library::TypeId) -> bool {
     use crate::library::{Fundamental::*, Type::*};
-    match *env.library.type_(type_id) {
+    match env.library.type_(type_id) {
         Fundamental(fund) => matches!(fund, Pointer | Utf8 | Filename | OsString),
-        Alias(ref alias) => can_be_nullable_return(env, alias.typ),
+        Alias(alias) => can_be_nullable_return(env, alias.typ),
         Enumeration(_) => false,
         Bitfield(_) => false,
         Record(_) => true,

--- a/src/analysis/rust_type.rs
+++ b/src/analysis/rust_type.rs
@@ -337,7 +337,7 @@ impl<'env> RustTypeBuilder<'env> {
                 if ConversionType::of(self.env, inner_tid) == ConversionType::Pointer =>
             {
                 skip_option = true;
-                let inner_ref_mode = match *self.env.library.type_(inner_tid) {
+                let inner_ref_mode = match self.env.library.type_(inner_tid) {
                     Class(..) | Interface(..) => RefMode::None,
                     _ => self.ref_mode,
                 };
@@ -359,7 +359,7 @@ impl<'env> RustTypeBuilder<'env> {
             CArray(inner_tid)
                 if ConversionType::of(self.env, inner_tid) == ConversionType::Direct =>
             {
-                if let Fundamental(fund) = *self.env.library.type_(inner_tid) {
+                if let Fundamental(fund) = self.env.library.type_(inner_tid) {
                     let array_type = match fund {
                         Int8 => Some("i8"),
                         UInt8 => Some("u8"),
@@ -601,21 +601,21 @@ impl<'env> RustTypeBuilder<'env> {
             .scope(self.scope)
             .try_from_glib(&self.try_from_glib)
             .try_build();
-        match *type_ {
-            Fundamental(fund) => {
-                if (fund == library::Fundamental::Utf8
-                    || fund == library::Fundamental::OsString
-                    || fund == library::Fundamental::Filename)
-                    && (self.direction == ParameterDirection::InOut
-                        || (self.direction == ParameterDirection::Out
-                            && self.ref_mode == RefMode::ByRefMut))
-                {
-                    return Err(TypeError::Unimplemented(into_inner(rust_type)));
-                }
+        match type_ {
+            Fundamental(library::Fundamental::Utf8)
+            | Fundamental(library::Fundamental::OsString)
+            | Fundamental(library::Fundamental::Filename)
+                if (self.direction == ParameterDirection::InOut
+                    || (self.direction == ParameterDirection::Out
+                        && self.ref_mode == RefMode::ByRefMut)) =>
+            {
+                Err(TypeError::Unimplemented(into_inner(rust_type)))
+            }
+            Fundamental(_) => {
                 rust_type.map_any(|rust_type| rust_type.format_parameter(self.direction))
             }
 
-            Alias(ref alias) => rust_type
+            Alias(alias) => rust_type
                 .and_then(|rust_type| {
                     RustType::builder(&self.env, alias.typ)
                         .direction(self.direction)

--- a/src/analysis/safety_assertion_mode.rs
+++ b/src/analysis/safety_assertion_mode.rs
@@ -41,7 +41,7 @@ impl SafetyAssertionMode {
         }
         for par in &params.rust_parameters {
             let c_par = &params.c_parameters[par.ind_c];
-            match *env.library.type_(c_par.typ) {
+            match env.library.type_(c_par.typ) {
                 Class(..) | Interface(..)
                     if !*c_par.nullable && c_par.typ.ns_id == library::MAIN_NAMESPACE =>
                 {

--- a/src/analysis/special_functions.rs
+++ b/src/analysis/special_functions.rs
@@ -249,7 +249,7 @@ pub fn unhide(functions: &mut Vec<FuncInfo>, specials: &Infos, type_: Type) {
 pub fn analyze_imports(specials: &Infos, imports: &mut Imports) {
     for (type_, info) in specials.traits() {
         use self::Type::*;
-        match *type_ {
+        match type_ {
             Copy if info.first_parameter_mut => {
                 imports.add_with_version("glib::translate::*", info.version)
             }

--- a/src/analysis/symbols.rs
+++ b/src/analysis/symbols.rs
@@ -143,24 +143,22 @@ pub fn run(library: &Library, namespaces: &namespaces::Info) -> Info {
                 id: pos as u32,
             };
 
-            match *typ {
-                Type::Alias(Alias {
-                    ref c_identifier, ..
-                }) => {
+            match typ {
+                Type::Alias(Alias { c_identifier, .. }) => {
                     info.insert(c_identifier, symbol, Some(tid));
                 }
                 Type::Enumeration(Enumeration {
-                    ref name,
-                    ref c_type,
-                    ref members,
-                    ref functions,
+                    name,
+                    c_type,
+                    members,
+                    functions,
                     ..
                 })
                 | Type::Bitfield(Bitfield {
-                    ref name,
-                    ref c_type,
-                    ref members,
-                    ref functions,
+                    name,
+                    c_type,
+                    members,
+                    functions,
                     ..
                 }) => {
                     info.insert(c_type, symbol, Some(tid));
@@ -184,21 +182,21 @@ pub fn run(library: &Library, namespaces: &namespaces::Info) -> Info {
                     }
                 }
                 Type::Record(Record {
-                    ref name,
-                    ref c_type,
-                    ref functions,
+                    name,
+                    c_type,
+                    functions,
                     ..
                 })
                 | Type::Class(Class {
-                    ref name,
-                    ref c_type,
-                    ref functions,
+                    name,
+                    c_type,
+                    functions,
                     ..
                 })
                 | Type::Interface(Interface {
-                    ref name,
-                    ref c_type,
-                    ref functions,
+                    name,
+                    c_type,
+                    functions,
                     ..
                 }) => {
                     info.insert(c_type, symbol, Some(tid));

--- a/src/analysis/trampoline_parameters.rs
+++ b/src/analysis/trampoline_parameters.rs
@@ -147,7 +147,7 @@ pub fn analyze(
         let nullable = nullable_override.unwrap_or(par.nullable);
 
         let conversion_type = {
-            match *env.library.type_(par.typ) {
+            match env.library.type_(par.typ) {
                 library::Type::Fundamental(library::Fundamental::Utf8)
                 | library::Type::Record(..)
                 | library::Type::Interface(..)
@@ -211,7 +211,7 @@ fn apply_transformation_type(
         }
         TransformationType::TreePath => {
             let type_ = env.type_(transform.typ);
-            if let library::Type::Fundamental(library::Fundamental::Utf8) = *type_ {
+            if let library::Type::Fundamental(library::Fundamental::Utf8) = type_ {
                 if let Some(type_tid) = env.library.find_type(0, "Gtk.TreePath") {
                     transform.typ = type_tid;
                     transform.conversion_type = ConversionType::Direct;

--- a/src/analysis/types.rs
+++ b/src/analysis/types.rs
@@ -149,14 +149,14 @@ impl IsIncomplete for TypeId {
 
 impl IsIncomplete for Type {
     fn is_incomplete(&self, lib: &Library) -> bool {
-        match *self {
-            Type::Fundamental(ref fundamental) => fundamental.is_incomplete(lib),
-            Type::Alias(ref alias) => alias.is_incomplete(lib),
+        match self {
+            Type::Fundamental(fundamental) => fundamental.is_incomplete(lib),
+            Type::Alias(alias) => alias.is_incomplete(lib),
             Type::FixedArray(tid, ..) => tid.is_incomplete(lib),
-            Type::Class(ref klass) => klass.is_incomplete(lib),
-            Type::Record(ref record) => record.is_incomplete(lib),
-            Type::Union(ref union) => union.is_incomplete(lib),
-            Type::Function(ref function) => function.is_incomplete(lib),
+            Type::Class(klass) => klass.is_incomplete(lib),
+            Type::Record(record) => record.is_incomplete(lib),
+            Type::Union(union) => union.is_incomplete(lib),
+            Type::Function(function) => function.is_incomplete(lib),
             Type::Interface(..) => true,
             Type::Custom(..)
             | Type::Enumeration(..)
@@ -206,11 +206,11 @@ impl IsExternal for Alias {
 
 impl IsExternal for Type {
     fn is_external(&self, lib: &Library) -> bool {
-        match *self {
-            Type::Alias(ref alias) => alias.is_external(lib),
-            Type::Class(ref klass) => klass.is_external(lib),
-            Type::Record(ref record) => record.is_external(lib),
-            Type::Union(ref union) => union.is_external(lib),
+        match self {
+            Type::Alias(alias) => alias.is_external(lib),
+            Type::Class(klass) => klass.is_external(lib),
+            Type::Record(record) => record.is_external(lib),
+            Type::Union(union) => union.is_external(lib),
             Type::Interface(..) => true,
             Type::Custom(..)
             | Type::Fundamental(..)

--- a/src/codegen/alias.rs
+++ b/src/codegen/alias.rs
@@ -23,7 +23,7 @@ pub fn generate(env: &Env, root_path: &Path, mod_rs: &mut Vec<String>) {
         .collect();
     let mut has_any = false;
     for config in &configs {
-        if let Type::Alias(_) = *env.library.type_(config.type_id.unwrap()) {
+        if let Type::Alias(_) = env.library.type_(config.type_id.unwrap()) {
             has_any = true;
             break;
         }
@@ -43,7 +43,7 @@ pub fn generate(env: &Env, root_path: &Path, mod_rs: &mut Vec<String>) {
 
         mod_rs.push("\nmod alias;".into());
         for config in &configs {
-            if let Type::Alias(ref alias) = *env.library.type_(config.type_id.unwrap()) {
+            if let Type::Alias(alias) = env.library.type_(config.type_id.unwrap()) {
                 mod_rs.push(format!("pub use self::alias::{};", alias.name));
                 generate_alias(env, w, alias, config)?;
             }

--- a/src/codegen/constants.rs
+++ b/src/codegen/constants.rs
@@ -28,7 +28,7 @@ pub fn generate(env: &Env, root_path: &Path, mod_rs: &mut Vec<String>) {
 
         for constant in &env.analysis.constants {
             let type_ = env.type_(constant.typ);
-            if let library::Type::Fundamental(library::Fundamental::Utf8) = *type_ {
+            if let library::Type::Fundamental(library::Fundamental::Utf8) = type_ {
                 cfg_deprecated(w, env, constant.deprecated_version, false, 0)?;
                 cfg_condition(w, &constant.cfg_condition, false, 0)?;
                 version_condition(w, env, constant.version, false, 0)?;

--- a/src/codegen/doc/mod.rs
+++ b/src/codegen/doc/mod.rs
@@ -120,7 +120,7 @@ fn generate_doc(w: &mut dyn Write, env: &Env) -> Result<()> {
     }
 
     for (tid, type_) in env.library.namespace_types(MAIN) {
-        if let LType::Enumeration(ref enum_) = *type_ {
+        if let LType::Enumeration(enum_) = type_ {
             if !env
                 .config
                 .objects
@@ -133,7 +133,7 @@ fn generate_doc(w: &mut dyn Write, env: &Env) -> Result<()> {
                     Box::new(move |w, e| create_enum_doc(w, e, enum_)),
                 ));
             }
-        } else if let LType::Bitfield(ref bitfield) = *type_ {
+        } else if let LType::Bitfield(bitfield) = type_ {
             if !env
                 .config
                 .objects
@@ -175,8 +175,8 @@ fn create_object_doc(w: &mut dyn Write, env: &Env, info: &analysis::object::Info
         .get(&info.full_name)
         .expect("Object not found");
 
-    match *env.library.type_(info.type_id) {
-        Type::Class(ref cl) => {
+    match env.library.type_(info.type_id) {
+        Type::Class(cl) => {
             doc = cl.doc.as_ref();
             doc_deprecated = cl.doc_deprecated.as_ref();
             functions = &cl.functions;
@@ -184,7 +184,7 @@ fn create_object_doc(w: &mut dyn Write, env: &Env, info: &analysis::object::Info
             properties = &cl.properties;
             is_abstract = env.library.type_(info.type_id).is_abstract();
         }
-        Type::Interface(ref iface) => {
+        Type::Interface(iface) => {
             doc = iface.doc.as_ref();
             doc_deprecated = iface.doc_deprecated.as_ref();
             functions = &iface.functions;
@@ -438,7 +438,7 @@ static PARAM_NAME: Lazy<Regex> = Lazy::new(|| Regex::new(r"@(\w+)\b").unwrap());
 
 fn fix_param_names<'a>(doc: &'a str, self_name: &Option<String>) -> Cow<'a, str> {
     PARAM_NAME.replace_all(doc, |caps: &Captures<'_>| {
-        if let Some(ref self_name) = *self_name {
+        if let Some(self_name) = self_name {
             if &caps[1] == self_name {
                 return "@self".into();
             }
@@ -483,19 +483,19 @@ where
         .map(|p| p.name.clone());
 
     write_item_doc(w, &ty, |w| {
-        if let Some(ref doc) = *fn_.doc() {
+        if let Some(doc) = fn_.doc() {
             writeln!(
                 w,
                 "{}",
                 reformat_doc(&fix_param_names(doc, &self_name), &symbols, &parent_name)
             )?;
         }
-        if let Some(ver) = *fn_.deprecated_version() {
+        if let Some(ver) = fn_.deprecated_version() {
             writeln!(w, "\n# Deprecated since {}\n", ver)?;
         } else if fn_.doc_deprecated().is_some() {
             writeln!(w, "\n# Deprecated\n")?;
         }
-        if let Some(ref doc) = *fn_.doc_deprecated() {
+        if let Some(doc) = fn_.doc_deprecated() {
             writeln!(
                 w,
                 "{}",

--- a/src/codegen/enums.rs
+++ b/src/codegen/enums.rs
@@ -259,7 +259,7 @@ impl FromGlib<{sys_crate_name}::{ffi_name}> for {name} {{
         )?;
 
         match domain {
-            ErrorDomain::Quark(ref quark) => {
+            ErrorDomain::Quark(quark) => {
                 writeln!(
                     w,
                     "        static QUARK: once_cell::sync::Lazy<{0}ffi::GQuark> = once_cell::sync::Lazy::new(|| unsafe {{
@@ -270,7 +270,7 @@ impl FromGlib<{sys_crate_name}::{ffi_name}> for {name} {{
                     quark,
                 )?;
             }
-            ErrorDomain::Function(ref f) => {
+            ErrorDomain::Function(f) => {
                 writeln!(
                     w,
                     "        unsafe {{ from_glib({sys_crate_name}::{get_quark}()) }}",

--- a/src/codegen/general.rs
+++ b/src/codegen/general.rs
@@ -77,7 +77,7 @@ pub fn uses(
     outer_version: Option<Version>,
 ) -> Result<()> {
     writeln!(w)?;
-    for (name, ref scope) in imports.iter() {
+    for (name, scope) in imports.iter() {
         if !scope.constraints.is_empty() {
             writeln!(
                 w,
@@ -259,7 +259,7 @@ fn define_boxed_type_internal(
         writeln!(w, "\t\tclear => {},", clear_function_expression,)?;
     }
 
-    if let Some(ref get_type_fn) = get_type_fn {
+    if let Some(get_type_fn) = get_type_fn {
         writeln!(w, "\t\ttype_ => || {}::{}(),", sys_crate_name, get_type_fn)?;
     }
     writeln!(w, "\t}}")?;
@@ -422,7 +422,7 @@ fn define_shared_type_internal(
         "\t\tunref => |ptr| {}::{}(ptr),",
         sys_crate_name, unref_fn
     )?;
-    if let Some(ref get_type_fn) = get_type_fn {
+    if let Some(get_type_fn) = get_type_fn {
         writeln!(w, "\t\ttype_ => || {}::{}(),", sys_crate_name, get_type_fn)?;
     }
     writeln!(w, "\t}}")?;

--- a/src/codegen/objects.rs
+++ b/src/codegen/objects.rs
@@ -20,7 +20,7 @@ pub fn generate(env: &Env, root_path: &Path, mod_rs: &mut Vec<String>, traits: &
         path.set_extension("rs");
         info!("Generating file {:?}", path);
 
-        save_to_file(path, env.config.make_backup, |ref mut w| {
+        save_to_file(path, env.config.make_backup, |w| {
             super::object::generate(w, env, class_analysis, generate_display_trait)
         });
 

--- a/src/codegen/signal.rs
+++ b/src/codegen/signal.rs
@@ -204,8 +204,8 @@ fn declaration(analysis: &analysis::signals::Info, function_type: &Option<String
 }
 
 fn bounds(function_type: &Option<String>) -> String {
-    match *function_type {
-        Some(ref type_) => format!("F: {}", type_),
+    match function_type {
+        Some(type_) => format!("F: {}", type_),
         _ => "Unsupported or ignored types".to_owned(),
     }
 }

--- a/src/codegen/sys/cargo_toml.rs
+++ b/src/codegen/sys/cargo_toml.rs
@@ -184,14 +184,14 @@ fn get_feature_dependencies(
 
 /// Returns the name of crate being currently generated.
 fn get_crate_name(config: &Config, root: &Table) -> String {
-    if let Some(&Value::Table(ref lib)) = root.get("lib") {
-        if let Some(&Value::String(ref lib_name)) = lib.get("name") {
+    if let Some(Value::Table(lib)) = root.get("lib") {
+        if let Some(Value::String(lib_name)) = lib.get("name") {
             //Converting don't needed as library target names cannot contain hyphens
             return lib_name.to_owned();
         }
     }
-    if let Some(&Value::Table(ref package)) = root.get("package") {
-        if let Some(&Value::String(ref package_name)) = package.get("name") {
+    if let Some(Value::Table(package)) = root.get("package") {
+        if let Some(Value::String(package_name)) = package.get("name") {
             return nameutil::crate_name(package_name);
         }
     }
@@ -207,7 +207,7 @@ fn unset(table: &mut Table, name: &str) {
 }
 
 fn upsert_table<S: Into<String>>(parent: &mut Table, name: S) -> &mut Table {
-    if let Value::Table(ref mut table) = *parent
+    if let Value::Table(table) = parent
         .entry(name.into())
         .or_insert_with(|| Value::Table(toml::map::Map::new()))
     {

--- a/src/codegen/sys/ffi_type.rs
+++ b/src/codegen/sys/ffi_type.rs
@@ -198,7 +198,7 @@ fn ffi_inner(env: &Env, tid: library::TypeId, mut inner: String) -> Result {
 
 fn fix_name(env: &Env, type_id: library::TypeId, name: &str) -> Result {
     if type_id.ns_id == library::INTERNAL_NAMESPACE {
-        match *env.library.type_(type_id) {
+        match env.library.type_(type_id) {
             Type::Array(..)
             | Type::PtrArray(..)
             | Type::List(..)

--- a/src/codegen/sys/functions.rs
+++ b/src/codegen/sys/functions.rs
@@ -322,7 +322,7 @@ fn function_return_value(env: &Env, func: &library::Function) -> (bool, String) 
 }
 
 fn function_parameter(env: &Env, par: &library::Parameter, bare: bool) -> (bool, String) {
-    if let library::Type::Fundamental(library::Fundamental::VarArgs) = *env.library.type_(par.typ) {
+    if let library::Type::Fundamental(library::Fundamental::VarArgs) = env.library.type_(par.typ) {
         return (false, "...".into());
     }
     let ffi_type = ffi_type(env, par.typ, &par.c_type);

--- a/src/codegen/sys/tests.rs
+++ b/src/codegen/sys/tests.rs
@@ -67,10 +67,10 @@ fn prepare_ctypes(env: &Env) -> Vec<CType> {
         .iter()
         .filter_map(Option::as_ref)
         .filter(|t| !t.is_incomplete(&env.library))
-        .filter_map(|t| match *t {
-            Type::Record(library::Record { disguised, .. }) if !disguised => {
-                prepare_ctype(env, ns, t)
-            }
+        .filter_map(|t| match t {
+            Type::Record(library::Record {
+                disguised: false, ..
+            }) => prepare_ctype(env, ns, t),
             Type::Alias(_)
             | Type::Class(_)
             | Type::Union(_)
@@ -129,7 +129,7 @@ fn prepare_cconsts(env: &Env) -> Vec<CConstant> {
         .collect();
 
     for typ in &ns.types {
-        let typ = if let Some(ref typ) = *typ {
+        let typ = if let Some(typ) = typ {
             typ
         } else {
             continue;
@@ -138,8 +138,8 @@ fn prepare_cconsts(env: &Env) -> Vec<CConstant> {
         if env.type_status_sys(&full_name).ignored() {
             continue;
         }
-        match *typ {
-            Type::Bitfield(Bitfield { ref members, .. }) => {
+        match typ {
+            Type::Bitfield(Bitfield { members, .. }) => {
                 for member in members {
                     // GLib assumes that bitflags are unsigned integers,
                     // see the GValue machinery around them for example
@@ -149,7 +149,7 @@ fn prepare_cconsts(env: &Env) -> Vec<CConstant> {
                     });
                 }
             }
-            Type::Enumeration(Enumeration { ref members, .. }) => {
+            Type::Enumeration(Enumeration { members, .. }) => {
                 for member in members {
                     // GLib assumes that enums are signed integers,
                     // see the GValue machinery around them for example

--- a/src/codegen/trait_impls.rs
+++ b/src/codegen/trait_impls.rs
@@ -20,7 +20,7 @@ pub fn generate(
 ) -> Result<()> {
     for (type_, special_info) in specials.traits().iter() {
         if let Some(info) = lookup(functions, &special_info.glib_name) {
-            match *type_ {
+            match type_ {
                 Type::Compare => {
                     if !specials.has_trait(Type::Equal) {
                         generate_eq_compare(w, env, type_name, info, trait_name, scope_version)?;

--- a/src/codegen/trampoline_from_glib.rs
+++ b/src/codegen/trampoline_from_glib.rs
@@ -70,12 +70,10 @@ pub fn from_glib_xxx(transfer: library::Transfer, is_borrow: bool) -> (String, S
 fn is_need_type_name(env: &Env, type_id: library::TypeId) -> bool {
     if type_id.ns_id == library::INTERNAL_NAMESPACE {
         use crate::library::{Fundamental::*, Type::*};
-        match *env.type_(type_id) {
-            Fundamental(fund) if fund == Utf8 => true,
-            Fundamental(fund) if fund == Filename => true,
-            Fundamental(fund) if fund == OsString => true,
-            _ => false,
-        }
+        matches!(
+            env.type_(type_id),
+            Fundamental(Utf8) | Fundamental(Filename) | Fundamental(OsString)
+        )
     } else {
         false
     }

--- a/src/codegen/translate_from_glib.rs
+++ b/src/codegen/translate_from_glib.rs
@@ -57,7 +57,7 @@ impl TranslateFromGlib for Mode {
             }
             Pointer => {
                 let trans = from_glib_xxx(self.transfer, array_length);
-                match *env.type_(self.typ) {
+                match env.type_(self.typ) {
                     library::Type::List(..)
                     | library::Type::SList(..)
                     | library::Type::PtrArray(..)

--- a/src/config/functions.rs
+++ b/src/config/functions.rs
@@ -207,7 +207,7 @@ impl Return {
 }
 
 fn check_rename(rename: &Option<String>, object_name: &str, function_name: &Ident) -> bool {
-    if let Some(ref rename) = rename {
+    if let Some(rename) = rename {
         for c in &["\t", "\n", " "] {
             if rename.contains(c) {
                 error!(

--- a/src/config/gobjects.rs
+++ b/src/config/gobjects.rs
@@ -506,8 +506,8 @@ pub fn resolve_type_ids(objects: &mut GObjects, library: &Library) {
         if type_id.is_none() && name != &global_functions_name {
             warn!("Configured object `{}` missing from the library", name);
         } else if object.generate_builder {
-            if let Some(ref type_id) = type_id {
-                if library.type_(*type_id).is_abstract() {
+            if let Some(type_id) = type_id {
+                if library.type_(type_id).is_abstract() {
                     warn!(
                         "Cannot generate builder for `{}` because it's a base class",
                         name

--- a/src/config/ident.rs
+++ b/src/config/ident.rs
@@ -23,8 +23,8 @@ impl PartialEq for Ident {
     fn eq(&self, other: &Ident) -> bool {
         pub use self::Ident::*;
         match (self, other) {
-            (&Name(ref s1), &Name(ref s2)) => s1 == s2,
-            (&Pattern(ref r1), &Pattern(ref r2)) => r1.as_str() == r2.as_str(),
+            (Name(s1), Name(s2)) => s1 == s2,
+            (Pattern(r1), Pattern(r2)) => r1.as_str() == r2.as_str(),
             _ => false,
         }
     }
@@ -65,9 +65,9 @@ impl Ident {
 
     pub fn is_match(&self, name: &str) -> bool {
         use self::Ident::*;
-        match *self {
-            Name(ref n) => name == n,
-            Pattern(ref regex) => regex.is_match(name),
+        match self {
+            Name(n) => name == n,
+            Pattern(regex) => regex.is_match(name),
         }
     }
 }

--- a/src/library.rs
+++ b/src/library.rs
@@ -244,7 +244,7 @@ pub enum Fundamental {
 }
 
 impl Fundamental {
-    pub fn requires_conversion(self) -> bool {
+    pub fn requires_conversion(&self) -> bool {
         !matches!(
             self,
             Fundamental::Int8
@@ -651,18 +651,18 @@ impl fmt::Display for Type {
 impl Type {
     pub fn get_name(&self) -> String {
         use self::Type::*;
-        match *self {
+        match self {
             Fundamental(fund) => format!("{:?}", fund),
-            Alias(ref alias) => alias.name.clone(),
-            Enumeration(ref enum_) => enum_.name.clone(),
-            Bitfield(ref bit_field) => bit_field.name.clone(),
-            Record(ref rec) => rec.name.clone(),
-            Union(ref union) => union.name.clone(),
-            Function(ref func) => func.name.clone(),
-            Interface(ref interface) => interface.name.clone(),
+            Alias(alias) => alias.name.clone(),
+            Enumeration(enum_) => enum_.name.clone(),
+            Bitfield(bit_field) => bit_field.name.clone(),
+            Record(rec) => rec.name.clone(),
+            Union(union) => union.name.clone(),
+            Function(func) => func.name.clone(),
+            Interface(interface) => interface.name.clone(),
             Array(type_id) => format!("Array {:?}", type_id),
-            Class(ref class) => class.name.clone(),
-            Custom(ref custom) => custom.name.clone(),
+            Class(class) => class.name.clone(),
+            Custom(custom) => custom.name.clone(),
             CArray(type_id) => format!("CArray {:?}", type_id),
             FixedArray(type_id, size, _) => format!("FixedArray {:?}; {}", type_id, size),
             PtrArray(type_id) => format!("PtrArray {:?}", type_id),
@@ -676,17 +676,17 @@ impl Type {
 
     pub fn get_deprecated_version(&self) -> Option<Version> {
         use self::Type::*;
-        match *self {
+        match self {
             Fundamental(_) => None,
             Alias(_) => None,
-            Enumeration(ref enum_) => enum_.deprecated_version,
-            Bitfield(ref bit_field) => bit_field.deprecated_version,
-            Record(ref rec) => rec.deprecated_version,
+            Enumeration(enum_) => enum_.deprecated_version,
+            Bitfield(bit_field) => bit_field.deprecated_version,
+            Record(rec) => rec.deprecated_version,
             Union(_) => None,
-            Function(ref func) => func.deprecated_version,
-            Interface(ref interface) => interface.deprecated_version,
+            Function(func) => func.deprecated_version,
+            Interface(interface) => interface.deprecated_version,
             Array(_) => None,
-            Class(ref class) => class.deprecated_version,
+            Class(class) => class.deprecated_version,
             Custom(_) => None,
             CArray(_) => None,
             FixedArray(..) => None,
@@ -699,15 +699,15 @@ impl Type {
 
     pub fn get_glib_name(&self) -> Option<&str> {
         use self::Type::*;
-        match *self {
-            Alias(ref alias) => Some(&alias.c_identifier),
-            Enumeration(ref enum_) => Some(&enum_.c_type),
-            Bitfield(ref bit_field) => Some(&bit_field.c_type),
-            Record(ref rec) => Some(&rec.c_type),
-            Union(ref union) => union.c_type.as_ref().map(|s| &s[..]),
-            Function(ref func) => func.c_identifier.as_ref().map(|s| &s[..]),
-            Interface(ref interface) => Some(&interface.c_type),
-            Class(ref class) => Some(&class.c_type),
+        match self {
+            Alias(alias) => Some(&alias.c_identifier),
+            Enumeration(enum_) => Some(&enum_.c_type),
+            Bitfield(bit_field) => Some(&bit_field.c_type),
+            Record(rec) => Some(&rec.c_type),
+            Union(union) => union.c_type.as_ref().map(|s| &s[..]),
+            Function(func) => func.c_identifier.as_ref().map(|s| &s[..]),
+            Interface(interface) => Some(&interface.c_type),
+            Class(class) => Some(&class.c_type),
             _ => None,
         }
     }
@@ -796,13 +796,13 @@ impl Type {
     }
 
     pub fn functions(&self) -> &[Function] {
-        match *self {
-            Type::Enumeration(ref e) => &e.functions,
-            Type::Bitfield(ref b) => &b.functions,
-            Type::Record(ref r) => &r.functions,
-            Type::Union(ref u) => &u.functions,
-            Type::Interface(ref i) => &i.functions,
-            Type::Class(ref c) => &c.functions,
+        match self {
+            Type::Enumeration(e) => &e.functions,
+            Type::Bitfield(b) => &b.functions,
+            Type::Record(r) => &r.functions,
+            Type::Union(u) => &u.functions,
+            Type::Interface(i) => &i.functions,
+            Type::Class(c) => &c.functions,
             _ => &[],
         }
     }
@@ -814,9 +814,9 @@ impl Type {
     /// If the type is an Alias containing a fundamental, it'll return true (whereas
     /// `is_fundamental` won't).
     pub fn is_fundamental_type(&self, env: &Env) -> bool {
-        match *self {
-            Type::Alias(ref x) => env.library.type_(x.typ).is_fundamental_type(env),
-            ref x => x.is_fundamental(),
+        match self {
+            Type::Alias(x) => env.library.type_(x.typ).is_fundamental_type(env),
+            x => x.is_fundamental(),
         }
     }
 
@@ -878,7 +878,7 @@ macro_rules! impl_maybe_ref {
 
         impl MaybeRef<$name> for Type {
             fn maybe_ref(&self) -> Option<&$name> {
-                if let Type::$name(ref x) = *self { Some(x) } else { None }
+                if let Type::$name(x) = self { Some(x) } else { None }
             }
 
             fn to_ref(&self) -> &$name {
@@ -1034,7 +1034,7 @@ impl Library {
         let mut parents = HashSet::new();
 
         for x in &self.namespace(MAIN_NAMESPACE).types {
-            if let Some(ref x) = *x {
+            if let Some(x) = x {
                 let name = x.get_name();
                 let full_name = format!("{}.{}", namespace_name, name);
                 let mut check_methods = true;

--- a/src/update_version.rs
+++ b/src/update_version.rs
@@ -13,15 +13,13 @@ pub fn check_function_real_version(library: &mut Library) {
     // In order to avoid the borrow checker to annoy us...
     let library2 = library as *const Library;
     for typ in &mut library.namespace_mut(MAIN_NAMESPACE).types {
-        match *typ {
-            Some(Type::Class(ref mut c)) => update_function_version(&mut c.functions, library2),
-            Some(Type::Interface(ref mut i)) => update_function_version(&mut i.functions, library2),
-            Some(Type::Union(ref mut u)) => update_function_version(&mut u.functions, library2),
-            Some(Type::Record(ref mut r)) => update_function_version(&mut r.functions, library2),
-            Some(Type::Bitfield(ref mut b)) => update_function_version(&mut b.functions, library2),
-            Some(Type::Enumeration(ref mut e)) => {
-                update_function_version(&mut e.functions, library2)
-            }
+        match typ {
+            Some(Type::Class(c)) => update_function_version(&mut c.functions, library2),
+            Some(Type::Interface(i)) => update_function_version(&mut i.functions, library2),
+            Some(Type::Union(u)) => update_function_version(&mut u.functions, library2),
+            Some(Type::Record(r)) => update_function_version(&mut r.functions, library2),
+            Some(Type::Bitfield(b)) => update_function_version(&mut b.functions, library2),
+            Some(Type::Enumeration(e)) => update_function_version(&mut e.functions, library2),
             _ => {}
         }
     }
@@ -35,12 +33,12 @@ fn check_versions(param: &Parameter, current_version: &mut Option<Version>, lib:
     if param.typ.ns_id != MAIN_NAMESPACE {
         return;
     }
-    let ty_version = match *unsafe { (*lib).type_(param.typ) } {
-        library::Type::Class(ref c) => c.version,
-        library::Type::Enumeration(ref c) => c.version,
-        library::Type::Bitfield(ref c) => c.version,
-        library::Type::Record(ref c) => c.version,
-        library::Type::Interface(ref c) => c.version,
+    let ty_version = match unsafe { (*lib).type_(param.typ) } {
+        library::Type::Class(c) => c.version,
+        library::Type::Enumeration(c) => c.version,
+        library::Type::Bitfield(c) => c.version,
+        library::Type::Record(c) => c.version,
+        library::Type::Interface(c) => c.version,
         _ => None,
     };
     let new_version = match (*current_version, ty_version) {
@@ -91,12 +89,12 @@ fn fix_versions_by_config(library: &mut Library, cfg: &Config) {
             Some(x) => x,
             None => continue,
         };
-        match *library.type_mut(tid) {
-            Class(ref mut class) => class.version = version,
-            Interface(ref mut interface) => interface.version = version,
-            Record(ref mut record) => record.version = version,
-            Bitfield(ref mut flags) => flags.version = version,
-            Enumeration(ref mut enum_) => enum_.version = version,
+        match library.type_mut(tid) {
+            Class(class) => class.version = version,
+            Interface(interface) => interface.version = version,
+            Record(record) => record.version = version,
+            Bitfield(flags) => flags.version = version,
+            Enumeration(enum_) => enum_.version = version,
             _ => (),
         }
     }

--- a/src/visitors.rs
+++ b/src/visitors.rs
@@ -8,11 +8,9 @@ pub trait FunctionsMutVisitor {
 
 impl Namespace {
     pub fn visit_functions_mut<V: FunctionsMutVisitor>(&mut self, visitor: &mut V) -> bool {
-        for type_ in &mut self.types {
-            if let Some(type_) = type_ {
-                if !type_.visit_functions_mut(visitor) {
-                    return false;
-                }
+        for type_ in self.types.iter_mut().flatten() {
+            if !type_.visit_functions_mut(visitor) {
+                return false;
             }
         }
         true

--- a/src/visitors.rs
+++ b/src/visitors.rs
@@ -9,7 +9,7 @@ pub trait FunctionsMutVisitor {
 impl Namespace {
     pub fn visit_functions_mut<V: FunctionsMutVisitor>(&mut self, visitor: &mut V) -> bool {
         for type_ in &mut self.types {
-            if let Some(ref mut type_) = *type_ {
+            if let Some(type_) = type_ {
                 if !type_.visit_functions_mut(visitor) {
                     return false;
                 }
@@ -21,22 +21,22 @@ impl Namespace {
 
 impl Type {
     pub fn visit_functions_mut<V: FunctionsMutVisitor>(&mut self, visitor: &mut V) -> bool {
-        match *self {
-            Type::Class(ref mut class) => {
+        match self {
+            Type::Class(class) => {
                 for function in &mut class.functions {
                     if !visitor.visit_function_mut(function) {
                         return false;
                     }
                 }
             }
-            Type::Interface(ref mut interface) => {
+            Type::Interface(interface) => {
                 for function in &mut interface.functions {
                     if !visitor.visit_function_mut(function) {
                         return false;
                     }
                 }
             }
-            Type::Record(ref mut record) => {
+            Type::Record(record) => {
                 for function in &mut record.functions {
                     if !visitor.visit_function_mut(function) {
                         return false;

--- a/src/writer/to_code.rs
+++ b/src/writer/to_code.rs
@@ -65,7 +65,7 @@ impl ToCode for Chunk {
                 ref type_,
             } => {
                 let modif = if is_mut { "mut " } else { "" };
-                let type_string = if let Some(ref type_) = *type_ {
+                let type_string = if let Some(type_) = type_ {
                     let type_strings = type_.to_code(env);
                     format_block_one_line(": ", "", &type_strings, "", "")
                 } else {
@@ -84,7 +84,7 @@ impl ToCode for Chunk {
             NullPtr => vec!["ptr::null()".into()],
             NullMutPtr => vec!["ptr::null_mut()".into()],
             Custom(ref string) => vec![string.clone()],
-            Tuple(ref chs, mode) => {
+            Tuple(ref chs, ref mode) => {
                 #[allow(deprecated)]
                 let with_bracket = match mode {
                     TupleMode::Auto => chs.len() > 1,
@@ -172,7 +172,7 @@ impl ToCode for Chunk {
                     .flat_map(|param| param.to_code(env))
                     .collect();
                 let mut s = format_block_one_line(&prefix, &suffix, &params, "", ", ");
-                if let Some(ref return_value) = return_value {
+                if let Some(return_value) = return_value {
                     s.push_str(&format!(" -> {}", return_value));
                 }
                 s.push_str(" {");


### PR DESCRIPTION
This is the churn part of #1134, initially intended to remove `derive(Copy)` from `enum Fundamental` to fit a `String` in there. Those were just addressing the compiler errors, but there are a lot - and I mean a lot - more cases where objects are first dereferenced (copied) like `match *self {}` and then later re-(mutably)-borrowed with `ref` and `ref mut` in match arms. This is not necessary anymore (both the `*` and `ref`/`ref mut` are simply removed) and makes the code more pleasant to read.

OTOH doing it this way satisfies https://rust-lang.github.io/rust-clippy/master/#pattern_type_mismatch.... Curious to all your thoughts!

~If this is okay I'll go ahead and finish the remainder of the offenders.~ Finished!