### PR TITLE
docs: ignore not useful function parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,8 @@ trust_return_value_nullability = false
     cfg_condition = "mycond"
     # prefixed function with #[doc(hidden)]
     doc_hidden = true
+    # define a list of function parameters to be ignored when the documentation is generated
+    doc_ignore_parameters = ["some_user_data_param"] 
     # disable length_of autodetection
     disable_length_detect = true
     # write function docs to trait other than default "xxxExt",

--- a/src/analysis/functions.rs
+++ b/src/analysis/functions.rs
@@ -89,6 +89,7 @@ pub struct Info {
     pub cfg_condition: Option<String>,
     pub assertion: SafetyAssertionMode,
     pub doc_hidden: bool,
+    pub doc_ignore_parameters: HashSet<String>,
     pub r#async: bool,
     pub unsafe_: bool,
     pub trampoline: Option<AsyncTrampoline>,
@@ -585,6 +586,11 @@ fn analyze_function(
         .iter()
         .find_map(|f| f.cfg_condition.clone());
     let doc_hidden = configured_functions.iter().any(|f| f.doc_hidden);
+    let doc_ignore_parameters = configured_functions
+        .iter()
+        .find(|f| !f.doc_ignore_parameters.is_empty())
+        .map(|f| f.doc_ignore_parameters.clone())
+        .unwrap_or_default();
     let disable_length_detect = configured_functions.iter().any(|f| f.disable_length_detect);
     let no_future = configured_functions.iter().any(|f| f.no_future);
     let unsafe_ = configured_functions.iter().any(|f| f.unsafe_);
@@ -842,6 +848,7 @@ fn analyze_function(
         cfg_condition,
         assertion,
         doc_hidden,
+        doc_ignore_parameters,
         r#async,
         unsafe_,
         trampoline,

--- a/src/config/functions.rs
+++ b/src/config/functions.rs
@@ -12,7 +12,7 @@ use crate::{
     version::Version,
 };
 use log::error;
-use std::str::FromStr;
+use std::{collections::HashSet, str::FromStr};
 use toml::Value;
 
 #[derive(Clone, Debug)]
@@ -230,6 +230,7 @@ pub struct Function {
     pub parameters: Parameters,
     pub ret: Return,
     pub doc_hidden: bool,
+    pub doc_ignore_parameters: HashSet<String>,
     pub is_windows_utf8: bool,
     pub disable_length_detect: bool,
     pub doc_trait_name: Option<String>,
@@ -263,6 +264,7 @@ impl Parse for Function {
                 "return",
                 "name",
                 "doc_hidden",
+                "doc_ignore_parameters",
                 "is_windows_utf8",
                 "disable_length_detect",
                 "pattern",
@@ -308,6 +310,14 @@ impl Parse for Function {
             .lookup("doc_hidden")
             .and_then(Value::as_bool)
             .unwrap_or(false);
+        let doc_ignore_parameters = toml
+            .lookup_vec("doc_ignore_parameters", "Invalid doc_ignore_parameters")
+            .map(|v| {
+                v.iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default();
         let is_windows_utf8 = toml
             .lookup("is_windows_utf8")
             .and_then(Value::as_bool)
@@ -358,6 +368,7 @@ impl Parse for Function {
             parameters,
             ret,
             doc_hidden,
+            doc_ignore_parameters,
             is_windows_utf8,
             disable_length_detect,
             doc_trait_name,


### PR DESCRIPTION
Fixes #1115 

A one last type of parameters that's not really useful, is the `n_X` followed after parameter `X` that's an array used to specify the length of the array. Not sure how to check for that one properly. I suppose looking for `n_X` param, if X is found and is of type of Array & `n_X` is of type `gsize` we can omit that one as well? 