### PR TITLE
codegen/doc: Drop `[Deprecated]` text in favour of Rust annotations

### DIFF
--- a/src/codegen/doc/mod.rs
+++ b/src/codegen/doc/mod.rs
@@ -198,13 +198,8 @@ fn create_object_doc(w: &mut dyn Write, env: &Env, info: &analysis::object::Info
     let manual_traits = get_type_manual_traits_for_implements(env, info);
 
     write_item_doc(w, &ty, |w| {
-        if let Some(ver) = info.deprecated_version {
-            write!(w, "`[Deprecated since {}]` ", ver)?;
-        }
         if let Some(doc) = doc_deprecated {
             writeln!(w, "{}", reformat_doc(doc, &symbols, &info.name))?;
-        } else if doc_deprecated.is_some() {
-            write!(w, "`[Deprecated]` ")?;
         }
         if let Some(doc) = doc {
             writeln!(w, "{}", reformat_doc(doc, &symbols, &info.name))?;
@@ -236,11 +231,6 @@ fn create_object_doc(w: &mut dyn Write, env: &Env, info: &analysis::object::Info
 
     if has_trait {
         write_item_doc(w, &ty_ext, |w| {
-            if let Some(ver) = info.deprecated_version {
-                write!(w, "`[Deprecated since {}]` ", ver)?;
-            } else if doc_deprecated.is_some() {
-                write!(w, "`[Deprecated]` ")?;
-            }
             writeln!(w, "Trait containing all `{}` methods.", ty.name)?;
 
             let mut implementors = Some(info.type_id)
@@ -330,9 +320,6 @@ fn create_record_doc(w: &mut dyn Write, env: &Env, info: &analysis::record::Info
 
     write_item_doc(w, &ty, |w| {
         if let Some(ref doc) = record.doc {
-            if let Some(ver) = info.deprecated_version {
-                write!(w, "`[Deprecated since {}]` ", ver)?;
-            }
             writeln!(w, "{}", reformat_doc(doc, &symbols, &info.name))?;
         }
         if let Some(ver) = info.deprecated_version {


### PR DESCRIPTION
All deprecated objects, traits and records already receive a `#[deprecated = "Since XXX"]` annotation in Rust which neatly shows up in the docs. The extra `[Deprecated]` label in the documentation is not necessary anymore.

`# Deprecated` headers remain for the documentation part clarifying why an item has been deprecated, and what its alternative is.

---

I planned to do this a while ago given https://github.com/gtk-rs/gir/pull/1087 but funnily enough gtk3-rs recently bumped a bunch of minimum versions and now no deprecated objects/traits/records exist anymore :stuck_out_tongue:
