### PR TITLE
Use `S: AsRef<str>`, `&[S]` instead of `&[&str]`

### DIFF
--- a/src/analysis/bounds.rs
+++ b/src/analysis/bounds.rs
@@ -186,6 +186,7 @@ impl Bounds {
                 }
             }
             Type::Interface(..) => Some(IsA(None)),
+            Type::CArray(t) if t == TypeId::tid_utf8() => Some(AsRef(None)),
             Type::List(_) | Type::SList(_) | Type::CArray(_) => None,
             Type::Fundamental(_) if *nullable => None,
             Type::Function(_) => Some(NoWrapper),

--- a/src/analysis/rust_type.rs
+++ b/src/analysis/rust_type.rs
@@ -349,7 +349,11 @@ impl<'env> RustTypeBuilder<'env> {
                     .map_any(|rust_type| {
                         rust_type.alter_type(|typ| {
                             if self.ref_mode.is_ref() {
-                                format!("[{}]", typ)
+                                if inner_tid == library::TypeId::tid_utf8() {
+                                    format!("{}", typ)
+                                } else {
+                                    format!("[{}]", typ)
+                                }
                             } else {
                                 format!("Vec<{}>", typ)
                             }


### PR DESCRIPTION
This PR complements the changes in https://github.com/gtk-rs/gtk-rs-core/pull/89 applying the new code pattern in the auto generated code.