### PR TITLE
Use `impl Trait` instead of generic type names with trait bound

### DIFF
--- a/src/analysis/child_properties.rs
+++ b/src/analysis/child_properties.rs
@@ -1,7 +1,12 @@
 use crate::{
-    analysis::{bounds::Bounds, imports::Imports, ref_mode::RefMode, rust_type::RustType},
-    codegen::function,
+    analysis::{
+        bounds::{Bound, Bounds},
+        imports::Imports,
+        ref_mode::RefMode,
+        rust_type::RustType,
+    },
     config,
+    consts::TYPE_PARAMETERS_START,
     env::Env,
     library::{self, ParameterDirection},
     nameutil,
@@ -123,14 +128,25 @@ fn analyze_property(
                 .ref_mode(RefMode::ByRefFake)
                 .try_build()
                 .into_string();
-            let mut bounds = Bounds::default();
-            bounds.add_parameter("P", &r_type, bound, false);
-            let (s_bounds, _) = function::bounds(&bounds, &[], false, false);
-            // Because the bounds won't necessarily be added into the final function, we
-            // only keep the "inner" part to make the string computation easier. So
-            // `<T: X>` becomes `T: X`.
-            bounds_str.push_str(&s_bounds[1..s_bounds.len() - 1]);
-            format!("{}: {}", prop_name, bounds.iter().last().unwrap().alias)
+
+            let _bound = Bound {
+                bound_type: bound,
+                parameter_name: TYPE_PARAMETERS_START.to_string(),
+                alias: Some(TYPE_PARAMETERS_START.to_owned()),
+                type_str: r_type,
+                callback_modified: false,
+            };
+            // TODO: bounds_str push?!?!
+            bounds_str.push_str("TODO");
+            format!("{}: {}", prop_name, TYPE_PARAMETERS_START)
+            // let mut bounds = Bounds::default();
+            // bounds.add_parameter("P", &r_type, bound, false);
+            // let (s_bounds, _) = function::bounds(&bounds, &[], false);
+            // // Because the bounds won't necessarily be added into the final function, we
+            // // only keep the "inner" part to make the string computation easier. So
+            // // `<T: X>` becomes `T: X`.
+            // bounds_str.push_str(&s_bounds[1..s_bounds.len() - 1]);
+            // format!("{}: {}", prop_name, bounds.iter().last().unwrap().alias)
         } else {
             format!(
                 "{}: {}",

--- a/src/codegen/bound.rs
+++ b/src/codegen/bound.rs
@@ -9,7 +9,7 @@ use crate::{
 impl Bound {
     /// Returns the type parameter reference.
     /// Currently always returns the alias.
-    pub(super) fn type_parameter_reference(&self) -> char {
+    pub(super) fn type_parameter_reference(&self) -> Option<char> {
         self.alias
     }
 
@@ -19,22 +19,48 @@ impl Bound {
         &self,
         ref_mode: RefMode,
         nullable: Nullable,
+        r#async: bool,
     ) -> String {
-        let t = self.type_parameter_reference();
         let ref_str = ref_mode.for_rust_type();
+
+        // Generate `impl Trait` if this bound does not have an alias
+        let trait_bound = match self.type_parameter_reference() {
+            Some(t) => t.to_string(),
+            None => {
+                let trait_bound = self.trait_bound(r#async);
+                let trait_bound = format!("impl {}", trait_bound);
+
+                // Combining a ref mode and lifetime requires parentheses for disambiguation
+                match self.bound_type {
+                    BoundType::IsA(lifetime) => {
+                        // TODO: This is fragile
+                        let has_lifetime = r#async || lifetime.is_some();
+
+                        if !ref_str.is_empty() && has_lifetime {
+                            format!("({})", trait_bound)
+                        } else {
+                            trait_bound
+                        }
+                    }
+                    _ => trait_bound,
+                }
+            }
+        };
+
         match self.bound_type {
             BoundType::IsA(_) if *nullable => {
-                format!("Option<{}{}>", ref_str, t)
+                format!("Option<{}{}>", ref_str, trait_bound)
             }
-            BoundType::IsA(_) => format!("{}{}", ref_str, t),
-            BoundType::NoWrapper | BoundType::AsRef(_) => t.to_string(),
+            BoundType::IsA(_) => format!("{}{}", ref_str, trait_bound),
+            BoundType::NoWrapper | BoundType::AsRef(_) => trait_bound,
         }
     }
 
     /// Returns the type parameter definition for this bound, usually
     /// of the form `T: SomeTrait` or `T: IsA<Foo>`.
-    pub(super) fn type_parameter_definition(&self, r#async: bool) -> String {
-        format!("{}: {}", self.alias, self.trait_bound(r#async))
+    pub(super) fn type_parameter_definition(&self, r#async: bool) -> Option<String> {
+        self.alias
+            .map(|alias| format!("{}: {}", alias, self.trait_bound(r#async)))
     }
 
     /// Returns the trait bound, usually of the form `SomeTrait`
@@ -47,6 +73,7 @@ impl Bound {
                     assert!(lifetime.is_none(), "Async overwrites lifetime");
                 }
                 let is_a = format!("IsA<{}>", self.type_str);
+
                 let lifetime = r#async
                     .then(|| " + Clone + 'static".to_string())
                     .or_else(|| lifetime.map(|l| format!(" + '{}", l)))

--- a/src/codegen/object.rs
+++ b/src/codegen/object.rs
@@ -243,6 +243,7 @@ fn generate_builder(w: &mut dyn Write, env: &Env, analysis: &analysis::object::I
                                     bound.full_type_parameter_reference(
                                         RefMode::ByRef,
                                         Nullable(false),
+                                        false,
                                     )
                                 });
                         (alias, bounds, ".clone().upcast()")

--- a/src/codegen/parameter.rs
+++ b/src/codegen/parameter.rs
@@ -8,16 +8,18 @@ use crate::{
 };
 
 pub trait ToParameter {
-    fn to_parameter(&self, env: &Env, bounds: &Bounds) -> String;
+    fn to_parameter(&self, env: &Env, bounds: &Bounds, r#async: bool) -> String;
 }
 
 impl ToParameter for CParameter {
-    fn to_parameter(&self, env: &Env, bounds: &Bounds) -> String {
+    fn to_parameter(&self, env: &Env, bounds: &Bounds, r#async: bool) -> String {
         if self.instance_parameter {
             format!("{}self", self.ref_mode.for_rust_type())
         } else {
             let type_str = match bounds.get_parameter_bound(&self.name) {
-                Some(bound) => bound.full_type_parameter_reference(self.ref_mode, self.nullable),
+                Some(bound) => {
+                    bound.full_type_parameter_reference(self.ref_mode, self.nullable, r#async)
+                }
                 None => {
                     let type_name = RustType::builder(env, self.typ)
                         .direction(self.direction)


### PR DESCRIPTION
For https://github.com/gtk-rs/gtk-rs-core/pull/89#issuecomment-846516935

---

`impl` is quite a bit more concise and readable when a type parameter with trait bound is only used once.  Aside that, this simplifies some of the type handling in trampolines by using `P: IsA<>` directly instead of through a `where P: ...` indirection.

---

Related MRs:
https://gitlab.freedesktop.org/gstreamer/gstreamer-rs/-/merge_requests/778
https://github.com/gtk-rs/gtk-rs-core/pull/95
https://github.com/gtk-rs/gtk3-rs/pull/547
https://github.com/gtk-rs/gtk4-rs/pull/404