### PR TITLE
codgen: generate impl T if there are builder properties as well

### DIFF
--- a/src/codegen/object.rs
+++ b/src/codegen/object.rs
@@ -414,7 +414,10 @@ fn generate_trait(w: &mut dyn Write, env: &Env, analysis: &analysis::object::Inf
 }
 
 fn need_generate_inherent(analysis: &analysis::object::Info) -> bool {
-    analysis.has_constructors || analysis.has_functions || !need_generate_trait(analysis)
+    analysis.has_constructors
+        || analysis.has_functions
+        || !need_generate_trait(analysis)
+        || !analysis.builder_properties.is_empty()
 }
 
 fn need_generate_trait(analysis: &analysis::object::Info) -> bool {


### PR DESCRIPTION
Fixes https://github.com/gtk-rs/gtk4-rs/issues/405

If a struct contains no method, or all of it's methods are manual for whatever reason this allows generation the builder method automatically 