### PR TITLE
[refactor] Simplify handling of trait bounds and aliases

### DIFF
--- a/src/analysis/bounds.rs
+++ b/src/analysis/bounds.rs
@@ -216,11 +216,8 @@ impl Bounds {
         });
     }
 
-    pub fn get_parameter_alias_info(&self, name: &str) -> Option<(char, BoundType)> {
-        self.used
-            .iter()
-            .find(|n| n.parameter_name == name)
-            .map(|t| (t.alias, t.bound_type.clone()))
+    pub fn get_parameter_bound(&self, name: &str) -> Option<&Bound> {
+        self.iter().find(move |n| n.parameter_name == name)
     }
 
     pub fn update_imports(&self, imports: &mut Imports) {
@@ -365,16 +362,17 @@ mod tests {
     }
 
     #[test]
-    fn get_parameter_alias_info() {
+    fn get_parameter_bound() {
         let mut bounds: Bounds = Default::default();
         let typ = BoundType::IsA(None);
         bounds.add_parameter("a", "", typ.clone(), false);
         bounds.add_parameter("b", "", typ.clone(), false);
-        assert_eq!(
-            bounds.get_parameter_alias_info("a"),
-            Some(('P', typ.clone()))
-        );
-        assert_eq!(bounds.get_parameter_alias_info("b"), Some(('Q', typ)));
-        assert_eq!(bounds.get_parameter_alias_info("c"), None);
+        let bound = bounds.get_parameter_bound("a").unwrap();
+        assert_eq!(bound.alias, 'P');
+        assert_eq!(bound.bound_type, typ);
+        let bound = bounds.get_parameter_bound("b").unwrap();
+        assert_eq!(bound.alias, 'Q');
+        assert_eq!(bound.bound_type, typ);
+        assert_eq!(bounds.get_parameter_bound("c"), None);
     }
 }

--- a/src/analysis/bounds.rs
+++ b/src/analysis/bounds.rs
@@ -52,9 +52,8 @@ pub struct Bounds {
 impl Default for Bounds {
     fn default() -> Bounds {
         Bounds {
-            unused: (TYPE_PARAMETERS_START as u8..)
-                .take_while(|x| *x <= b'Z')
-                .map(|x| x as char)
+            unused: (TYPE_PARAMETERS_START..)
+                .take_while(|x| *x <= 'Z')
                 .collect(),
             used: Vec::new(),
             unused_lifetimes: "abcdefg".chars().collect(),
@@ -152,14 +151,8 @@ impl Bounds {
                         });
                     }
                 }
-                if (!need_is_into_check || !*par.nullable)
-                    && par.c_type != "GDestroyNotify"
-                    && !self.add_parameter(&par.name, &type_string, bound_type, r#async)
-                {
-                    panic!(
-                        "Too many type constraints for {}",
-                        func.c_identifier.as_ref().unwrap()
-                    )
+                if (!need_is_into_check || !*par.nullable) && par.c_type != "GDestroyNotify" {
+                    self.add_parameter(&par.name, &type_string, bound_type, r#async)
                 }
             }
         } else if par.instance_parameter {
@@ -204,37 +197,23 @@ impl Bounds {
         &mut self,
         name: &str,
         type_str: &str,
-        bound_type: BoundType,
+        mut bound_type: BoundType,
         r#async: bool,
-    ) -> bool {
+    ) {
         if r#async && name == "callback" {
-            if let Some(alias) = self.unused.pop_front() {
-                self.used.push(Bound {
-                    bound_type: BoundType::NoWrapper,
-                    parameter_name: name.to_owned(),
-                    alias,
-                    type_str: type_str.to_string(),
-                    callback_modified: false,
-                });
-                return true;
-            }
-            return false;
+            bound_type = BoundType::NoWrapper;
         }
         if self.used.iter().any(|n| n.parameter_name == name) {
-            return false;
+            return;
         }
-        if let Some(alias) = self.unused.pop_front() {
-            self.used.push(Bound {
-                bound_type,
-                parameter_name: name.to_owned(),
-                alias,
-                type_str: type_str.to_owned(),
-                callback_modified: false,
-            });
-            true
-        } else {
-            false
-        }
+        let alias = self.unused.pop_front().expect("No free type aliases!");
+        self.used.push(Bound {
+            bound_type,
+            parameter_name: name.to_owned(),
+            alias,
+            type_str: type_str.to_owned(),
+            callback_modified: false,
+        });
     }
 
     pub fn get_parameter_alias_info(&self, name: &str) -> Option<(char, BoundType)> {
@@ -354,21 +333,35 @@ mod tests {
     fn get_new_all() {
         let mut bounds: Bounds = Default::default();
         let typ = BoundType::IsA(None);
-        assert_eq!(bounds.add_parameter("a", "", typ.clone(), false), true);
+        bounds.add_parameter("a", "", typ.clone(), false);
+        assert_eq!(bounds.iter().len(), 1);
         // Don't add second time
-        assert_eq!(bounds.add_parameter("a", "", typ.clone(), false), false);
-        assert_eq!(bounds.add_parameter("b", "", typ.clone(), false), true);
-        assert_eq!(bounds.add_parameter("c", "", typ.clone(), false), true);
-        assert_eq!(bounds.add_parameter("d", "", typ.clone(), false), true);
-        assert_eq!(bounds.add_parameter("e", "", typ.clone(), false), true);
-        assert_eq!(bounds.add_parameter("f", "", typ.clone(), false), true);
-        assert_eq!(bounds.add_parameter("g", "", typ.clone(), false), true);
-        assert_eq!(bounds.add_parameter("h", "", typ.clone(), false), true);
-        assert_eq!(bounds.add_parameter("h", "", typ.clone(), false), false);
-        assert_eq!(bounds.add_parameter("i", "", typ.clone(), false), true);
-        assert_eq!(bounds.add_parameter("j", "", typ.clone(), false), true);
-        assert_eq!(bounds.add_parameter("k", "", typ.clone(), false), true);
-        assert_eq!(bounds.add_parameter("l", "", typ, false), false);
+        bounds.add_parameter("a", "", typ.clone(), false);
+        assert_eq!(bounds.iter().len(), 1);
+        bounds.add_parameter("b", "", typ.clone(), false);
+        bounds.add_parameter("c", "", typ.clone(), false);
+        bounds.add_parameter("d", "", typ.clone(), false);
+        bounds.add_parameter("e", "", typ.clone(), false);
+        bounds.add_parameter("f", "", typ.clone(), false);
+        bounds.add_parameter("g", "", typ.clone(), false);
+        bounds.add_parameter("h", "", typ.clone(), false);
+        assert_eq!(bounds.iter().len(), 8);
+        bounds.add_parameter("h", "", typ.clone(), false);
+        assert_eq!(bounds.iter().len(), 8);
+        bounds.add_parameter("i", "", typ.clone(), false);
+        bounds.add_parameter("j", "", typ.clone(), false);
+        bounds.add_parameter("k", "", typ, false);
+    }
+
+    #[test]
+    #[should_panic(expected = "No free type aliases!")]
+    fn exhaust_type_parameters() {
+        let mut bounds: Bounds = Default::default();
+        let typ = BoundType::NoWrapper;
+        for c in 'a'..='l' {
+            // Should panic on `l` because all type parameters are exhausted
+            bounds.add_parameter(c.to_string().as_str(), "", typ.clone(), false);
+        }
     }
 
     #[test]

--- a/src/analysis/bounds.rs
+++ b/src/analysis/bounds.rs
@@ -38,7 +38,6 @@ pub struct Bound {
     pub parameter_name: String,
     pub alias: char,
     pub type_str: String,
-    pub info_for_next_type: bool,
     pub callback_modified: bool,
 }
 
@@ -215,7 +214,6 @@ impl Bounds {
                     parameter_name: name.to_owned(),
                     alias,
                     type_str: type_str.to_string(),
-                    info_for_next_type: false,
                     callback_modified: false,
                 });
                 return true;
@@ -231,7 +229,6 @@ impl Bounds {
                 parameter_name: name.to_owned(),
                 alias,
                 type_str: type_str.to_owned(),
-                info_for_next_type: false,
                 callback_modified: false,
             });
             true
@@ -243,31 +240,8 @@ impl Bounds {
     pub fn get_parameter_alias_info(&self, name: &str) -> Option<(char, BoundType)> {
         self.used
             .iter()
-            .find(move |n| {
-                if n.parameter_name == name {
-                    !n.info_for_next_type
-                } else {
-                    false
-                }
-            })
+            .find(|n| n.parameter_name == name)
             .map(|t| (t.alias, t.bound_type.clone()))
-    }
-
-    pub fn get_base_alias(&self, alias: char) -> Option<char> {
-        if alias == TYPE_PARAMETERS_START {
-            return None;
-        }
-        let prev_alias = ((alias as u8) - 1) as char;
-        self.used
-            .iter()
-            .find(move |n| n.alias == prev_alias)
-            .and_then(|b| {
-                if b.info_for_next_type {
-                    Some(b.alias)
-                } else {
-                    None
-                }
-            })
     }
 
     pub fn update_imports(&self, imports: &mut Imports) {

--- a/src/analysis/rust_type.rs
+++ b/src/analysis/rust_type.rs
@@ -121,12 +121,9 @@ impl RustType {
 
     #[inline]
     fn apply_ref_mode(self, ref_mode: RefMode) -> Self {
-        match ref_mode {
-            RefMode::None | RefMode::ByRefFake => self,
-            RefMode::ByRef | RefMode::ByRefImmut | RefMode::ByRefConst => {
-                self.alter_type(|typ_| format!("&{}", typ_))
-            }
-            RefMode::ByRefMut => self.alter_type(|typ_| format!("&mut {}", typ_)),
+        match ref_mode.for_rust_type() {
+            "" => self,
+            ref_mode => self.alter_type(|typ_| format!("{}{}", ref_mode, typ_)),
         }
     }
 }

--- a/src/codegen/bound.rs
+++ b/src/codegen/bound.rs
@@ -1,0 +1,61 @@
+use crate::{
+    analysis::{
+        bounds::{Bound, BoundType},
+        ref_mode::RefMode,
+    },
+    library::Nullable,
+};
+
+impl Bound {
+    /// Returns the type parameter reference.
+    /// Currently always returns the alias.
+    pub(super) fn type_parameter_reference(&self) -> char {
+        self.alias
+    }
+
+    /// Returns the type parameter reference, with [`BoundType::IsA`] wrapped
+    /// in `ref_mode` and `nullable` as appropriate.
+    pub(super) fn full_type_parameter_reference(
+        &self,
+        ref_mode: RefMode,
+        nullable: Nullable,
+    ) -> String {
+        let t = self.type_parameter_reference();
+        let ref_str = ref_mode.for_rust_type();
+        match self.bound_type {
+            BoundType::IsA(_) if *nullable => {
+                format!("Option<{}{}>", ref_str, t)
+            }
+            BoundType::IsA(_) => format!("{}{}", ref_str, t),
+            BoundType::NoWrapper | BoundType::AsRef(_) => t.to_string(),
+        }
+    }
+
+    /// Returns the type parameter definition for this bound, usually
+    /// of the form `T: SomeTrait` or `T: IsA<Foo>`.
+    pub(super) fn type_parameter_definition(&self, r#async: bool) -> String {
+        format!("{}: {}", self.alias, self.trait_bound(r#async))
+    }
+
+    /// Returns the trait bound, usually of the form `SomeTrait`
+    /// or `IsA<Foo>`.
+    pub(super) fn trait_bound(&self, r#async: bool) -> String {
+        match self.bound_type {
+            BoundType::NoWrapper => self.type_str.clone(),
+            BoundType::IsA(lifetime) => {
+                if r#async {
+                    assert!(lifetime.is_none(), "Async overwrites lifetime");
+                }
+                let is_a = format!("IsA<{}>", self.type_str);
+                let lifetime = r#async
+                    .then(|| " + Clone + 'static".to_string())
+                    .or_else(|| lifetime.map(|l| format!(" + '{}", l)))
+                    .unwrap_or_default();
+
+                format!("{}{}", is_a, lifetime)
+            }
+            BoundType::AsRef(Some(_ /*lifetime*/)) => panic!("AsRef cannot have a lifetime"),
+            BoundType::AsRef(None) => format!("AsRef<{}>", self.type_str),
+        }
+    }
+}

--- a/src/codegen/function.rs
+++ b/src/codegen/function.rs
@@ -10,11 +10,7 @@ use super::{
 };
 use crate::{
     analysis::{
-        self,
-        bounds::{Bound, Bounds},
-        functions::Visibility,
-        namespaces,
-        try_from_glib::TryFromGlib,
+        self, bounds::Bounds, functions::Visibility, namespaces, try_from_glib::TryFromGlib,
     },
     chunk::{ffi_function_todo, Chunk},
     env::Env,
@@ -214,8 +210,8 @@ pub fn declaration_futures(env: &Env, analysis: &analysis::functions::Info) -> S
 
         if c_par.name == "callback" || c_par.name == "cancellable" {
             skipped += 1;
-            if let Some((t, _)) = analysis.bounds.get_parameter_alias_info(&c_par.name) {
-                skipped_bounds.push(t);
+            if let Some(bound) = analysis.bounds.get_parameter_bound(&c_par.name) {
+                skipped_bounds.push(bound.type_parameter_reference());
             }
             continue;
         }
@@ -234,36 +230,6 @@ pub fn declaration_futures(env: &Env, analysis: &analysis::functions::Info) -> S
         "fn {}{}({}){}",
         async_future.name, bounds, param_str, return_str,
     )
-}
-
-pub fn bound_to_string(bound: &Bound, r#async: bool) -> String {
-    use crate::analysis::bounds::BoundType::*;
-
-    match bound.bound_type {
-        NoWrapper => format!("{}: {}", bound.alias, bound.type_str),
-        IsA(Some(lifetime)) => format!(
-            "{}: IsA<{}> + {}",
-            bound.alias,
-            bound.type_str,
-            if r#async {
-                "Clone + 'static".into()
-            } else {
-                format!("'{}", lifetime)
-            }
-        ),
-        IsA(None) => format!(
-            "{}: IsA<{}>{}",
-            bound.alias,
-            bound.type_str,
-            if r#async { " + Clone + 'static" } else { "" }
-        ),
-        // This case should normally never happened
-        AsRef(Some(_ /*lifetime*/)) => {
-            unreachable!();
-            // format!("{}: AsRef<{}> + '{}", bound.alias, bound.type_str, lifetime)
-        }
-        AsRef(None) => format!("{}: AsRef<{}>", bound.alias, bound.type_str),
-    }
 }
 
 pub fn bounds(
@@ -287,40 +253,34 @@ pub fn bounds(
         })
         .collect::<Vec<_>>();
 
-    let strs: Vec<String> = bounds
+    let lifetimes = bounds
         .iter_lifetimes()
         .filter(|s| !skip_lifetimes.contains(s))
         .map(|s| format!("'{}", s))
-        .chain(
-            bounds
-                .iter()
-                .filter(|bound| {
-                    !skip.contains(&bound.alias)
-                        && (!filter_callback_modified || !bound.callback_modified)
-                })
-                .map(|b| bound_to_string(b, r#async)),
-        )
-        .collect();
+        .collect::<Vec<_>>();
 
-    if strs.is_empty() {
-        (String::new(), Vec::new())
+    let bounds = bounds.iter().filter(|bound| {
+        !skip.contains(&bound.alias) && (!filter_callback_modified || !bound.callback_modified)
+    });
+
+    let type_names = lifetimes
+        .iter()
+        .cloned()
+        .chain(bounds.clone().map(|b| b.type_parameter_definition(r#async)))
+        .collect::<Vec<_>>();
+
+    let type_names = if type_names.is_empty() {
+        String::new()
     } else {
-        let bounds = bounds
-            .iter_lifetimes()
-            .filter(|s| !skip_lifetimes.contains(s))
-            .map(|s| format!("'{}", s))
-            .chain(
-                bounds
-                    .iter()
-                    .filter(|bound| {
-                        !skip.contains(&bound.alias)
-                            && (!filter_callback_modified || !bound.callback_modified)
-                    })
-                    .map(|b| b.alias.to_string()),
-            )
-            .collect::<Vec<_>>();
-        (format!("<{}>", strs.join(", ")), bounds)
-    }
+        format!("<{}>", type_names.join(", "))
+    };
+
+    let bounds = lifetimes
+        .into_iter()
+        .chain(bounds.map(|b| b.alias.to_string()))
+        .collect::<Vec<_>>();
+
+    (type_names, bounds)
 }
 
 pub fn body_chunk(env: &Env, analysis: &analysis::functions::Info) -> Chunk {

--- a/src/codegen/function.rs
+++ b/src/codegen/function.rs
@@ -216,9 +216,6 @@ pub fn declaration_futures(env: &Env, analysis: &analysis::functions::Info) -> S
             skipped += 1;
             if let Some((t, _)) = analysis.bounds.get_parameter_alias_info(&c_par.name) {
                 skipped_bounds.push(t);
-                if let Some(p) = analysis.bounds.get_base_alias(t) {
-                    skipped_bounds.push(p);
-                }
             }
             continue;
         }

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -2,6 +2,7 @@ use crate::{config::WorkMode, env::Env, file_saver::*};
 use std::path::Path;
 
 mod alias;
+mod bound;
 mod child_properties;
 mod constants;
 mod doc;

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -18,6 +18,7 @@ mod properties;
 mod property_body;
 mod record;
 mod records;
+mod ref_mode;
 mod return_value;
 mod signal;
 mod signal_body;

--- a/src/codegen/parameter.rs
+++ b/src/codegen/parameter.rs
@@ -3,7 +3,6 @@ use crate::{
         bounds::{BoundType, Bounds},
         conversion_type::ConversionType,
         function_parameters::CParameter,
-        ref_mode::RefMode,
         rust_type::RustType,
     },
     env::Env,
@@ -16,11 +15,7 @@ pub trait ToParameter {
 
 impl ToParameter for CParameter {
     fn to_parameter(&self, env: &Env, bounds: &Bounds) -> String {
-        let ref_str = match self.ref_mode {
-            RefMode::ByRefMut => "&mut ",
-            RefMode::None => "",
-            _ => "&",
-        };
+        let ref_str = self.ref_mode.for_rust_type();
         if self.instance_parameter {
             format!("{}self", ref_str)
         } else {

--- a/src/codegen/parameter.rs
+++ b/src/codegen/parameter.rs
@@ -1,8 +1,6 @@
 use crate::{
     analysis::{
-        bounds::{BoundType, Bounds},
-        conversion_type::ConversionType,
-        function_parameters::CParameter,
+        bounds::Bounds, conversion_type::ConversionType, function_parameters::CParameter,
         rust_type::RustType,
     },
     env::Env,
@@ -15,20 +13,11 @@ pub trait ToParameter {
 
 impl ToParameter for CParameter {
     fn to_parameter(&self, env: &Env, bounds: &Bounds) -> String {
-        let ref_str = self.ref_mode.for_rust_type();
         if self.instance_parameter {
-            format!("{}self", ref_str)
+            format!("{}self", self.ref_mode.for_rust_type())
         } else {
-            let type_str: String;
-            match bounds.get_parameter_alias_info(&self.name) {
-                Some((t, bound_type)) => match bound_type {
-                    BoundType::NoWrapper => type_str = t.to_string(),
-                    BoundType::IsA(_) if *self.nullable => {
-                        type_str = format!("Option<{}{}>", ref_str, t)
-                    }
-                    BoundType::IsA(_) => type_str = format!("{}{}", ref_str, t),
-                    BoundType::AsRef(_) => type_str = t.to_string(),
-                },
+            let type_str = match bounds.get_parameter_bound(&self.name) {
+                Some(bound) => bound.full_type_parameter_reference(self.ref_mode, self.nullable),
                 None => {
                     let type_name = RustType::builder(env, self.typ)
                         .direction(self.direction)
@@ -38,17 +27,13 @@ impl ToParameter for CParameter {
                         .try_from_glib(&self.try_from_glib)
                         .try_build_param()
                         .into_string();
-                    type_str = match ConversionType::of(env, self.typ) {
+                    match ConversionType::of(env, self.typ) {
                         ConversionType::Unknown => format!("/*Unknown conversion*/{}", type_name),
                         _ => type_name,
                     }
                 }
-            }
-            format_parameter(&self.name, &type_str)
+            };
+            format!("{}: {}", self.name, type_str)
         }
     }
-}
-
-fn format_parameter(name: &str, type_str: &str) -> String {
-    format!("{}: {}", name, type_str)
 }

--- a/src/codegen/ref_mode.rs
+++ b/src/codegen/ref_mode.rs
@@ -1,0 +1,11 @@
+use crate::analysis::ref_mode::RefMode;
+
+impl RefMode {
+    pub(crate) fn for_rust_type(self) -> &'static str {
+        match self {
+            RefMode::None | RefMode::ByRefFake => "",
+            RefMode::ByRef | RefMode::ByRefImmut | RefMode::ByRefConst => "&",
+            RefMode::ByRefMut => "&mut ",
+        }
+    }
+}

--- a/src/codegen/signal.rs
+++ b/src/codegen/signal.rs
@@ -6,7 +6,6 @@ use super::{
 use crate::{
     analysis,
     chunk::Chunk,
-    consts::TYPE_PARAMETERS_START,
     env::Env,
     nameutil::use_glib_type,
     writer::{primitives::tabs, ToCode},
@@ -179,11 +178,7 @@ fn function_type_string(
     let type_ = func_string(
         env,
         trampoline,
-        if closure {
-            Some((TYPE_PARAMETERS_START, "Self"))
-        } else {
-            Some((TYPE_PARAMETERS_START, "self"))
-        },
+        Some(if closure { "Self" } else { "self" }),
         closure,
     );
     Some(type_)

--- a/src/codegen/trampoline.rs
+++ b/src/codegen/trampoline.rs
@@ -4,13 +4,8 @@ use super::{
 };
 use crate::{
     analysis::{
-        bounds::{BoundType, Bounds},
-        ffi_type::ffi_type,
-        ref_mode::RefMode,
-        rust_type::RustType,
-        trampoline_parameters::*,
-        trampolines::Trampoline,
-        try_from_glib::TryFromGlib,
+        bounds::Bounds, ffi_type::ffi_type, ref_mode::RefMode, rust_type::RustType,
+        trampoline_parameters::*, trampolines::Trampoline, try_from_glib::TryFromGlib,
     },
     consts::TYPE_PARAMETERS_START,
     env::Env,
@@ -128,15 +123,8 @@ fn func_parameter(env: &Env, par: &RustParameter, bounds: &Bounds) -> String {
         par.ref_mode
     };
 
-    match bounds.get_parameter_alias_info(&par.name) {
-        Some((t, bound_type)) => match bound_type {
-            BoundType::NoWrapper => unreachable!(),
-            BoundType::IsA(_) if *par.nullable => {
-                format!("Option<{}{}>", ref_mode.for_rust_type(), t)
-            }
-            BoundType::IsA(_) => format!("{}{}", ref_mode.for_rust_type(), t),
-            BoundType::AsRef(_) => t.to_string(),
-        },
+    match bounds.get_parameter_bound(&par.name) {
+        Some(bound) => bound.full_type_parameter_reference(ref_mode, par.nullable),
         None => RustType::builder(env, par.typ)
             .direction(par.direction)
             .nullable(par.nullable)

--- a/src/codegen/trampoline.rs
+++ b/src/codegen/trampoline.rs
@@ -124,8 +124,6 @@ fn func_parameter(
     bound_replace: Option<(char, &str)>,
 ) -> String {
     //TODO: restore mutable support
-    //let mut_str = if par.ref_mode == RefMode::ByRefMut { "mut " } else { "" };
-    let mut_str = "";
     let ref_mode = if par.ref_mode == RefMode::ByRefMut {
         RefMode::ByRef
     } else {
@@ -137,15 +135,15 @@ fn func_parameter(
             BoundType::NoWrapper => unreachable!(),
             BoundType::IsA(_) => {
                 if *par.nullable {
-                    format!("Option<&{}{}>", mut_str, t)
+                    format!("Option<{}{}>", ref_mode.for_rust_type(), t)
                 } else if let Some((from, to)) = bound_replace {
                     if from == t {
-                        format!("&{}{}", mut_str, to)
+                        format!("{}{}", ref_mode.for_rust_type(), to)
                     } else {
-                        format!("&{}{}", mut_str, t)
+                        format!("{}{}", ref_mode.for_rust_type(), t)
                     }
                 } else {
-                    format!("&{}{}", mut_str, t)
+                    format!("{}{}", ref_mode.for_rust_type(), t)
                 }
             }
             BoundType::AsRef(_) => t.to_string(),


### PR DESCRIPTION
All the cleanups from #1153 separated in nicely documented, individually reviewable commits.

This includes a simplification of `where T: IsA<Foo>` into specifying the trait bound directly when the type parameter is defined: `func<T: IsA<Foo>>`.

As requested by @GuillaumeGomez the "fix" for `clippy::use_self` is in here too, but in hindsight I'm not too sure how useful it is. This is what it does:

```diff
diff --git a/gdk/src/auto/device.rs b/gdk/src/auto/device.rs
index f53e2a154f..9994f88311 100644
--- a/gdk/src/auto/device.rs
+++ b/gdk/src/auto/device.rs
@@ -450,7 +450,7 @@ impl Device {
     }

     #[doc(alias = "changed")]
-    pub fn connect_changed<F: Fn(&Device) + 'static>(&self, f: F) -> SignalHandlerId {
+    pub fn connect_changed<F: Fn(&Self) + 'static>(&self, f: F) -> SignalHandlerId {
         unsafe extern "C" fn changed_trampoline<F: Fn(&Device) + 'static>(
             this: *mut ffi::GdkDevice,
             f: glib::ffi::gpointer,
```

`F` of the function and `F` of the `unsafe extern "C" fn` still mean the same thing, though they are now textually different. The the nested `unsafe extern "C" fn` cannot reference type parameters (`Self` is a type parameter!) of the surrounding context, which is why it still carries `Device` instead of `Self`.
A bit further don this code-block the pointer of `changed_trampoline::<F>` is taken, to pass type parameter `F` of the surrounding function into the nested one (hence they reference the same type).