### PR TITLE
Docs: refactored + GI Docgen support

### DIFF
--- a/src/analysis/functions.rs
+++ b/src/analysis/functions.rs
@@ -104,6 +104,15 @@ impl Info {
         self.new_name.as_ref().unwrap_or(&self.name)
     }
 
+    pub fn is_special(&self) -> bool {
+        self.codegen_name()
+            .trim_end_matches('_')
+            .split('_')
+            .last()
+            .map(|i| i.parse::<special_functions::Type>().is_ok())
+            .unwrap_or(false)
+    }
+
     pub fn is_async_finish(&self, env: &Env) -> bool {
         let has_async_result = self
             .parameters

--- a/src/analysis/functions.rs
+++ b/src/analysis/functions.rs
@@ -115,10 +115,7 @@ impl Info {
 
     // returns whether the method can be linked in the docs
     pub fn should_be_doc_linked<F: Fn(&Self) -> bool>(&self, env: &Env, search: F) -> bool {
-        self.status != GStatus::Ignore
-            && !self.is_special()
-            && !self.is_async_finish(env)
-            && search(self)
+        !self.status.ignored() && !self.is_special() && !self.is_async_finish(env) && search(self)
     }
 
     pub fn doc_link(&self, parent: Option<&str>, visible_parent: Option<&str>) -> String {

--- a/src/analysis/functions.rs
+++ b/src/analysis/functions.rs
@@ -124,17 +124,16 @@ impl Info {
         is_self: bool,
     ) -> String {
         if let Some(p) = parent {
-            let visible_parent_name = if is_self {
-                "Self"
+            if is_self {
+                format!("[`{f}()`][Self::{f}()]", f = self.codegen_name())
             } else {
-                visible_parent.unwrap_or(p)
-            };
-            format!(
-                "[`{visible_type_name}::{fn_name}()`][crate::{name}::{fn_name}()]",
-                name = p,
-                visible_type_name = visible_parent_name,
-                fn_name = self.codegen_name(),
-            )
+                format!(
+                    "[`{visible_parent}::{f}()`][crate::{p}::{f}()]",
+                    visible_parent = visible_parent.unwrap_or(p),
+                    p = p,
+                    f = self.codegen_name()
+                )
+            }
         } else {
             format!(
                 "[`{fn_name}()`][crate::{fn_name}()]",

--- a/src/analysis/functions.rs
+++ b/src/analysis/functions.rs
@@ -107,8 +107,8 @@ impl Info {
     pub fn is_special(&self) -> bool {
         self.codegen_name()
             .trim_end_matches('_')
-            .split('_')
-            .last()
+            .rsplit('_')
+            .next()
             .map(|i| i.parse::<special_functions::Type>().is_ok())
             .unwrap_or(false)
     }

--- a/src/analysis/functions.rs
+++ b/src/analysis/functions.rs
@@ -118,12 +118,22 @@ impl Info {
         !self.status.ignored() && !self.is_special() && !self.is_async_finish(env) && search(self)
     }
 
-    pub fn doc_link(&self, parent: Option<&str>, visible_parent: Option<&str>) -> String {
+    pub fn doc_link(
+        &self,
+        parent: Option<&str>,
+        visible_parent: Option<&str>,
+        is_self: bool,
+    ) -> String {
         if let Some(p) = parent {
+            let visible_parent_name = if is_self {
+                "Self"
+            } else {
+                visible_parent.unwrap_or(p)
+            };
             format!(
                 "[`{visible_type_name}::{fn_name}()`][crate::{name}::{fn_name}()]",
                 name = p,
-                visible_type_name = visible_parent.unwrap_or(p),
+                visible_type_name = visible_parent_name,
                 fn_name = self.codegen_name(),
             )
         } else {

--- a/src/analysis/functions.rs
+++ b/src/analysis/functions.rs
@@ -113,6 +113,30 @@ impl Info {
             .unwrap_or(false)
     }
 
+    // returns whether the method can be linked in the docs
+    pub fn should_be_doc_linked<F: Fn(&Self) -> bool>(&self, env: &Env, search: F) -> bool {
+        self.status != GStatus::Ignore
+            && !self.is_special()
+            && !self.is_async_finish(env)
+            && search(self)
+    }
+
+    pub fn doc_link(&self, parent: Option<&str>, visible_parent: Option<&str>) -> String {
+        if let Some(p) = parent {
+            format!(
+                "[`{visible_type_name}::{fn_name}()`][crate::{name}::{fn_name}()]",
+                name = p,
+                visible_type_name = visible_parent.unwrap_or(p),
+                fn_name = self.codegen_name(),
+            )
+        } else {
+            format!(
+                "[`{fn_name}()`][crate::{fn_name}()]",
+                fn_name = self.codegen_name()
+            )
+        }
+    }
+
     pub fn is_async_finish(&self, env: &Env) -> bool {
         let has_async_result = self
             .parameters

--- a/src/analysis/functions.rs
+++ b/src/analysis/functions.rs
@@ -109,8 +109,7 @@ impl Info {
             .trim_end_matches('_')
             .rsplit('_')
             .next()
-            .map(|i| i.parse::<special_functions::Type>().is_ok())
-            .unwrap_or(false)
+            .map_or(false, |i| i.parse::<special_functions::Type>().is_ok())
     }
 
     // returns whether the method can be linked in the docs

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -80,9 +80,9 @@ impl Analysis {
         search_fn: F,
     ) -> Option<(&record::Info, &functions::Info)> {
         self.records
-            .iter()
-            .filter(|(_, r)| search_record(r))
-            .find_map(|(_, record_info)| {
+            .values()
+            .filter(|r| search_record(r))
+            .find_map(|record_info| {
                 record_info
                     .functions
                     .iter()
@@ -101,9 +101,9 @@ impl Analysis {
         search_fn: F,
     ) -> Option<(&object::Info, &functions::Info)> {
         self.objects
-            .iter()
-            .filter(|(_, o)| search_obj(o))
-            .find_map(|(_, obj_info)| {
+            .values()
+            .filter(|o| search_obj(o))
+            .find_map(|obj_info| {
                 obj_info
                     .functions
                     .iter()

--- a/src/analysis/object.rs
+++ b/src/analysis/object.rs
@@ -44,14 +44,19 @@ impl Info {
         self.signals.iter().any(|s| s.action_emit_name.is_some())
     }
 
-    // Generate a visible doc name based on whether the passed function and whether the type is final
-    pub fn generate_doc_link_info(&self, fn_info: &functions::Info) -> (String, String) {
-        if self.final_type
+    /// Returns [`true`] when the function is implemented directly on the type,
+    /// [`false`] when it is implemented on an extension trait instead.
+    pub fn function_in_impl(&self, fn_info: &functions::Info) -> bool {
+        self.final_type
             || matches!(
                 fn_info.kind,
                 FunctionKind::Constructor | FunctionKind::Function
             )
-        {
+    }
+
+    // Generate a visible doc name based on whether the passed function and whether the type is final
+    pub fn generate_doc_link_info(&self, fn_info: &functions::Info) -> (String, String) {
+        if self.function_in_impl(fn_info) {
             (self.name.clone(), self.name.clone())
         } else {
             let type_name = if fn_info.status == GStatus::Generate {

--- a/src/analysis/object.rs
+++ b/src/analysis/object.rs
@@ -2,7 +2,13 @@ use super::{
     child_properties::ChildProperties, imports::Imports, info_base::InfoBase,
     signatures::Signatures, *,
 };
-use crate::{config::gobjects::GObject, env::Env, library, nameutil::*, traits::*};
+use crate::{
+    config::gobjects::{GObject, GStatus},
+    env::Env,
+    library::{self, FunctionKind},
+    nameutil::*,
+    traits::*,
+};
 use log::info;
 use std::ops::Deref;
 
@@ -36,6 +42,25 @@ impl Info {
 
     pub fn has_action_signals(&self) -> bool {
         self.signals.iter().any(|s| s.action_emit_name.is_some())
+    }
+
+    // Generate a visible doc name based on whether the passed function and whether the type is final
+    pub fn generate_doc_link_info(&self, fn_info: &functions::Info) -> (String, String) {
+        if self.final_type
+            || matches!(
+                fn_info.kind,
+                FunctionKind::Constructor | FunctionKind::Function
+            )
+        {
+            (self.name.clone(), self.name.clone())
+        } else {
+            let type_name = if fn_info.status == GStatus::Generate {
+                self.trait_name.clone()
+            } else {
+                format!("{}Manual", self.trait_name)
+            };
+            (format!("prelude::{}", type_name), type_name)
+        }
     }
 }
 

--- a/src/analysis/symbols.rs
+++ b/src/analysis/symbols.rs
@@ -169,7 +169,7 @@ pub fn run(library: &Library, namespaces: &namespaces::Info) -> Info {
                             name: member.name.to_camel(),
                             ..Default::default()
                         };
-                        info.insert(&member.c_identifier, symbol, Some(tid));
+                        info.insert(&member.c_identifier, symbol, None);
                     }
                     for func in functions {
                         let symbol = Symbol {

--- a/src/analysis/symbols.rs
+++ b/src/analysis/symbols.rs
@@ -18,7 +18,7 @@ impl Symbol {
     pub fn parent(&self) -> String {
         let mut ret = String::new();
         if Some("gobject") == self.crate_name() {
-            ret.push_str("glib::object::");
+            ret.push_str("glib::");
         } else {
             if let Some(ref s) = self.crate_name {
                 ret.push_str(s);

--- a/src/codegen/doc/format.rs
+++ b/src/codegen/doc/format.rs
@@ -146,7 +146,7 @@ fn find_constant_or_variant(symbol: &str, env: &Env) -> String {
         .find(|c| c.glib_name == symbol)
     {
         // for whatever reason constants are not part of the symbols list
-        format!("[`{name}`][crate::{name}]", name = const_info.name)
+        format!("[`{n}`][crate::{n}]", n = const_info.name)
     } else if let Some((flag_info, member_info)) = env.analysis.flags.iter().find_map(|f| {
         f.type_(&env.library)
             .members
@@ -156,10 +156,9 @@ fn find_constant_or_variant(symbol: &str, env: &Env) -> String {
     }) {
         let sym = symbols.by_tid(flag_info.type_id).unwrap();
         format!(
-            "[`{flag_name}::{member_name}`][crate::{parent}::{member_name}]",
-            member_name = nameutil::bitfield_member_name(&member_info.name),
-            flag_name = flag_info.name,
-            parent = sym.full_rust_name()
+            "[`{p}::{m}`][crate::{p}::{m}]",
+            m = nameutil::bitfield_member_name(&member_info.name),
+            p = sym.full_rust_name()
         )
     } else if let Some((enum_info, member_info)) = env.analysis.enumerations.iter().find_map(|e| {
         e.type_(&env.library)
@@ -170,10 +169,9 @@ fn find_constant_or_variant(symbol: &str, env: &Env) -> String {
     }) {
         let sym = symbols.by_tid(enum_info.type_id).unwrap();
         format!(
-            "[`{enum_name}::{member}`][crate::{parent}::{member}]",
-            enum_name = enum_info.name,
-            member = nameutil::enum_member_name(&member_info.name),
-            parent = sym.full_rust_name()
+            "[`{e}::{m}`][crate::{e}::{m}]",
+            m = nameutil::enum_member_name(&member_info.name),
+            e = sym.full_rust_name()
         )
     } else {
         format!("`{}`", symbol)
@@ -211,7 +209,7 @@ fn find_type(name: &str, env: &Env) -> String {
         None
     };
     symbol
-        .map(|sym| format!("[`{name}`][crate::{name}]", name = sym.full_rust_name()))
+        .map(|sym| format!("[`{n}`][crate::{n}]", n = sym.full_rust_name()))
         .unwrap_or_else(|| format!("`{}`", name))
 }
 
@@ -244,10 +242,7 @@ fn find_function(name: &str, env: &Env) -> String {
         .analysis
         .find_global_function(env, |f| f.glib_name == name)
     {
-        format!(
-            "[`{fn_name}()`][crate::{fn_name}()]",
-            fn_name = fn_info.codegen_name()
-        )
+        fn_info.doc_link(None, None)
     } else {
         format!("`{}()`", name)
     }

--- a/src/codegen/doc/format.rs
+++ b/src/codegen/doc/format.rs
@@ -1,5 +1,5 @@
 use super::gi_docgen;
-use crate::{nameutil, Env};
+use crate::{library::TypeId, nameutil, Env};
 use log::{info, warn};
 use once_cell::sync::Lazy;
 use regex::{Captures, Regex};
@@ -9,7 +9,7 @@ const LANGUAGE_SEP_END: &str = "\" -->";
 const LANGUAGE_BLOCK_BEGIN: &str = "|[";
 const LANGUAGE_BLOCK_END: &str = "\n]|";
 
-pub fn reformat_doc(input: &str, env: &Env, in_type: &str) -> String {
+pub fn reformat_doc(input: &str, env: &Env, in_type: Option<&TypeId>) -> String {
     code_blocks_transformation(input, env, in_type)
 }
 
@@ -20,7 +20,7 @@ fn try_split<'a>(src: &'a str, needle: &str) -> (&'a str, Option<&'a str>) {
     }
 }
 
-fn code_blocks_transformation(mut input: &str, env: &Env, in_type: &str) -> String {
+fn code_blocks_transformation(mut input: &str, env: &Env, in_type: Option<&TypeId>) -> String {
     let mut out = String::with_capacity(input.len());
 
     loop {
@@ -56,7 +56,7 @@ fn get_language<'a>(entry: &'a str, out: &mut String) -> &'a str {
     entry
 }
 
-fn format(input: &str, env: &Env, in_type: &str) -> String {
+fn format(input: &str, env: &Env, in_type: Option<&TypeId>) -> String {
     let mut ret = String::with_capacity(input.len());
     // We run gi_docgen first because it's super picky about the types it replaces
     let out = replace_c_types(input, env, in_type);
@@ -80,10 +80,10 @@ static GDK_GTK: Lazy<Regex> =
 static TAGS: Lazy<Regex> = Lazy::new(|| Regex::new(r"<[\w/-]+>").unwrap());
 static SPACES: Lazy<Regex> = Lazy::new(|| Regex::new(r"[ ]{2,}").unwrap());
 
-fn replace_c_types(entry: &str, env: &Env, _in_type: &str) -> String {
+fn replace_c_types(entry: &str, env: &Env, in_type: Option<&TypeId>) -> String {
     let out = FUNCTION.replace_all(entry, |caps: &Captures<'_>| {
         let name = &caps[3];
-        find_function(name, env).unwrap_or_else(|| {
+        find_function(name, env, in_type).unwrap_or_else(|| {
             info!("No function found for `{}()`", name);
             format!("`{}()`", name)
         })
@@ -94,10 +94,10 @@ fn replace_c_types(entry: &str, env: &Env, _in_type: &str) -> String {
         "FALSE" => "[`false`]".to_string(),
         "NULL" => "[`None`]".to_string(),
         symbol_name => match &caps[1] {
-            "%" => find_constant_or_variant(symbol_name, env),
+            "%" => find_constant_or_variant(symbol_name, env, in_type),
             "#" => {
                 let method_name = caps.get(3).map(|m| m.as_str().trim_start_matches('.'));
-                find_method_or_type(symbol_name, method_name, env)
+                find_method_or_type(symbol_name, method_name, env, in_type)
             }
             s => panic!("Unknown symbol prefix `{}`", s),
         }
@@ -108,13 +108,18 @@ fn replace_c_types(entry: &str, env: &Env, _in_type: &str) -> String {
         }),
     });
     let out = GDK_GTK.replace_all(&out, |caps: &Captures<'_>| {
-        find_type(&caps[2], env).unwrap_or_else(|| format!("`{}`", &caps[2]))
+        find_type(&caps[2], env, in_type).unwrap_or_else(|| format!("`{}`", &caps[2]))
     });
     let out = TAGS.replace_all(&out, "`$0`");
     SPACES.replace_all(&out, " ").into_owned()
 }
 
-fn find_method_or_type(type_: &str, method_name: Option<&str>, env: &Env) -> Option<String> {
+fn find_method_or_type(
+    type_: &str,
+    method_name: Option<&str>,
+    env: &Env,
+    in_type: Option<&TypeId>,
+) -> Option<String> {
     let symbols = env.symbols.borrow();
     if let Some(method) = method_name {
         let is_signal = method.starts_with("::");
@@ -128,8 +133,9 @@ fn find_method_or_type(type_: &str, method_name: Option<&str>, env: &Env) -> Opt
                 let sym = symbols.by_tid(obj_info.type_id).unwrap(); // we are sure the object exists
                 let (type_name, visible_type_name) = obj_info.generate_doc_link_info(fn_info);
                 let name = sym.full_rust_name().replace(&obj_info.name, &type_name);
+                let is_self = in_type.map(|t| t == &obj_info.type_id).unwrap_or(false);
 
-                Some(fn_info.doc_link(Some(&name), Some(&visible_type_name)))
+                Some(fn_info.doc_link(Some(&name), Some(&visible_type_name), is_self))
             } else if let Some((record_info, fn_info)) = env.analysis.find_record_by_function(
                 env,
                 |r| r.type_(&env.library).c_type == type_,
@@ -139,7 +145,8 @@ fn find_method_or_type(type_: &str, method_name: Option<&str>, env: &Env) -> Opt
                     .by_tid(record_info.type_id)
                     .unwrap()
                     .full_rust_name(); // we are sure the object exists
-                Some(fn_info.doc_link(Some(&sym_name), None))
+                let is_self = in_type.map(|t| t == &record_info.type_id).unwrap_or(false);
+                Some(fn_info.doc_link(Some(&sym_name), None, is_self))
             } else {
                 warn!("Method `{}` of type `{}` not found", method, type_);
                 None
@@ -160,11 +167,11 @@ fn find_method_or_type(type_: &str, method_name: Option<&str>, env: &Env) -> Opt
                 })
         }
     } else {
-        find_type(type_, env)
+        find_type(type_, env, in_type)
     }
 }
 
-fn find_constant_or_variant(symbol: &str, env: &Env) -> Option<String> {
+fn find_constant_or_variant(symbol: &str, env: &Env, in_type: Option<&TypeId>) -> Option<String> {
     let symbols = env.symbols.borrow();
     if let Some((flag_info, member_info)) = env.analysis.flags.iter().find_map(|f| {
         f.type_(&env.library)
@@ -173,11 +180,19 @@ fn find_constant_or_variant(symbol: &str, env: &Env) -> Option<String> {
             .find(|m| m.c_identifier == symbol && !m.status.ignored())
             .map(|m| (f, m))
     }) {
-        let sym = symbols.by_tid(flag_info.type_id).unwrap();
+        let sym = symbols.by_tid(flag_info.type_id).unwrap().full_rust_name();
+        let is_self = in_type.map(|t| t == &flag_info.type_id).unwrap_or(false);
+        let visible_sym = if is_self {
+            "Self".to_string()
+        } else {
+            sym.clone()
+        };
+
         Some(format!(
-            "[`{p}::{m}`][crate::{p}::{m}]",
+            "[`{p}::{m}`][crate::{s}::{m}]",
             m = nameutil::bitfield_member_name(&member_info.name),
-            p = sym.full_rust_name()
+            s = sym,
+            p = visible_sym
         ))
     } else if let Some((enum_info, member_info)) = env.analysis.enumerations.iter().find_map(|e| {
         e.type_(&env.library)
@@ -186,11 +201,19 @@ fn find_constant_or_variant(symbol: &str, env: &Env) -> Option<String> {
             .find(|m| m.c_identifier == symbol && !m.status.ignored())
             .map(|m| (e, m))
     }) {
-        let sym = symbols.by_tid(enum_info.type_id).unwrap();
+        let sym = symbols.by_tid(enum_info.type_id).unwrap().full_rust_name();
+        let is_self = in_type.map(|t| t == &enum_info.type_id).unwrap_or(false);
+
+        let visible_sym = if is_self {
+            "Self".to_string()
+        } else {
+            sym.clone()
+        };
         Some(format!(
-            "[`{e}::{m}`][crate::{e}::{m}]",
+            "[`{e}::{m}`][crate::{s}::{m}]",
             m = nameutil::enum_member_name(&member_info.name),
-            e = sym.full_rust_name()
+            s = sym,
+            e = visible_sym
         ))
     } else if let Some(const_info) = env
         .analysis
@@ -215,7 +238,7 @@ const IGNORED_C_TYPES: [&str; 6] = [
     "gchararray",
     "GList",
 ];
-fn find_type(type_: &str, env: &Env) -> Option<String> {
+fn find_type(type_: &str, env: &Env, in_type: Option<&TypeId>) -> Option<String> {
     if IGNORED_C_TYPES.contains(&type_) {
         return None;
     }
@@ -252,7 +275,7 @@ fn find_type(type_: &str, env: &Env) -> Option<String> {
 
     symbol.map_or_else(
         || {
-            find_constant_or_variant(type_, env).map(|i| {
+            find_constant_or_variant(type_, env, in_type).map(|i| {
                 warn!(
                     "`{}` was found to be a constant or enum-variant (`%`) but is instead prefixed with (`#`)",
                     type_
@@ -275,7 +298,7 @@ const IGNORE_C_WARNING_FUNCS: [&str; 6] = [
     "g_strfreev",
     "printf",
 ];
-fn find_function(name: &str, env: &Env) -> Option<String> {
+fn find_function(name: &str, env: &Env, in_type: Option<&TypeId>) -> Option<String> {
     let symbols = env.symbols.borrow();
     // if we can find the function in an object
     if let Some((obj_info, fn_info)) =
@@ -286,7 +309,9 @@ fn find_function(name: &str, env: &Env) -> Option<String> {
         let (type_name, visible_type_name) = obj_info.generate_doc_link_info(fn_info);
 
         let name = sym.full_rust_name().replace(&obj_info.name, &type_name);
-        Some(fn_info.doc_link(Some(&name), Some(&visible_type_name)))
+        let is_self = in_type.map(|t| t == &obj_info.type_id).unwrap_or(false);
+
+        Some(fn_info.doc_link(Some(&name), Some(&visible_type_name), is_self))
     // or in a record
     } else if let Some((record_info, fn_info)) =
         env.analysis
@@ -296,13 +321,15 @@ fn find_function(name: &str, env: &Env) -> Option<String> {
             .by_tid(record_info.type_id)
             .unwrap()
             .full_rust_name(); // we are sure the object exists
-        Some(fn_info.doc_link(Some(&sym_name), None))
+        let is_self = in_type.map(|t| t == &record_info.type_id).unwrap_or(false);
+
+        Some(fn_info.doc_link(Some(&sym_name), None, is_self))
     // or as a global function
     } else if let Some(fn_info) = env
         .analysis
         .find_global_function(env, |f| f.glib_name == name)
     {
-        Some(fn_info.doc_link(None, None))
+        Some(fn_info.doc_link(None, None, false))
     } else {
         if !IGNORE_C_WARNING_FUNCS.contains(&name) {
             warn!("Function `{}` not found", name);

--- a/src/codegen/doc/format.rs
+++ b/src/codegen/doc/format.rs
@@ -212,7 +212,7 @@ fn find_type(name: &str, env: &Env) -> String {
     };
     symbol
         .map(|sym| format!("[`{name}`][crate::{name}]", name = sym.full_rust_name()))
-        .unwrap_or_else(|| name.to_string())
+        .unwrap_or_else(|| format!("`{}`", name))
 }
 
 /// Find a function in all the possible items, if not found return the original name surrounded with backsticks

--- a/src/codegen/doc/format.rs
+++ b/src/codegen/doc/format.rs
@@ -89,8 +89,12 @@ fn replace_c_types(entry: &str, env: &Env, in_type: &str) -> String {
             format!("{}", symbol_name)
         } else {
             // would be equal to "%"
-            let symbol_name = &caps[2];
-            find_constant_or_variant(symbol_name, env)
+            match &caps[2] {
+                "TRUE" => "[`true`]".to_string(),
+                "FALSE" => "[`false`]".to_string(),
+                "NULL" => "[`None`]".to_string(),
+                symbol_name => find_constant_or_variant(symbol_name, env),
+            }
         }
     });
     let out = GDK_GTK.replace_all(&out, |caps: &Captures<'_>| find_struct(&caps[2], env));

--- a/src/codegen/doc/format.rs
+++ b/src/codegen/doc/format.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::manual_map)]
 use super::{gi_docgen, LocationInObject};
 use crate::{
     analysis::functions::Info,

--- a/src/codegen/doc/format.rs
+++ b/src/codegen/doc/format.rs
@@ -70,7 +70,8 @@ static FUNCTION: Lazy<Regex> =
 // **note**
 // The optional . at the end is to make the regex more relaxed for some weird broken cases on gtk3's docs
 // it doesn't hurt other docs so please don't drop it
-static GDK_GTK: Lazy<Regex> = Lazy::new(|| Regex::new(r"`(G[dt]k[A-Z]\w+\b)(\.)?`").unwrap());
+static GDK_GTK: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"`(G[dts]k|Pango[A-Z]\w+\b)(\.)?`").unwrap());
 static TAGS: Lazy<Regex> = Lazy::new(|| Regex::new(r"<[\w/-]+>").unwrap());
 static SPACES: Lazy<Regex> = Lazy::new(|| Regex::new(r"[ ]{2,}").unwrap());
 

--- a/src/codegen/doc/format.rs
+++ b/src/codegen/doc/format.rs
@@ -1,5 +1,6 @@
 use super::gi_docgen;
 use crate::{nameutil, Env};
+use log::{info, warn};
 use once_cell::sync::Lazy;
 use regex::{Captures, Regex};
 
@@ -82,7 +83,10 @@ static SPACES: Lazy<Regex> = Lazy::new(|| Regex::new(r"[ ]{2,}").unwrap());
 fn replace_c_types(entry: &str, env: &Env, _in_type: &str) -> String {
     let out = FUNCTION.replace_all(entry, |caps: &Captures<'_>| {
         let name = &caps[3];
-        find_function(name, env)
+        find_function(name, env).unwrap_or_else(|| {
+            info!("Function not found, falling back to symbol name `{}`", name);
+            format!("`{}`", name)
+        })
     });
 
     let out = SYMBOL.replace_all(&out, |caps: &Captures<'_>| {
@@ -96,58 +100,58 @@ fn replace_c_types(entry: &str, env: &Env, _in_type: &str) -> String {
                 } else {
                     let method_name = caps.get(3).map(|m| m.as_str().trim_start_matches('.'));
                     // would be #
-                    find_type_by_name(symbol_name, method_name, env)
+                    find_method_or_type(symbol_name, method_name, env)
                 }
+                .unwrap_or_else(|| {
+                    info!("Symbol not found: `{}`", symbol_name);
+
+                    format!("`{}`", symbol_name)
+                })
             }
         }
     });
-    let out = GDK_GTK.replace_all(&out, |caps: &Captures<'_>| find_type(&caps[2], env));
+    let out = GDK_GTK.replace_all(&out, |caps: &Captures<'_>| {
+        find_type(&caps[2], env).unwrap_or_else(|| format!("`{}`", &caps[2]))
+    });
     let out = TAGS.replace_all(&out, "`$0`");
     SPACES.replace_all(&out, " ").into_owned()
 }
 
-fn find_type_by_name(symbol: &str, method_name: Option<&str>, env: &Env) -> String {
+fn find_method_or_type(type_: &str, method_name: Option<&str>, env: &Env) -> Option<String> {
     let symbols = env.symbols.borrow();
     if let Some(method) = method_name {
         if let Some((obj_info, fn_info)) = env.analysis.find_object_by_function(
             env,
-            |o| o.full_name == symbol,
+            |o| o.full_name == type_,
             |f| f.name == method,
         ) {
             let sym = symbols.by_tid(obj_info.type_id).unwrap(); // we are sure the object exists
             let (type_name, visible_type_name) = obj_info.generate_doc_link_info(fn_info);
             let name = sym.full_rust_name().replace(&obj_info.name, &type_name);
 
-            fn_info.doc_link(Some(&name), Some(&visible_type_name))
+            Some(fn_info.doc_link(Some(&name), Some(&visible_type_name)))
         } else if let Some((record_info, fn_info)) = env.analysis.find_record_by_function(
             env,
-            |r| r.type_(&env.library).c_type == symbol,
+            |r| r.type_(&env.library).c_type == type_,
             |f| f.name == method,
         ) {
             let sym_name = symbols
                 .by_tid(record_info.type_id)
                 .unwrap()
                 .full_rust_name(); // we are sure the object exists
-            fn_info.doc_link(Some(&sym_name), None)
+            Some(fn_info.doc_link(Some(&sym_name), None))
         } else {
-            format!("`{}::{}`", symbol, method)
+            warn!("Method `{}` of type `{}` was not found", method, type_);
+            None
         }
     } else {
-        find_type(symbol, env)
+        find_type(type_, env)
     }
 }
 
-fn find_constant_or_variant(symbol: &str, env: &Env) -> String {
+fn find_constant_or_variant(symbol: &str, env: &Env) -> Option<String> {
     let symbols = env.symbols.borrow();
-    if let Some(const_info) = env
-        .analysis
-        .constants
-        .iter()
-        .find(|c| c.glib_name == symbol)
-    {
-        // for whatever reason constants are not part of the symbols list
-        format!("[`{n}`][crate::{n}]", n = const_info.name)
-    } else if let Some((flag_info, member_info)) = env.analysis.flags.iter().find_map(|f| {
+    if let Some((flag_info, member_info)) = env.analysis.flags.iter().find_map(|f| {
         f.type_(&env.library)
             .members
             .iter()
@@ -155,11 +159,11 @@ fn find_constant_or_variant(symbol: &str, env: &Env) -> String {
             .map(|m| (f, m))
     }) {
         let sym = symbols.by_tid(flag_info.type_id).unwrap();
-        format!(
+        Some(format!(
             "[`{p}::{m}`][crate::{p}::{m}]",
             m = nameutil::bitfield_member_name(&member_info.name),
             p = sym.full_rust_name()
-        )
+        ))
     } else if let Some((enum_info, member_info)) = env.analysis.enumerations.iter().find_map(|e| {
         e.type_(&env.library)
             .members
@@ -168,54 +172,98 @@ fn find_constant_or_variant(symbol: &str, env: &Env) -> String {
             .map(|m| (e, m))
     }) {
         let sym = symbols.by_tid(enum_info.type_id).unwrap();
-        format!(
+        Some(format!(
             "[`{e}::{m}`][crate::{e}::{m}]",
             m = nameutil::enum_member_name(&member_info.name),
             e = sym.full_rust_name()
-        )
+        ))
+    } else if let Some(const_info) = env
+        .analysis
+        .constants
+        .iter()
+        .find(|c| c.glib_name == symbol)
+    {
+        // for whatever reason constants are not part of the symbols list
+        Some(format!("[`{n}`][crate::{n}]", n = const_info.name))
     } else {
-        format!("`{}`", symbol)
+        warn!(
+            "Constant/Flag variant/Enum member `{}` was not found",
+            symbol
+        );
+        None
     }
 }
 
 /// either an object/interface, record, enum or a flag
-fn find_type(name: &str, env: &Env) -> String {
+const IGNORED_C_TYPES: [&str; 6] = [
+    "gconstpointer",
+    "guint16",
+    "guint",
+    "gunicode",
+    "gchararray",
+    "GList",
+];
+fn find_type(type_: &str, env: &Env) -> Option<String> {
+    if IGNORED_C_TYPES.contains(&type_) {
+        return None;
+    }
+
     let symbols = env.symbols.borrow();
 
-    let symbol = if let Some(obj) = env.analysis.objects.values().find(|o| o.c_type == name) {
+    let symbol = if let Some(obj) = env.analysis.objects.values().find(|o| o.c_type == type_) {
         symbols.by_tid(obj.type_id)
     } else if let Some(record) = env
         .analysis
         .records
         .values()
-        .find(|r| r.type_(&env.library).c_type == name)
+        .find(|r| r.type_(&env.library).c_type == type_)
     {
         symbols.by_tid(record.type_id)
     } else if let Some(enum_) = env
         .analysis
         .enumerations
         .iter()
-        .find(|e| e.type_(&env.library).c_type == name)
+        .find(|e| e.type_(&env.library).c_type == type_)
     {
         symbols.by_tid(enum_.type_id)
     } else if let Some(flag) = env
         .analysis
         .flags
         .iter()
-        .find(|f| f.type_(&env.library).c_type == name)
+        .find(|f| f.type_(&env.library).c_type == type_)
     {
         symbols.by_tid(flag.type_id)
     } else {
+        warn!("Object/Interface/Record not found: `{}`", type_);
         None
     };
-    symbol
-        .map(|sym| format!("[`{n}`][crate::{n}]", n = sym.full_rust_name()))
-        .unwrap_or_else(|| format!("`{}`", name))
+
+    symbol.map_or_else(
+        || {
+            find_constant_or_variant(type_, env).map(|i| {
+                warn!(
+                    "`{}` should be a type (`#`) but was parsed as constant or variant (`%`)",
+                    type_
+                );
+                i
+            })
+        },
+        |sym| Some(format!("[`{n}`][crate::{n}]", n = sym.full_rust_name())),
+    )
 }
 
 /// Find a function in all the possible items, if not found return the original name surrounded with backsticks
 /// A function can either be a struct/interface/record method, a global function or maybe a virtual function
-fn find_function(name: &str, env: &Env) -> String {
+
+const IGNORE_C_WARNING_FUNCS: [&str; 6] = [
+    "g_object_unref",
+    "g_object_ref",
+    "g_free",
+    "g_list_free",
+    "g_strfreev",
+    "printf",
+];
+fn find_function(name: &str, env: &Env) -> Option<String> {
     let symbols = env.symbols.borrow();
     // if we can find the function in an object
     if let Some((obj_info, fn_info)) =
@@ -226,7 +274,7 @@ fn find_function(name: &str, env: &Env) -> String {
         let (type_name, visible_type_name) = obj_info.generate_doc_link_info(fn_info);
 
         let name = sym.full_rust_name().replace(&obj_info.name, &type_name);
-        fn_info.doc_link(Some(&name), Some(&visible_type_name))
+        Some(fn_info.doc_link(Some(&name), Some(&visible_type_name)))
     // or in a record
     } else if let Some((record_info, fn_info)) =
         env.analysis
@@ -236,14 +284,17 @@ fn find_function(name: &str, env: &Env) -> String {
             .by_tid(record_info.type_id)
             .unwrap()
             .full_rust_name(); // we are sure the object exists
-        fn_info.doc_link(Some(&sym_name), None)
+        Some(fn_info.doc_link(Some(&sym_name), None))
     // or as a global function
     } else if let Some(fn_info) = env
         .analysis
         .find_global_function(env, |f| f.glib_name == name)
     {
-        fn_info.doc_link(None, None)
+        Some(fn_info.doc_link(None, None))
     } else {
-        format!("`{}()`", name)
+        if !IGNORE_C_WARNING_FUNCS.contains(&name) {
+            warn!("Function not found found: `{}`", name);
+        }
+        None
     }
 }

--- a/src/codegen/doc/format.rs
+++ b/src/codegen/doc/format.rs
@@ -254,6 +254,7 @@ fn find_method_or_function_by_ctype(
         |f| f.glib_name == name,
         |o| c_type.map_or(true, |t| o.c_type == t),
         |r| c_type.map_or(true, |t| r.type_(&env.library).c_type == t),
+        c_type.map_or(false, |t| t.ends_with("Class")),
     )
 }
 
@@ -283,7 +284,13 @@ pub(crate) fn find_method_or_function<
     search_fn: F,
     search_obj: G,
     search_record: H,
+    is_class_method: bool,
 ) -> Option<String> {
+    if is_class_method {
+        info!("Class methods are not supported yet `{}`", name);
+        return None;
+    }
+
     // if we can find the function in an object
     if let Some((obj_info, fn_info)) = env
         .analysis

--- a/src/codegen/doc/format.rs
+++ b/src/codegen/doc/format.rs
@@ -64,6 +64,8 @@ fn format(input: &str, env: &Env, in_type: &str) -> String {
 }
 
 static SYMBOL: Lazy<Regex> = Lazy::new(|| Regex::new(r"([#%])(\w+\b)([:.]+[\w-]+\b)?").unwrap());
+static PARAM_SYMBOL: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"([@])(\w+\b)([:.]+[\w-]+\b)?").unwrap());
 static FUNCTION: Lazy<Regex> =
     Lazy::new(|| Regex::new(r"([@#%])?(\w+\b[:.]+)?(\b[a-z0-9_]+)\(\)").unwrap());
 // **note**
@@ -97,6 +99,7 @@ fn replace_c_types(entry: &str, env: &Env, in_type: &str) -> String {
         }
     });
     let out = GDK_GTK.replace_all(&out, |caps: &Captures<'_>| find_struct(&caps[2], env));
+    let out = PARAM_SYMBOL.replace_all(&out, |caps: &Captures<'_>| format!("`{}`", &caps[2]));
     let out = TAGS.replace_all(&out, "`$0`");
     SPACES.replace_all(&out, " ").into_owned()
 }

--- a/src/codegen/doc/format.rs
+++ b/src/codegen/doc/format.rs
@@ -1,3 +1,4 @@
+use super::gi_docgen;
 use crate::{analysis::symbols, Env};
 use once_cell::sync::Lazy;
 use regex::{Captures, Match, Regex};
@@ -58,7 +59,10 @@ fn format(mut input: &str, env: &Env, in_type: &str) -> String {
     let mut ret = String::with_capacity(input.len());
     loop {
         let (before, after) = try_split(input, "`");
-        ret.push_str(&replace_c_types(before, env, in_type));
+        // We run gi_docgen first because it's super picky about the types it replaces
+        let no_c_types_re = gi_docgen::replace_c_types(before, env, in_type);
+        ret.push_str(&replace_c_types(&no_c_types_re, env, in_type));
+
         if let Some(after) = after {
             ret.push('`');
             let (before, after) = try_split(after, "`");

--- a/src/codegen/doc/format.rs
+++ b/src/codegen/doc/format.rs
@@ -151,7 +151,7 @@ fn find_constant_or_variant(symbol: &str, env: &Env) -> String {
         f.type_(&env.library)
             .members
             .iter()
-            .find(|m| m.c_identifier == symbol)
+            .find(|m| m.c_identifier == symbol && !m.status.ignored())
             .map(|m| (f, m))
     }) {
         let sym = symbols.by_tid(flag_info.type_id).unwrap();
@@ -164,7 +164,7 @@ fn find_constant_or_variant(symbol: &str, env: &Env) -> String {
         e.type_(&env.library)
             .members
             .iter()
-            .find(|m| m.c_identifier == symbol)
+            .find(|m| m.c_identifier == symbol && !m.status.ignored())
             .map(|m| (e, m))
     }) {
         let sym = symbols.by_tid(enum_info.type_id).unwrap();

--- a/src/codegen/doc/format.rs
+++ b/src/codegen/doc/format.rs
@@ -399,18 +399,12 @@ pub(crate) fn gen_member_doc_link(
     let symbols = env.symbols.borrow();
     let sym = symbols.by_tid(type_id).unwrap().full_rust_name();
     let is_self = in_type == Some(&type_id);
-    let visible_sym = if is_self {
-        "Self".to_string()
-    } else {
-        sym.clone()
-    };
 
-    format!(
-        "[`{p}::{m}`][crate::{s}::{m}]",
-        m = member_name,
-        s = sym,
-        p = visible_sym
-    )
+    if is_self {
+        format!("[`{m}`][Self::{m}]", m = member_name)
+    } else {
+        format!("[`{s}::{m}`][crate::{s}::{m}]", s = sym, m = member_name)
+    }
 }
 
 pub(crate) fn gen_const_doc_link(const_info: &crate::analysis::constants::Info) -> String {

--- a/src/codegen/doc/format.rs
+++ b/src/codegen/doc/format.rs
@@ -158,6 +158,7 @@ fn find_function(name: &str, env: &Env) -> String {
             .functions
             .iter()
             .filter(|fn_info| fn_info.status != GStatus::Ignore)
+            .filter(|fn_info| !fn_info.is_special() && !fn_info.is_async_finish(env))
             .find(|fn_info| fn_info.glib_name == name)
             .map(|fn_info| (obj_info, fn_info))
     });
@@ -166,6 +167,7 @@ fn find_function(name: &str, env: &Env) -> String {
             .functions
             .iter()
             .filter(|fn_info| fn_info.status != GStatus::Ignore)
+            .filter(|fn_info| !fn_info.is_special() && !fn_info.is_async_finish(env))
             .find(|fn_info| fn_info.glib_name == name)
             .map(|fn_info| (record_info, fn_info))
     });
@@ -173,6 +175,7 @@ fn find_function(name: &str, env: &Env) -> String {
         info.functions
             .iter()
             .filter(|fn_info| fn_info.status != GStatus::Ignore)
+            .filter(|fn_info| !fn_info.is_special() && !fn_info.is_async_finish(env))
             .find(|fn_info| fn_info.glib_name == name)
     });
 

--- a/src/codegen/doc/format.rs
+++ b/src/codegen/doc/format.rs
@@ -1,5 +1,5 @@
 use super::gi_docgen;
-use crate::{config::gobjects::GStatus, library::FunctionKind, nameutil, Env};
+use crate::{nameutil, Env};
 use once_cell::sync::Lazy;
 use regex::{Captures, Regex};
 
@@ -107,63 +107,26 @@ fn replace_c_types(entry: &str, env: &Env, _in_type: &str) -> String {
 fn find_type_by_name(symbol: &str, method_name: Option<&str>, env: &Env) -> String {
     let symbols = env.symbols.borrow();
     if let Some(method) = method_name {
-        let is_obj_func = env
-            .analysis
-            .objects
-            .iter()
-            .find(|(_, o)| o.full_name == symbol)
-            .and_then(|(_, obj_info)| {
-                obj_info
-                    .functions
-                    .iter()
-                    .filter(|fn_info| fn_info.status != GStatus::Ignore)
-                    .filter(|fn_info| !fn_info.is_special() && !fn_info.is_async_finish(env))
-                    .find(|fn_info| fn_info.name == method)
-                    .map(|fn_info| (obj_info, fn_info))
-            });
-        let is_record_func = env
-            .analysis
-            .records
-            .iter()
-            .find(|(_, r)| r.type_(&env.library).c_type == symbol)
-            .and_then(|(_, record_info)| {
-                record_info
-                    .functions
-                    .iter()
-                    .filter(|fn_info| fn_info.status != GStatus::Ignore)
-                    .filter(|fn_info| !fn_info.is_special() && !fn_info.is_async_finish(env))
-                    .find(|fn_info| fn_info.glib_name == method)
-                    .map(|fn_info| (record_info, fn_info))
-            });
-        if let Some((obj_info, fn_info)) = is_obj_func {
+        if let Some((obj_info, fn_info)) = env.analysis.find_object_by_function(
+            env,
+            |o| o.full_name == symbol,
+            |f| f.name == method,
+        ) {
             let sym = symbols.by_tid(obj_info.type_id).unwrap(); // we are sure the object exists
-            let (type_name, visible_type_name) = if obj_info.final_type
-                || fn_info.kind == FunctionKind::Constructor
-                || fn_info.kind == FunctionKind::Function
-            {
-                (obj_info.name.clone(), obj_info.name.clone())
-            } else {
-                let type_name = if fn_info.status == GStatus::Generate {
-                    obj_info.trait_name.clone()
-                } else {
-                    format!("{}Manual", obj_info.trait_name)
-                };
-                (format!("prelude::{}", type_name), type_name)
-            };
+            let (type_name, visible_type_name) = obj_info.generate_doc_link_info(fn_info);
             let name = sym.full_rust_name().replace(&obj_info.name, &type_name);
-            format!(
-                "[`{visible_type_name}::{fn_name}`][crate::{name}::{fn_name}]",
-                name = name,
-                visible_type_name = visible_type_name,
-                fn_name = fn_info.codegen_name()
-            )
-        } else if let Some((record_info, fn_info)) = is_record_func {
-            let sym = symbols.by_tid(record_info.type_id).unwrap(); // we are sure the object exists
-            format!(
-                "[`{name}::{fn_name}`][crate::{name}::{fn_name}]",
-                name = sym.full_rust_name(),
-                fn_name = fn_info.codegen_name()
-            )
+
+            fn_info.doc_link(Some(&name), Some(&visible_type_name))
+        } else if let Some((record_info, fn_info)) = env.analysis.find_record_by_function(
+            env,
+            |r| r.type_(&env.library).c_type == symbol,
+            |f| f.name == method,
+        ) {
+            let sym_name = symbols
+                .by_tid(record_info.type_id)
+                .unwrap()
+                .full_rust_name(); // we are sure the object exists
+            fn_info.doc_link(Some(&sym_name), None)
         } else {
             format!("`{}::{}`", symbol, method)
         }
@@ -218,20 +181,13 @@ fn find_constant_or_variant(symbol: &str, env: &Env) -> String {
 fn find_struct(name: &str, env: &Env) -> String {
     let symbols = env.symbols.borrow();
 
-    let symbol = if let Some(obj) = env
-        .analysis
-        .objects
-        .iter()
-        .find(|(_, o)| o.c_type == name)
-        .map(|(_, o)| o)
-    {
+    let symbol = if let Some(obj) = env.analysis.objects.values().find(|o| o.c_type == name) {
         symbols.by_tid(obj.type_id)
     } else if let Some(record) = env
         .analysis
         .records
-        .iter()
-        .find(|(_, r)| r.type_(&env.library).c_type == name)
-        .map(|(_, r)| r)
+        .values()
+        .find(|r| r.type_(&env.library).c_type == name)
     {
         symbols.by_tid(record.type_id)
     } else {
@@ -246,62 +202,31 @@ fn find_struct(name: &str, env: &Env) -> String {
 /// A function can either be a struct/interface/record method, a global function or maybe a virtual function
 fn find_function(name: &str, env: &Env) -> String {
     let symbols = env.symbols.borrow();
-    let is_obj_func = env.analysis.objects.iter().find_map(|(_, obj_info)| {
-        obj_info
-            .functions
-            .iter()
-            .filter(|fn_info| fn_info.status != GStatus::Ignore)
-            .filter(|fn_info| !fn_info.is_special() && !fn_info.is_async_finish(env))
-            .find(|fn_info| fn_info.glib_name == name)
-            .map(|fn_info| (obj_info, fn_info))
-    });
-    let is_record_func = env.analysis.records.iter().find_map(|(_, record_info)| {
-        record_info
-            .functions
-            .iter()
-            .filter(|fn_info| fn_info.status != GStatus::Ignore)
-            .filter(|fn_info| !fn_info.is_special() && !fn_info.is_async_finish(env))
-            .find(|fn_info| fn_info.glib_name == name)
-            .map(|fn_info| (record_info, fn_info))
-    });
-    let is_globa_func = env.analysis.global_functions.as_ref().and_then(|info| {
-        info.functions
-            .iter()
-            .filter(|fn_info| fn_info.status != GStatus::Ignore)
-            .filter(|fn_info| !fn_info.is_special() && !fn_info.is_async_finish(env))
-            .find(|fn_info| fn_info.glib_name == name)
-    });
-
-    if let Some((obj_info, fn_info)) = is_obj_func {
+    // if we can find the function in an object
+    if let Some((obj_info, fn_info)) =
+        env.analysis
+            .find_object_by_function(env, |_| true, |f| f.glib_name == name)
+    {
         let sym = symbols.by_tid(obj_info.type_id).unwrap(); // we are sure the object exists
-        let (type_name, visible_type_name) = if obj_info.final_type
-            || fn_info.kind == FunctionKind::Constructor
-            || fn_info.kind == FunctionKind::Function
-        {
-            (obj_info.name.clone(), obj_info.name.clone())
-        } else {
-            let type_name = if fn_info.status == GStatus::Generate {
-                obj_info.trait_name.clone()
-            } else {
-                format!("{}Manual", obj_info.trait_name)
-            };
-            (format!("prelude::{}", type_name), type_name)
-        };
+        let (type_name, visible_type_name) = obj_info.generate_doc_link_info(fn_info);
+
         let name = sym.full_rust_name().replace(&obj_info.name, &type_name);
-        format!(
-            "[`{visible_type_name}::{fn_name}()`][crate::{name}::{fn_name}()]",
-            name = name,
-            visible_type_name = visible_type_name,
-            fn_name = fn_info.codegen_name()
-        )
-    } else if let Some((record_info, fn_info)) = is_record_func {
-        let sym = symbols.by_tid(record_info.type_id).unwrap(); // we are sure the object exists
-        format!(
-            "[`{name}::{fn_name}()`][crate::{name}::{fn_name}()]",
-            name = sym.full_rust_name(),
-            fn_name = fn_info.codegen_name()
-        )
-    } else if let Some(fn_info) = is_globa_func {
+        fn_info.doc_link(Some(&name), Some(&visible_type_name))
+    // or in a record
+    } else if let Some((record_info, fn_info)) =
+        env.analysis
+            .find_record_by_function(env, |_| true, |f| f.glib_name == name)
+    {
+        let sym_name = symbols
+            .by_tid(record_info.type_id)
+            .unwrap()
+            .full_rust_name(); // we are sure the object exists
+        fn_info.doc_link(Some(&sym_name), None)
+    // or as a global function
+    } else if let Some(fn_info) = env
+        .analysis
+        .find_global_function(env, |f| f.glib_name == name)
+    {
         format!(
             "[`{fn_name}()`][crate::{fn_name}()]",
             fn_name = fn_info.codegen_name()

--- a/src/codegen/doc/format.rs
+++ b/src/codegen/doc/format.rs
@@ -181,17 +181,19 @@ fn find_function(name: &str, env: &Env) -> String {
 
     if let Some((obj_info, fn_info)) = is_obj_func {
         let sym = symbols.by_tid(obj_info.type_id).unwrap(); // we are sure the object exists
-        let (type_name, visible_type_name) =
-            if obj_info.final_type || fn_info.kind == FunctionKind::Constructor {
-                (obj_info.name.clone(), obj_info.name.clone())
+        let (type_name, visible_type_name) = if obj_info.final_type
+            || fn_info.kind == FunctionKind::Constructor
+            || fn_info.kind == FunctionKind::Function
+        {
+            (obj_info.name.clone(), obj_info.name.clone())
+        } else {
+            let type_name = if fn_info.status == GStatus::Generate {
+                obj_info.trait_name.clone()
             } else {
-                let type_name = if fn_info.status == GStatus::Generate {
-                    obj_info.trait_name.clone()
-                } else {
-                    format!("{}Manual", obj_info.trait_name)
-                };
-                (format!("prelude::{}", type_name), type_name)
+                format!("{}Manual", obj_info.trait_name)
             };
+            (format!("prelude::{}", type_name), type_name)
+        };
         let name = sym.full_rust_name().replace(&obj_info.name, &type_name);
         format!(
             "[{visible_type_name}::{fn_name}](crate::{name}::{fn_name})",

--- a/src/codegen/doc/format.rs
+++ b/src/codegen/doc/format.rs
@@ -73,8 +73,8 @@ fn get_language<'a>(entry: &'a str, out: &mut String) -> &'a str {
 fn format(input: &str, env: &Env, in_type: Option<&TypeId>) -> String {
     let mut ret = String::with_capacity(input.len());
     // We run gi_docgen first because it's super picky about the types it replaces
-    let out = replace_c_types(input, env, in_type);
-    let out = gi_docgen::replace_c_types(&out, env, in_type);
+    let out = gi_docgen::replace_c_types(input, env, in_type);
+    let out = replace_c_types(&out, env, in_type);
     // this has to be done after gi_docgen replaced the various types it knows as it uses `@` in it's linking format
     let out = PARAM_SYMBOL.replace_all(&out, |caps: &Captures<'_>| format!("`{}`", &caps[2]));
     ret.push_str(&out);

--- a/src/codegen/doc/gi_docgen.rs
+++ b/src/codegen/doc/gi_docgen.rs
@@ -1,0 +1,798 @@
+use crate::{config::gobjects::GStatus, nameutil, Env};
+use once_cell::sync::Lazy;
+use regex::{Captures, Regex};
+use std::{
+    fmt::{self, Display, Formatter},
+    str::FromStr,
+};
+
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum GiDocgenError {
+    InvalidLinkType(String),
+    BrokenLinkType(String),
+    InvalidLink,
+}
+
+impl Display for GiDocgenError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidLinkType(e) => f.write_str(&format!("Invalid link type \"{}\"", e)),
+            Self::BrokenLinkType(e) => {
+                f.write_str(&format!("Broken link syntax for type \"{}\"", e))
+            }
+            Self::InvalidLink => f.write_str("Invalid link syntax"),
+        }
+    }
+}
+
+impl std::error::Error for GiDocgenError {}
+
+/// Convert a "Namespace.Type" to (Option<Namespace>, Type)
+fn namespace_type_from_details(
+    link_details: &str,
+    link_type: &str,
+) -> Result<(Option<String>, String), GiDocgenError> {
+    let res: Vec<&str> = link_details.split('.').collect();
+    let len = res.len();
+    if len == 1 {
+        Ok((None, res[0].to_string()))
+    } else if len == 2 {
+        if res[1].is_empty() {
+            Err(GiDocgenError::BrokenLinkType(link_type.to_string()))
+        } else {
+            Ok((Some(res[0].to_string()), res[1].to_string()))
+        }
+    } else {
+        Err(GiDocgenError::BrokenLinkType(link_type.to_string()))
+    }
+}
+
+/// Convert a "Namespace.Type.method_name" to (Option<Namespace>, Option<Type>, name)
+/// Type is only optional for global functions and the order can be modified the `is_global_func` parameters
+fn namespace_type_method_from_details(
+    link_details: &str,
+    link_type: &str,
+    is_global_func: bool,
+) -> Result<(Option<String>, Option<String>, String), GiDocgenError> {
+    let res: Vec<&str> = link_details.split('.').collect();
+    let len = res.len();
+    if len == 1 {
+        Ok((None, None, res[0].to_string()))
+    } else if len == 2 {
+        if res[1].is_empty() {
+            Err(GiDocgenError::BrokenLinkType(link_type.to_string()))
+        } else if is_global_func {
+            Ok((Some(res[0].to_string()), None, res[1].to_string()))
+        } else {
+            Ok((None, Some(res[0].to_string()), res[1].to_string()))
+        }
+    } else if len == 3 {
+        if res[2].is_empty() {
+            Err(GiDocgenError::BrokenLinkType(link_type.to_string()))
+        } else {
+            Ok((
+                Some(res[0].to_string()),
+                Some(res[1].to_string()),
+                res[2].to_string(),
+            ))
+        }
+    } else {
+        Err(GiDocgenError::BrokenLinkType(link_type.to_string()))
+    }
+}
+
+static GI_DOCGEN_SYMBOLS: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"\[(callback|id|alias|class|const|ctor|enum|error|flags|func|iface|method|property|signal|struct|vfunc)[@](\w+\b)([:.]+[\w-]+\b)?([:.]+[\w-]+\b)?\]?").unwrap()
+});
+
+pub(crate) fn replace_c_types(entry: &str, env: &Env, _in_type: &str) -> String {
+    GI_DOCGEN_SYMBOLS
+        .replace_all(entry, |caps: &Captures<'_>| {
+            if let Ok(gi_type) = GiDocgen::from_str(&caps[0]) {
+                gi_type.rust_link(env)
+            } else {
+                format!("`{}`", entry.trim_start_matches('[').trim_end_matches(']'))
+            }
+        })
+        .to_string()
+}
+
+/// A representation of the various ways to link items using GI-docgen
+///
+/// See <https://gnome.pages.gitlab.gnome.org/gi-docgen/linking.html> for details.
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum GiDocgen {
+    // C-identifier
+    Id(String),
+    // Alias to another type
+    Alias(String),
+    // Object Class
+    Class {
+        namespace: Option<String>,
+        type_: String,
+    },
+    Const {
+        namespace: Option<String>,
+        type_: String,
+    },
+    Constructor {
+        namespace: Option<String>,
+        type_: String,
+        name: String,
+    },
+    Callback {
+        namespace: Option<String>,
+        name: String,
+    },
+    Enum {
+        namespace: Option<String>,
+        type_: String,
+    },
+    Error {
+        namespace: Option<String>,
+        type_: String,
+    },
+    Flag {
+        namespace: Option<String>,
+        type_: String,
+    },
+    Func {
+        namespace: Option<String>,
+        type_: Option<String>,
+        name: String,
+    },
+    Interface {
+        namespace: Option<String>,
+        type_: String,
+    },
+    Method {
+        namespace: Option<String>,
+        type_: String,
+        name: String,
+        is_instance: bool, // Whether `type_` ends with Class
+    },
+    Property {
+        namespace: Option<String>,
+        type_: String,
+        name: String,
+    },
+    Signal {
+        namespace: Option<String>,
+        type_: String,
+        name: String,
+    },
+    Struct {
+        namespace: Option<String>,
+        type_: String,
+    },
+    VFunc {
+        namespace: Option<String>,
+        type_: String,
+        name: String,
+    },
+}
+
+fn ns_type_to_doc(namespace: &Option<String>, type_: &str) -> String {
+    if let Some(ns) = namespace {
+        format!("{}::{}", ns, type_)
+    } else {
+        type_.to_string()
+    }
+}
+
+impl GiDocgen {
+    pub fn rust_link(&self, env: &Env) -> String {
+        let symbols = env.symbols.borrow();
+
+        match self {
+            GiDocgen::Enum { namespace, type_ } | GiDocgen::Error { namespace, type_ } => {
+                if let Some(enum_info) = env.analysis.enumerations.iter().find(|e| &e.name == type_)
+                {
+                    let sym = symbols.by_tid(enum_info.type_id).unwrap();
+                    format!("[{name}](crate::{name})", name = sym.full_rust_name())
+                } else {
+                    format!("`{}`", ns_type_to_doc(namespace, type_))
+                }
+            }
+            GiDocgen::Class { namespace, type_ } | GiDocgen::Interface { namespace, type_ } => {
+                if let Some((_, class_info)) =
+                    env.analysis.objects.iter().find(|(_, o)| &o.name == type_)
+                {
+                    let sym = symbols.by_tid(class_info.type_id).unwrap();
+                    format!("[{name}](crate::{name})", name = sym.full_rust_name())
+                } else {
+                    format!("`{}`", ns_type_to_doc(namespace, type_))
+                }
+            }
+            GiDocgen::Flag { namespace, type_ } => {
+                if let Some(flag_info) = env.analysis.flags.iter().find(|e| &e.name == type_) {
+                    let sym = symbols.by_tid(flag_info.type_id).unwrap();
+                    format!("[{name}](crate::{name})", name = sym.full_rust_name())
+                } else {
+                    format!("`{}`", ns_type_to_doc(namespace, type_))
+                }
+            }
+            GiDocgen::Const { namespace, type_ } => {
+                if let Some(const_info) = env.analysis.constants.iter().find(|c| &c.name == type_) {
+                    let sym = symbols.by_tid(const_info.typ).unwrap();
+                    format!("[{name}](crate::{name})", name = sym.full_rust_name())
+                } else {
+                    format!("`{}`", ns_type_to_doc(namespace, type_))
+                }
+            }
+            GiDocgen::Property {
+                namespace,
+                type_,
+                name,
+            } => {
+                if let Some((_, class_info)) =
+                    env.analysis.objects.iter().find(|(_, o)| &o.name == type_)
+                {
+                    let sym = symbols.by_tid(class_info.type_id).unwrap();
+                    format!("`{}:{}`", sym.full_rust_name(), name)
+                } else {
+                    format!("`{}:{}`", ns_type_to_doc(namespace, type_), name)
+                }
+            }
+            GiDocgen::Signal {
+                namespace,
+                type_,
+                name,
+            } => {
+                if let Some((_, class_info)) =
+                    env.analysis.objects.iter().find(|(_, o)| &o.name == type_)
+                {
+                    let sym = symbols.by_tid(class_info.type_id).unwrap();
+                    format!("`{}::{}`", sym.full_rust_name(), name)
+                } else {
+                    format!("`{}::{}`", ns_type_to_doc(namespace, type_), name)
+                }
+            }
+            GiDocgen::Id(c_name) => {
+                if let Some(sym) = symbols.by_c_name(c_name) {
+                    format!("[{name}](crate::{name})", name = sym.full_rust_name())
+                } else {
+                    format!("`{}`", c_name)
+                }
+            }
+            GiDocgen::Struct { namespace, type_ } => {
+                if let Some((_, record_info)) =
+                    env.analysis.records.iter().find(|(_, r)| &r.name == type_)
+                {
+                    let sym = symbols.by_tid(record_info.type_id).unwrap();
+                    format!("[{name}](crate::{name})", name = sym.full_rust_name())
+                } else {
+                    format!("`{}`", ns_type_to_doc(namespace, type_))
+                }
+            }
+            GiDocgen::Constructor {
+                namespace,
+                type_,
+                name,
+            } => {
+                if let Some((_, class_info)) =
+                    env.analysis.objects.iter().find(|(_, o)| &o.name == type_)
+                {
+                    let sym = symbols.by_tid(class_info.type_id).unwrap();
+                    if let Some(constructor) = class_info
+                        .constructors()
+                        .iter()
+                        .find(|f| f.name == nameutil::mangle_keywords(name))
+                    {
+                        format!(
+                            "[{name}::{fn_name}](crate::{name}::{fn_name})",
+                            name = sym.full_rust_name(),
+                            fn_name = constructor.codegen_name()
+                        )
+                    } else {
+                        format!("`{}::{}`", sym.full_rust_name(), name)
+                    }
+                } else {
+                    format!("`{}::{}`", ns_type_to_doc(namespace, type_), name)
+                }
+            }
+            GiDocgen::Func {
+                namespace: _,
+                type_,
+                name,
+            } => {
+                if let Some(ty) = type_ {
+                    if let Some(obj_ty) = env
+                        .analysis
+                        .objects
+                        .iter()
+                        .find(|(_, o)| &o.name == ty)
+                        .map(|(_, info)| info)
+                    {
+                        let sym = symbols.by_tid(obj_ty.type_id).unwrap();
+                        if let Some(fn_info) = obj_ty
+                            .functions
+                            .iter()
+                            .find(|f| f.name == nameutil::mangle_keywords(name))
+                        {
+                            format!(
+                                "[{name}::{fn_name}](crate::{name}::{fn_name})",
+                                name = sym.full_rust_name(),
+                                fn_name = fn_info.codegen_name()
+                            )
+                        } else {
+                            format!("`{}::{}`", sym.full_rust_name(), name)
+                        }
+                    } else {
+                        format!("`{}`", name)
+                    }
+                } else if let Some(fn_info) = env
+                    .analysis
+                    .global_functions
+                    .as_ref()
+                    .unwrap()
+                    .functions
+                    .iter()
+                    .find(|n| &n.name == name)
+                {
+                    format!(
+                        "[{fn_name}()](crate::{fn_name})",
+                        fn_name = fn_info.codegen_name()
+                    )
+                } else {
+                    format!("`{}`", name)
+                }
+            }
+            GiDocgen::Alias(alias) => {
+                if let Some((_, record_info)) =
+                    env.analysis.records.iter().find(|(_, r)| &r.name == alias)
+                {
+                    let sym = symbols.by_tid(record_info.type_id).unwrap();
+                    format!(
+                        "{alias} alias [{name}](crate::{name})",
+                        alias = alias,
+                        name = sym.full_rust_name()
+                    )
+                } else {
+                    format!("`{}`", alias)
+                }
+            }
+            GiDocgen::Method {
+                namespace,
+                type_,
+                name,
+                is_instance: _,
+            } => {
+                if let Some((_, class_info)) =
+                    env.analysis.objects.iter().find(|(_, o)| &o.name == type_)
+                {
+                    let sym = symbols.by_tid(class_info.type_id).unwrap();
+                    if let Some(fn_info) = class_info
+                        .functions
+                        .iter()
+                        .filter(|f| f.status != GStatus::Ignore)
+                        .find(|f| f.name == nameutil::mangle_keywords(name))
+                    {
+                        let (type_name, visible_type_name) = if class_info.final_type {
+                            (class_info.name.clone(), class_info.name.clone())
+                        } else {
+                            let type_name = if fn_info.status == GStatus::Generate {
+                                class_info.trait_name.clone()
+                            } else {
+                                format!("{}Manual", class_info.trait_name)
+                            };
+                            (format!("prelude::{}", type_name), type_name)
+                        };
+                        format!(
+                            "[{visible_type_name}::{fn_name}](crate::{name}::{fn_name})",
+                            name = sym.full_rust_name().replace(type_, &type_name),
+                            visible_type_name = visible_type_name,
+                            fn_name = fn_info.codegen_name()
+                        )
+                    } else {
+                        format!("`{}::{}()`", sym.full_rust_name(), name)
+                    }
+                } else {
+                    format!("`{}::{}()`", ns_type_to_doc(namespace, type_), name)
+                }
+            }
+            GiDocgen::Callback { namespace, name } => {
+                format!("`{}`", ns_type_to_doc(namespace, name))
+            }
+            GiDocgen::VFunc {
+                namespace,
+                type_,
+                name,
+            } => {
+                format!("`virtual:{}::{}`", ns_type_to_doc(namespace, type_), name)
+            }
+        }
+    }
+}
+
+impl FromStr for GiDocgen {
+    type Err = GiDocgenError;
+    // We assume the string is contained inside a []
+    fn from_str(item_link: &str) -> Result<Self, Self::Err> {
+        let item_link = item_link.trim_start_matches('[').trim_end_matches(']');
+        if let Some((link_type, link_details)) = item_link.split_once('@') {
+            match link_type {
+                "alias" => Ok(GiDocgen::Alias(link_details.to_string())),
+                "class" => {
+                    let (namespace, type_) = namespace_type_from_details(link_details, "class")?;
+                    Ok(GiDocgen::Class { namespace, type_ })
+                }
+                "const" => {
+                    let (namespace, type_) = namespace_type_from_details(link_details, "const")?;
+                    Ok(GiDocgen::Const { namespace, type_ })
+                }
+                "ctor" => {
+                    let (namespace, type_, name) =
+                        namespace_type_method_from_details(link_details, "ctor", false)?;
+                    Ok(GiDocgen::Constructor {
+                        namespace,
+                        type_: type_
+                            .ok_or_else(|| GiDocgenError::BrokenLinkType("ctor".to_string()))?,
+                        name,
+                    })
+                }
+                "enum" => {
+                    let (namespace, type_) = namespace_type_from_details(link_details, "enum")?;
+                    Ok(GiDocgen::Enum { namespace, type_ })
+                }
+                "error" => {
+                    let (namespace, type_) = namespace_type_from_details(link_details, "error")?;
+                    Ok(GiDocgen::Error { namespace, type_ })
+                }
+                "flags" => {
+                    let (namespace, type_) = namespace_type_from_details(link_details, "flags")?;
+                    Ok(GiDocgen::Flag { namespace, type_ })
+                }
+                "func" => {
+                    let (namespace, type_, name) =
+                        namespace_type_method_from_details(link_details, "func", true)?;
+                    Ok(GiDocgen::Func {
+                        namespace,
+                        type_,
+                        name,
+                    })
+                }
+                "iface" => {
+                    let (namespace, type_) = namespace_type_from_details(link_details, "iface")?;
+                    Ok(GiDocgen::Interface { namespace, type_ })
+                }
+                "callback" => {
+                    let (namespace, name) = namespace_type_from_details(link_details, "callback")?;
+                    Ok(GiDocgen::Callback { namespace, name })
+                }
+                "method" => {
+                    let (namespace, type_, name) =
+                        namespace_type_method_from_details(link_details, "method", false)?;
+                    let type_ =
+                        type_.ok_or_else(|| GiDocgenError::BrokenLinkType("method".to_string()))?;
+                    Ok(GiDocgen::Method {
+                        namespace,
+                        is_instance: type_.ends_with("Class"),
+                        type_,
+                        name,
+                    })
+                }
+                "property" => {
+                    let (namespace, type_) = namespace_type_from_details(link_details, "property")?;
+                    let type_details: Vec<_> = type_.split(':').collect();
+                    if type_details.len() < 2 || type_details[1].is_empty() {
+                        Err(GiDocgenError::BrokenLinkType("property".to_string()))
+                    } else {
+                        Ok(GiDocgen::Property {
+                            namespace,
+                            type_: type_details[0].to_string(),
+                            name: type_details[1].to_string(),
+                        })
+                    }
+                }
+                "signal" => {
+                    let (namespace, type_) = namespace_type_from_details(link_details, "signal")?;
+                    let type_details: Vec<_> = type_.split("::").collect();
+                    if type_details.len() < 2 || type_details[1].is_empty() {
+                        Err(GiDocgenError::BrokenLinkType("signal".to_string()))
+                    } else {
+                        Ok(GiDocgen::Signal {
+                            namespace,
+                            type_: type_details[0].to_string(),
+                            name: type_details[1].to_string(),
+                        })
+                    }
+                }
+                "struct" => {
+                    let (namespace, type_) = namespace_type_from_details(link_details, "struct")?;
+                    Ok(GiDocgen::Struct { namespace, type_ })
+                }
+                "vfunc" => {
+                    let (namespace, type_, name) =
+                        namespace_type_method_from_details(link_details, "vfunc", false)?;
+                    Ok(GiDocgen::VFunc {
+                        namespace,
+                        type_: type_
+                            .ok_or_else(|| GiDocgenError::BrokenLinkType("vfunc".to_string()))?,
+                        name,
+                    })
+                }
+                "id" => Ok(GiDocgen::Id(link_details.to_string())),
+                e => Err(GiDocgenError::InvalidLinkType(e.to_string())),
+            }
+        } else {
+            Err(GiDocgenError::InvalidLink)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn test_link_alias() {
+        assert_eq!(
+            GiDocgen::from_str("[alias@Allocation]"),
+            Ok(GiDocgen::Alias("Allocation".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_link_class() {
+        assert_eq!(
+            GiDocgen::from_str("[class@Widget]"),
+            Ok(GiDocgen::Class {
+                namespace: None,
+                type_: "Widget".to_string(),
+            })
+        );
+        assert_eq!(
+            GiDocgen::from_str("[class@Gdk.Surface]"),
+            Ok(GiDocgen::Class {
+                namespace: Some("Gdk".to_string()),
+                type_: "Surface".to_string(),
+            })
+        );
+        assert_eq!(
+            GiDocgen::from_str("[class@Gsk.RenderNode]"),
+            Ok(GiDocgen::Class {
+                namespace: Some("Gsk".to_string()),
+                type_: "RenderNode".to_string(),
+            })
+        );
+
+        assert_eq!(
+            GiDocgen::from_str("[class@Gsk.RenderNode.test]"),
+            Err(GiDocgenError::BrokenLinkType("class".to_string()))
+        );
+
+        assert_eq!(
+            GiDocgen::from_str("[class@Gsk.]"),
+            Err(GiDocgenError::BrokenLinkType("class".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_link_id() {
+        assert_eq!(
+            GiDocgen::from_str("[id@gtk_widget_show]"),
+            Ok(GiDocgen::Id("gtk_widget_show".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_link_const() {
+        assert_eq!(
+            GiDocgen::from_str("[const@Gdk.KEY_q]"),
+            Ok(GiDocgen::Const {
+                namespace: Some("Gdk".to_string()),
+                type_: "KEY_q".to_string()
+            })
+        );
+    }
+
+    #[test]
+    fn test_link_callback() {
+        assert_eq!(
+            GiDocgen::from_str("[callback@Gtk.MapListModelMapFunc]"),
+            Ok(GiDocgen::Callback {
+                namespace: Some("Gtk".to_string()),
+                name: "MapListModelMapFunc".to_string()
+            })
+        )
+    }
+
+    #[test]
+    fn test_link_enum() {
+        assert_eq!(
+            GiDocgen::from_str("[enum@Orientation]"),
+            Ok(GiDocgen::Enum {
+                namespace: None,
+                type_: "Orientation".to_string()
+            })
+        );
+    }
+
+    #[test]
+    fn test_link_error() {
+        assert_eq!(
+            GiDocgen::from_str("[error@Gtk.BuilderParseError]"),
+            Ok(GiDocgen::Error {
+                namespace: Some("Gtk".to_string()),
+                type_: "BuilderParseError".to_string()
+            })
+        );
+    }
+
+    #[test]
+    fn test_link_flags() {
+        assert_eq!(
+            GiDocgen::from_str("[flags@Gdk.ModifierType]"),
+            Ok(GiDocgen::Flag {
+                namespace: Some("Gdk".to_string()),
+                type_: "ModifierType".to_string()
+            })
+        );
+    }
+
+    #[test]
+    fn test_link_iface() {
+        assert_eq!(
+            GiDocgen::from_str("[iface@Gtk.Buildable]"),
+            Ok(GiDocgen::Interface {
+                namespace: Some("Gtk".to_string()),
+                type_: "Buildable".to_string()
+            })
+        );
+    }
+
+    #[test]
+    fn test_link_struct() {
+        assert_eq!(
+            GiDocgen::from_str("[struct@Gtk.TextIter]"),
+            Ok(GiDocgen::Struct {
+                namespace: Some("Gtk".to_string()),
+                type_: "TextIter".to_string()
+            })
+        );
+    }
+
+    #[test]
+    fn test_link_property() {
+        assert_eq!(
+            GiDocgen::from_str("[property@Gtk.Orientable:orientation]"),
+            Ok(GiDocgen::Property {
+                namespace: Some("Gtk".to_string()),
+                type_: "Orientable".to_string(),
+                name: "orientation".to_string(),
+            })
+        );
+
+        assert_eq!(
+            GiDocgen::from_str("[property@Gtk.Orientable]"),
+            Err(GiDocgenError::BrokenLinkType("property".to_string()))
+        );
+
+        assert_eq!(
+            GiDocgen::from_str("[property@Gtk.Orientable:]"),
+            Err(GiDocgenError::BrokenLinkType("property".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_link_signal() {
+        assert_eq!(
+            GiDocgen::from_str("[signal@Gtk.RecentManager::changed]"),
+            Ok(GiDocgen::Signal {
+                namespace: Some("Gtk".to_string()),
+                type_: "RecentManager".to_string(),
+                name: "changed".to_string(),
+            })
+        );
+
+        assert_eq!(
+            GiDocgen::from_str("[signal@Gtk.RecentManager]"),
+            Err(GiDocgenError::BrokenLinkType("signal".to_string()))
+        );
+
+        assert_eq!(
+            GiDocgen::from_str("[signal@Gtk.RecentManager::]"),
+            Err(GiDocgenError::BrokenLinkType("signal".to_string()))
+        );
+
+        assert_eq!(
+            GiDocgen::from_str("[signal@Gtk.RecentManager:]"),
+            Err(GiDocgenError::BrokenLinkType("signal".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_link_vfunc() {
+        assert_eq!(
+            GiDocgen::from_str("[vfunc@Gtk.Widget.measure]"),
+            Ok(GiDocgen::VFunc {
+                namespace: Some("Gtk".to_string()),
+                type_: "Widget".to_string(),
+                name: "measure".to_string(),
+            })
+        );
+
+        assert_eq!(
+            GiDocgen::from_str("[vfunc@Widget.snapshot]"),
+            Ok(GiDocgen::VFunc {
+                namespace: None,
+                type_: "Widget".to_string(),
+                name: "snapshot".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn test_link_ctor() {
+        assert_eq!(
+            GiDocgen::from_str("[ctor@Gtk.Box.new]"),
+            Ok(GiDocgen::Constructor {
+                namespace: Some("Gtk".to_string()),
+                type_: "Box".to_string(),
+                name: "new".to_string(),
+            })
+        );
+
+        assert_eq!(
+            GiDocgen::from_str("[ctor@Button.new_with_label]"),
+            Ok(GiDocgen::Constructor {
+                namespace: None,
+                type_: "Button".to_string(),
+                name: "new_with_label".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn test_link_func() {
+        assert_eq!(
+            GiDocgen::from_str("[func@Gtk.init]"),
+            Ok(GiDocgen::Func {
+                namespace: Some("Gtk".to_string()),
+                type_: None,
+                name: "init".to_string(),
+            })
+        );
+
+        assert_eq!(
+            GiDocgen::from_str("[func@show_uri]"),
+            Ok(GiDocgen::Func {
+                namespace: None,
+                type_: None,
+                name: "show_uri".to_string(),
+            })
+        );
+
+        assert_eq!(
+            GiDocgen::from_str("[func@Gtk.Window.list_toplevels]"),
+            Ok(GiDocgen::Func {
+                namespace: Some("Gtk".to_string()),
+                type_: Some("Window".to_string()),
+                name: "list_toplevels".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn test_link_method() {
+        assert_eq!(
+            GiDocgen::from_str("[method@Gtk.Widget.show]"),
+            Ok(GiDocgen::Method {
+                namespace: Some("Gtk".to_string()),
+                type_: "Widget".to_string(),
+                name: "show".to_string(),
+                is_instance: false,
+            })
+        );
+
+        assert_eq!(
+            GiDocgen::from_str("[method@WidgetClass.add_binding]"),
+            Ok(GiDocgen::Method {
+                namespace: None,
+                type_: "WidgetClass".to_string(),
+                name: "add_binding".to_string(),
+                is_instance: true,
+            })
+        );
+    }
+}

--- a/src/codegen/doc/gi_docgen.rs
+++ b/src/codegen/doc/gi_docgen.rs
@@ -91,7 +91,8 @@ pub(crate) fn replace_c_types(entry: &str, env: &Env, _in_type: &str) -> String 
             if let Ok(gi_type) = GiDocgen::from_str(&caps[0]) {
                 gi_type.rust_link(env)
             } else {
-                format!("`{}`", entry.trim_start_matches('[').trim_end_matches(']'))
+                // otherwise fallback to the original string
+                caps[0].to_string()
             }
         })
         .to_string()

--- a/src/codegen/doc/gi_docgen.rs
+++ b/src/codegen/doc/gi_docgen.rs
@@ -1,4 +1,5 @@
 use crate::{
+    analysis::object::LocationInObject,
     codegen::doc::format::{
         gen_alias_doc_link, gen_callback_doc_link, gen_const_doc_link, gen_object_fn_doc_link,
         gen_property_doc_link, gen_signal_doc_link, gen_symbol_doc_link, gen_vfunc_doc_link,
@@ -95,7 +96,11 @@ static GI_DOCGEN_SYMBOLS: Lazy<Regex> = Lazy::new(|| {
     Regex::new(r"\[(callback|id|alias|class|const|ctor|enum|error|flags|func|iface|method|property|signal|struct|vfunc)[@](\w+\b)([:.]+[\w-]+\b)?([:.]+[\w-]+\b)?\]?").unwrap()
 });
 
-pub(crate) fn replace_c_types(entry: &str, env: &Env, in_type: Option<&TypeId>) -> String {
+pub(crate) fn replace_c_types(
+    entry: &str,
+    env: &Env,
+    in_type: Option<(&TypeId, Option<LocationInObject>)>,
+) -> String {
     GI_DOCGEN_SYMBOLS
         .replace_all(entry, |caps: &Captures<'_>| {
             if let Ok(gi_type) = GiDocgen::from_str(&caps[0]) {
@@ -195,7 +200,7 @@ fn find_method_or_function_by_name(
     type_: Option<&str>,
     name: &str,
     env: &Env,
-    in_type: Option<&TypeId>,
+    in_type: Option<(&TypeId, Option<LocationInObject>)>,
     is_class_method: bool,
 ) -> Option<String> {
     find_method_or_function(
@@ -210,7 +215,11 @@ fn find_method_or_function_by_name(
 }
 
 impl GiDocgen {
-    pub fn rust_link(&self, env: &Env, in_type: Option<&TypeId>) -> String {
+    pub fn rust_link(
+        &self,
+        env: &Env,
+        in_type: Option<(&TypeId, Option<LocationInObject>)>,
+    ) -> String {
         let symbols = env.symbols.borrow();
         match self {
             GiDocgen::Enum { type_, namespace } | GiDocgen::Error { type_, namespace } => env

--- a/src/codegen/doc/gi_docgen.rs
+++ b/src/codegen/doc/gi_docgen.rs
@@ -387,6 +387,24 @@ impl GiDocgen {
                     } else {
                         format!("`{}::{}()`", sym.full_rust_name(), name)
                     }
+                } else if let Some((_, record_info)) =
+                    env.analysis.records.iter().find(|(_, o)| &o.name == type_)
+                {
+                    let sym = symbols.by_tid(record_info.type_id).unwrap();
+                    if let Some(fn_info) = record_info
+                        .functions
+                        .iter()
+                        .filter(|f| f.status != GStatus::Ignore)
+                        .find(|f| f.name == nameutil::mangle_keywords(name))
+                    {
+                        format!(
+                            "[{name}::{fn_name}](crate::{name}::{fn_name})",
+                            name = sym.full_rust_name(),
+                            fn_name = fn_info.codegen_name()
+                        )
+                    } else {
+                        format!("`{}::{}()`", sym.full_rust_name(), name)
+                    }
                 } else {
                     format!("`{}::{}()`", ns_type_to_doc(namespace, type_), name)
                 }

--- a/src/codegen/doc/gi_docgen.rs
+++ b/src/codegen/doc/gi_docgen.rs
@@ -190,11 +190,7 @@ impl GiDocgen {
                 if let Some(enum_info) = env.analysis.enumerations.iter().find(|e| &e.name == type_)
                 {
                     let sym = symbols.by_tid(enum_info.type_id).unwrap();
-                    format!(
-                        "[{name}](crate::{parent})",
-                        name = enum_info.name,
-                        parent = sym.parent().trim_end_matches("::")
-                    )
+                    format!("[`{name}`](crate::{name})", name = sym.full_rust_name())
                 } else {
                     format!("`{}`", ns_type_to_doc(namespace, type_))
                 }
@@ -212,11 +208,7 @@ impl GiDocgen {
             GiDocgen::Flag { namespace, type_ } => {
                 if let Some(flag_info) = env.analysis.flags.iter().find(|e| &e.name == type_) {
                     let sym = symbols.by_tid(flag_info.type_id).unwrap();
-                    format!(
-                        "[{name}](crate::{parent})",
-                        name = flag_info.name,
-                        parent = sym.parent().trim_end_matches("::")
-                    )
+                    format!("[`{name}`](crate::{name})", name = sym.full_rust_name())
                 } else {
                     format!("`{}`", ns_type_to_doc(namespace, type_))
                 }

--- a/src/codegen/doc/gi_docgen.rs
+++ b/src/codegen/doc/gi_docgen.rs
@@ -189,7 +189,11 @@ impl GiDocgen {
                 if let Some(enum_info) = env.analysis.enumerations.iter().find(|e| &e.name == type_)
                 {
                     let sym = symbols.by_tid(enum_info.type_id).unwrap();
-                    format!("[{name}](crate::{name})", name = sym.full_rust_name())
+                    format!(
+                        "[{name}](crate::{parent})",
+                        name = enum_info.name,
+                        parent = sym.parent().trim_end_matches("::")
+                    )
                 } else {
                     format!("`{}`", ns_type_to_doc(namespace, type_))
                 }
@@ -207,7 +211,11 @@ impl GiDocgen {
             GiDocgen::Flag { namespace, type_ } => {
                 if let Some(flag_info) = env.analysis.flags.iter().find(|e| &e.name == type_) {
                     let sym = symbols.by_tid(flag_info.type_id).unwrap();
-                    format!("[{name}](crate::{name})", name = sym.full_rust_name())
+                    format!(
+                        "[{name}](crate::{parent})",
+                        name = flag_info.name,
+                        parent = sym.parent().trim_end_matches("::")
+                    )
                 } else {
                     format!("`{}`", ns_type_to_doc(namespace, type_))
                 }
@@ -308,6 +316,9 @@ impl GiDocgen {
                         if let Some(fn_info) = obj_ty
                             .functions
                             .iter()
+                            .filter(|fn_info| {
+                                !fn_info.is_special() && !fn_info.is_async_finish(env)
+                            })
                             .find(|f| f.name == nameutil::mangle_keywords(name))
                         {
                             format!(
@@ -328,6 +339,7 @@ impl GiDocgen {
                     .unwrap()
                     .functions
                     .iter()
+                    .filter(|fn_info| !fn_info.is_special() && !fn_info.is_async_finish(env))
                     .find(|n| &n.name == name)
                 {
                     format!(

--- a/src/codegen/doc/gi_docgen.rs
+++ b/src/codegen/doc/gi_docgen.rs
@@ -190,7 +190,7 @@ impl GiDocgen {
                 if let Some(enum_info) = env.analysis.enumerations.iter().find(|e| &e.name == type_)
                 {
                     let sym = symbols.by_tid(enum_info.type_id).unwrap();
-                    format!("[`{name}`][crate::{name}]", name = sym.full_rust_name())
+                    format!("[`{n}`][crate::{n}]", n = sym.full_rust_name())
                 } else {
                     format!("`{}`", ns_type_to_doc(namespace, type_))
                 }
@@ -200,7 +200,7 @@ impl GiDocgen {
                     env.analysis.objects.iter().find(|(_, o)| &o.name == type_)
                 {
                     let sym = symbols.by_tid(class_info.type_id).unwrap();
-                    format!("[`{name}`][crate::{name}]", name = sym.full_rust_name())
+                    format!("[`{n}`][crate::{n}]", n = sym.full_rust_name())
                 } else {
                     format!("`{}`", ns_type_to_doc(namespace, type_))
                 }
@@ -208,7 +208,7 @@ impl GiDocgen {
             GiDocgen::Flag { namespace, type_ } => {
                 if let Some(flag_info) = env.analysis.flags.iter().find(|e| &e.name == type_) {
                     let sym = symbols.by_tid(flag_info.type_id).unwrap();
-                    format!("[`{name}`][crate::{name}]", name = sym.full_rust_name())
+                    format!("[`{n}`][crate::{n}]", n = sym.full_rust_name())
                 } else {
                     format!("`{}`", ns_type_to_doc(namespace, type_))
                 }
@@ -216,7 +216,7 @@ impl GiDocgen {
             GiDocgen::Const { namespace, type_ } => {
                 if let Some(const_info) = env.analysis.constants.iter().find(|c| &c.name == type_) {
                     let sym = symbols.by_tid(const_info.typ).unwrap();
-                    format!("[`{name}`][crate::{name}]", name = sym.full_rust_name())
+                    format!("[`{n}`][crate::{n}]", n = sym.full_rust_name())
                 } else {
                     format!("`{}`", ns_type_to_doc(namespace, type_))
                 }
@@ -251,7 +251,7 @@ impl GiDocgen {
             }
             GiDocgen::Id(c_name) => {
                 if let Some(sym) = symbols.by_c_name(c_name) {
-                    format!("[`{name}`][crate::{name}]", name = sym.full_rust_name())
+                    format!("[`{n}`][crate::{n}]", n = sym.full_rust_name())
                 } else {
                     format!("`{}`", c_name)
                 }
@@ -261,7 +261,7 @@ impl GiDocgen {
                     env.analysis.records.iter().find(|(_, r)| &r.name == type_)
                 {
                     let sym = symbols.by_tid(record_info.type_id).unwrap();
-                    format!("[`{name}`][crate::{name}]", name = sym.full_rust_name())
+                    format!("[`{n}`][crate::{n}]", n = sym.full_rust_name())
                 } else {
                     format!("`{}`", ns_type_to_doc(namespace, type_))
                 }
@@ -277,9 +277,7 @@ impl GiDocgen {
                     |f| f.name == mangle_keywords(name),
                 ) {
                     let sym = symbols.by_tid(class_info.type_id).unwrap();
-
-                    let parent = sym.full_rust_name();
-                    fn_info.doc_link(Some(&parent), None)
+                    fn_info.doc_link(Some(&sym.full_rust_name()), None)
                 } else {
                     format!("`{}::{}`", ns_type_to_doc(namespace, type_), name)
                 }
@@ -296,9 +294,7 @@ impl GiDocgen {
                         |f| f.name == mangle_keywords(name),
                     ) {
                         let sym = symbols.by_tid(obj_info.type_id).unwrap();
-
-                        let parent = sym.full_rust_name();
-                        fn_info.doc_link(Some(&parent), None)
+                        fn_info.doc_link(Some(&sym.full_rust_name()), None)
                     } else {
                         format!("`{}`", name)
                     }
@@ -315,10 +311,7 @@ impl GiDocgen {
                     env.analysis.records.iter().find(|(_, r)| &r.name == alias)
                 {
                     let sym = symbols.by_tid(record_info.type_id).unwrap();
-                    format!(
-                        "alias::[`{name}`][crate::{name}]",
-                        name = sym.full_rust_name()
-                    )
+                    format!("alias::[`{n}`][crate::{n}]", n = sym.full_rust_name())
                 } else {
                     format!("`alias::{}`", alias)
                 }
@@ -347,8 +340,7 @@ impl GiDocgen {
                     |f| f.name == mangle_keywords(name),
                 ) {
                     let sym = symbols.by_tid(record_info.type_id).unwrap();
-                    let parent = sym.full_rust_name();
-                    fn_info.doc_link(Some(&parent), None)
+                    fn_info.doc_link(Some(&sym.full_rust_name()), None)
                 } else {
                     format!("`{}::{}()`", ns_type_to_doc(namespace, type_), name)
                 }

--- a/src/codegen/doc/gi_docgen.rs
+++ b/src/codegen/doc/gi_docgen.rs
@@ -366,6 +366,7 @@ impl GiDocgen {
                         .functions
                         .iter()
                         .filter(|f| f.status != GStatus::Ignore)
+                        .filter(|fn_info| !fn_info.is_special() && !fn_info.is_async_finish(env))
                         .find(|f| f.name == nameutil::mangle_keywords(name))
                     {
                         let (type_name, visible_type_name) = if class_info.final_type {
@@ -395,6 +396,7 @@ impl GiDocgen {
                         .functions
                         .iter()
                         .filter(|f| f.status != GStatus::Ignore)
+                        .filter(|fn_info| !fn_info.is_special() && !fn_info.is_async_finish(env))
                         .find(|f| f.name == nameutil::mangle_keywords(name))
                     {
                         format!(

--- a/src/codegen/doc/gi_docgen.rs
+++ b/src/codegen/doc/gi_docgen.rs
@@ -190,7 +190,7 @@ impl GiDocgen {
                 if let Some(enum_info) = env.analysis.enumerations.iter().find(|e| &e.name == type_)
                 {
                     let sym = symbols.by_tid(enum_info.type_id).unwrap();
-                    format!("[`{name}`](crate::{name})", name = sym.full_rust_name())
+                    format!("[`{name}`][crate::{name}]", name = sym.full_rust_name())
                 } else {
                     format!("`{}`", ns_type_to_doc(namespace, type_))
                 }
@@ -200,7 +200,7 @@ impl GiDocgen {
                     env.analysis.objects.iter().find(|(_, o)| &o.name == type_)
                 {
                     let sym = symbols.by_tid(class_info.type_id).unwrap();
-                    format!("[{name}](crate::{name})", name = sym.full_rust_name())
+                    format!("[`{name}`][crate::{name}]", name = sym.full_rust_name())
                 } else {
                     format!("`{}`", ns_type_to_doc(namespace, type_))
                 }
@@ -208,7 +208,7 @@ impl GiDocgen {
             GiDocgen::Flag { namespace, type_ } => {
                 if let Some(flag_info) = env.analysis.flags.iter().find(|e| &e.name == type_) {
                     let sym = symbols.by_tid(flag_info.type_id).unwrap();
-                    format!("[`{name}`](crate::{name})", name = sym.full_rust_name())
+                    format!("[`{name}`][crate::{name}]", name = sym.full_rust_name())
                 } else {
                     format!("`{}`", ns_type_to_doc(namespace, type_))
                 }
@@ -216,7 +216,7 @@ impl GiDocgen {
             GiDocgen::Const { namespace, type_ } => {
                 if let Some(const_info) = env.analysis.constants.iter().find(|c| &c.name == type_) {
                     let sym = symbols.by_tid(const_info.typ).unwrap();
-                    format!("[{name}](crate::{name})", name = sym.full_rust_name())
+                    format!("[`{name}`][crate::{name}]", name = sym.full_rust_name())
                 } else {
                     format!("`{}`", ns_type_to_doc(namespace, type_))
                 }
@@ -230,9 +230,9 @@ impl GiDocgen {
                     env.analysis.objects.iter().find(|(_, o)| &o.name == type_)
                 {
                     let sym = symbols.by_tid(class_info.type_id).unwrap();
-                    format!("`{}:{}`", sym.full_rust_name(), name)
+                    format!("`property::{}::{}`", sym.full_rust_name(), name)
                 } else {
-                    format!("`{}:{}`", ns_type_to_doc(namespace, type_), name)
+                    format!("`property::{}::{}`", ns_type_to_doc(namespace, type_), name)
                 }
             }
             GiDocgen::Signal {
@@ -244,14 +244,14 @@ impl GiDocgen {
                     env.analysis.objects.iter().find(|(_, o)| &o.name == type_)
                 {
                     let sym = symbols.by_tid(class_info.type_id).unwrap();
-                    format!("`{}::{}`", sym.full_rust_name(), name)
+                    format!("`signal::{}::{}`", sym.full_rust_name(), name)
                 } else {
-                    format!("`{}::{}`", ns_type_to_doc(namespace, type_), name)
+                    format!("`signal::{}::{}`", ns_type_to_doc(namespace, type_), name)
                 }
             }
             GiDocgen::Id(c_name) => {
                 if let Some(sym) = symbols.by_c_name(c_name) {
-                    format!("[{name}](crate::{name})", name = sym.full_rust_name())
+                    format!("[`{name}`][crate::{name}]", name = sym.full_rust_name())
                 } else {
                     format!("`{}`", c_name)
                 }
@@ -261,7 +261,7 @@ impl GiDocgen {
                     env.analysis.records.iter().find(|(_, r)| &r.name == type_)
                 {
                     let sym = symbols.by_tid(record_info.type_id).unwrap();
-                    format!("[{name}](crate::{name})", name = sym.full_rust_name())
+                    format!("[`{name}`][crate::{name}]", name = sym.full_rust_name())
                 } else {
                     format!("`{}`", ns_type_to_doc(namespace, type_))
                 }
@@ -316,12 +316,11 @@ impl GiDocgen {
                 {
                     let sym = symbols.by_tid(record_info.type_id).unwrap();
                     format!(
-                        "{alias} alias [{name}](crate::{name})",
-                        alias = alias,
+                        "alias::[`{name}`][crate::{name}]",
                         name = sym.full_rust_name()
                     )
                 } else {
-                    format!("`{}`", alias)
+                    format!("`alias::{}`", alias)
                 }
             }
             GiDocgen::Method {
@@ -355,14 +354,18 @@ impl GiDocgen {
                 }
             }
             GiDocgen::Callback { namespace, name } => {
-                format!("`{}`", ns_type_to_doc(namespace, name))
+                format!("`callback::{}`", ns_type_to_doc(namespace, name))
             }
             GiDocgen::VFunc {
                 namespace,
                 type_,
                 name,
             } => {
-                format!("`virtual:{}::{}`", ns_type_to_doc(namespace, type_), name)
+                format!(
+                    "`virtual-function::{}::{}`",
+                    ns_type_to_doc(namespace, type_),
+                    name
+                )
             }
         }
     }

--- a/src/codegen/doc/mod.rs
+++ b/src/codegen/doc/mod.rs
@@ -336,7 +336,12 @@ fn create_object_doc(w: &mut dyn Write, env: &Env, info: &analysis::object::Info
             let mut implementors = std::iter::once(info.type_id)
                 .chain(env.class_hierarchy.subtypes(info.type_id))
                 .filter(|&tid| !env.type_status(&tid.full_name(&env.library)).ignored())
-                .map(|tid| format!("[`struct@crate::{}`]", env.library.type_(tid).get_name()))
+                .map(|tid| {
+                    format!(
+                        "[{name}](crate::{name})",
+                        name = env.library.type_(tid).get_name()
+                    )
+                })
                 .collect::<Vec<_>>();
             implementors.sort();
 
@@ -768,11 +773,11 @@ fn get_type_trait_for_implements(env: &Env, tid: TypeId) -> String {
         format!("{}Ext", env.library.type_(tid).get_name())
     };
     if tid.ns_id == MAIN_NAMESPACE {
-        format!("[`trait@crate::prelude::{}`]", &trait_name)
+        format!("[{name}](crate::prelude::{name})", name = &trait_name)
     } else if let Some(symbol) = env.symbols.borrow().by_tid(tid) {
         let mut symbol = symbol.clone();
         symbol.make_trait(&trait_name);
-        format!("[`trait@{}`]", &symbol.full_rust_name())
+        format!("[{name}](trait@{name})", name = &symbol.full_rust_name())
     } else {
         error!("Type {} doesn't have crate", tid.full_name(&env.library));
         format!("`{}`", trait_name)
@@ -799,6 +804,6 @@ pub fn get_type_manual_traits_for_implements(
     manual_trait_iters
         .into_iter()
         .flatten()
-        .map(|name| format!("[`trait@crate::prelude::{}`]", name))
+        .map(|name| format!("[{name}](trait@crate::prelude::{name})", name = name))
         .collect()
 }

--- a/src/codegen/doc/mod.rs
+++ b/src/codegen/doc/mod.rs
@@ -338,8 +338,8 @@ fn create_object_doc(w: &mut dyn Write, env: &Env, info: &analysis::object::Info
                 .filter(|&tid| !env.type_status(&tid.full_name(&env.library)).ignored())
                 .map(|tid| {
                     format!(
-                        "[{name}](crate::{name})",
-                        name = env.library.type_(tid).get_name()
+                        "[`{0}`][struct@crate::{0}]",
+                        env.library.type_(tid).get_name()
                     )
                 })
                 .collect::<Vec<_>>();
@@ -773,11 +773,11 @@ fn get_type_trait_for_implements(env: &Env, tid: TypeId) -> String {
         format!("{}Ext", env.library.type_(tid).get_name())
     };
     if tid.ns_id == MAIN_NAMESPACE {
-        format!("[{name}](crate::prelude::{name})", name = &trait_name)
+        format!("[`{0}`][trait@crate::prelude::{0}]", trait_name)
     } else if let Some(symbol) = env.symbols.borrow().by_tid(tid) {
         let mut symbol = symbol.clone();
         symbol.make_trait(&trait_name);
-        format!("[{name}](trait@{name})", name = &symbol.full_rust_name())
+        format!("[`trait@{}`]", &symbol.full_rust_name())
     } else {
         error!("Type {} doesn't have crate", tid.full_name(&env.library));
         format!("`{}`", trait_name)
@@ -804,6 +804,6 @@ pub fn get_type_manual_traits_for_implements(
     manual_trait_iters
         .into_iter()
         .flatten()
-        .map(|name| format!("[{name}](trait@crate::prelude::{name})", name = name))
+        .map(|name| format!("[`{0}`][trait@crate::prelude::{0}]", name))
         .collect()
 }

--- a/src/codegen/enums.rs
+++ b/src/codegen/enums.rs
@@ -78,8 +78,7 @@ fn generate_enum(
     for member in &enum_.members {
         let member_config = config.members.matched(&member.name);
         let is_alias = member_config.iter().any(|m| m.alias);
-        let generate = member_config.iter().all(|m| m.status.need_generate());
-        if is_alias || !generate || vals.contains(&member.value) {
+        if is_alias || member.status.ignored() || vals.contains(&member.value) {
             continue;
         }
         vals.insert(member.value.clone());

--- a/src/codegen/flags.rs
+++ b/src/codegen/flags.rs
@@ -76,8 +76,7 @@ fn generate_flags(
     writeln!(w, "    pub struct {}: u32 {{", flags.name)?;
     for member in &flags.members {
         let member_config = config.members.matched(&member.name);
-        let generate = member_config.iter().all(|m| m.status.need_generate());
-        if !generate {
+        if member.status.ignored() {
             continue;
         }
 

--- a/src/library.rs
+++ b/src/library.rs
@@ -1,6 +1,6 @@
 use crate::{
-    analysis::conversion_type::ConversionType, env::Env, nameutil::split_namespace_name, traits::*,
-    version::Version,
+    analysis::conversion_type::ConversionType, config::gobjects::GStatus, env::Env,
+    nameutil::split_namespace_name, traits::*, version::Version,
 };
 use std::{
     cmp::{Ord, Ordering, PartialOrd},
@@ -376,6 +376,7 @@ pub struct Member {
     pub c_identifier: String,
     pub value: String,
     pub doc: Option<String>,
+    pub status: GStatus,
 }
 
 #[derive(Debug)]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -872,6 +872,7 @@ impl Library {
             value: value.into(),
             doc,
             c_identifier: c_identifier.unwrap_or_else(|| member_name.into()),
+            status: crate::config::gobjects::GStatus::Generate,
         })
     }
 


### PR DESCRIPTION
What does this PR do:

- Adds support of the news docs linking format used in GTK4 newer Pango/GdkPixbuf and other GTK specific libraries.
See https://gnome.pages.gitlab.gnome.org/gi-docgen/linking.html for the linking spec.

-  Switch to using analysis data instead of the symbols list for figuring out whether a function, object, enum member/bitfield variant should have a doc link which solves the broken doc links

- Handles Markdown codeblocks correctly as we now try to find items in a \`item\` situation and falls back to text language in case no language is defined so that doc tests can still pass.

The advantages of doing so are:
- Support of renamed functions
- Properly ignored enum members/flag variants are handled correctly
- No more #1140 
- Properly working links or nothing.

The disadvantages: 
- Bindings now have to be extra careful with their Gir.toml configurations as that defines what we can link to for the docs or not. Note that this is not super optimal and sometimes you have to duplicate things across multiple Gir.toml configurations. The only way forward to optimize that is by having a way to merge multiple configurations (say use Gio's configuration inside GTK 4 without having to duplicate all the manual/renamed/ and bunch of stuff from there). 
- The approach of abusing manual types by putting everything that comes from other crates on it isn't great, we probably want something like "external" for types that are defined elsewhere, along from where to look at their definitions. Related to the first point.
- Probably a bit slower to run because of all the search required to find the right types/the right methods. Especially when the link doesn't provide us with enough informations. But somehow Rust handles that pretty great and the "slowness" isn't that noticeable at all. It was tested on both GTK4 by me & GStreamer bindings by @MarijnS95 

Still TODO for the future:

- The regex for catching `#Item` can catch a URL such as `https://some-url.com/#info`, the same way the regex for catching `@item` can catch `some@email.com` but those are considered very low priority breakages for now compared to the fixes this PR brings in. Of course, they should be properly handled in the future but the possible solutions we have are pretty limited especially with `rust-regex` not supporting look-ahead/look-behind. Details in https://github.com/gtk-rs/gir/pull/1161#discussion_r640217460
- Functions ignored by gi-docgen because they can't be found are reformatted as `namespace::type::the_method()` but that makes the `FUNCTION` regex catches the items and they get checked again and they end up in a double "`" which slightly breaks the formatting. Again, requires a similar solution to the item in the point 1. 
- Figure out the whole merge different Gir configurations. 

Fixes #1109, #1140