### PR TITLE
codegen/doc: Use `[][]` for intradoc links instead of `[]()`

### DIFF
--- a/src/codegen/doc/format.rs
+++ b/src/codegen/doc/format.rs
@@ -100,7 +100,7 @@ fn replace_c_types(entry: &str, symbols: &symbols::Info, in_type: &str) -> Strin
             if sym.owner_name() == Some(in_type) {
                 // `#` or `%` symbols should probably have been `@` to denote
                 // that it is a reference within the current type.
-                format!("[`{f}()`](Self::{f}())", f = sym.name())
+                format!("[`{f}()`][Self::{f}()]", f = sym.name())
             } else {
                 match caps.get(1).as_ref().map(Match::as_str) {
                     // Catch invalid @ references that have a C symbol available but do not belong
@@ -113,7 +113,7 @@ fn replace_c_types(entry: &str, symbols: &symbols::Info, in_type: &str) -> Strin
                         in_type,
                     ),
                     Some("#") | None => {
-                        format!("[`{f}()`](crate::{f}())", f = sym.full_rust_name())
+                        format!("[`{f}()`][crate::{f}()]", f = sym.full_rust_name())
                     }
                     Some("%") => panic!("% not allowed for {:?}", caps),
                     Some(c) => panic!("Unknown symbol reference {}", c),
@@ -122,9 +122,9 @@ fn replace_c_types(entry: &str, symbols: &symbols::Info, in_type: &str) -> Strin
         } else if let Some(typ) = caps.get(2) {
             let typ = typ.as_str();
             if typ == in_type {
-                format!("[`{f}()`](Self::{f}())", f = name)
+                format!("[`{f}()`][Self::{f}()]", f = name)
             } else {
-                format!("[`{t}{f}()`](crate::{t}{f}())", t = typ, f = name)
+                format!("[`{t}{f}()`][crate::{t}{f}()]", t = typ, f = name)
             }
         } else {
             format!("`{}()`", name)
@@ -140,7 +140,7 @@ fn replace_c_types(entry: &str, symbols: &symbols::Info, in_type: &str) -> Strin
                 // `#` or `%` symbols should probably have been `@` to denote
                 // that it is a reference within the current type.
                 format!(
-                    "{}[`{n}{m}`](Self::{n}{m})",
+                    "{}[`{n}{m}`][Self::{n}{m}]",
                     &caps[1],
                     n = sym.name(),
                     m = member
@@ -162,7 +162,7 @@ fn replace_c_types(entry: &str, symbols: &symbols::Info, in_type: &str) -> Strin
                         format!("{}[`{}{}`]", &caps[1], sym.full_rust_name(), member)
                     }
                     "#" | "%" => format!(
-                        "{}[`{n}{m}`](crate::{n}{m})",
+                        "{}[`{n}{m}`][crate::{n}{m}]",
                         &caps[1],
                         n = sym.full_rust_name(),
                         m = member

--- a/src/codegen/doc/mod.rs
+++ b/src/codegen/doc/mod.rs
@@ -337,7 +337,12 @@ fn create_object_doc(w: &mut dyn Write, env: &Env, info: &analysis::object::Info
             let mut implementors = std::iter::once(info.type_id)
                 .chain(env.class_hierarchy.subtypes(info.type_id))
                 .filter(|&tid| !env.type_status(&tid.full_name(&env.library)).ignored())
-                .map(|tid| format!("[`struct@crate::{}`]", env.library.type_(tid).get_name()))
+                .map(|tid| {
+                    format!(
+                        "[`{n}`](struct@crate::{n})",
+                        n = env.library.type_(tid).get_name()
+                    )
+                })
                 .collect::<Vec<_>>();
             implementors.sort();
 
@@ -774,7 +779,7 @@ fn get_type_trait_for_implements(env: &Env, tid: TypeId) -> String {
         format!("{}Ext", env.library.type_(tid).get_name())
     };
     if tid.ns_id == MAIN_NAMESPACE {
-        format!("[`trait@crate::prelude::{}`]", &trait_name)
+        format!("[`{n}`](trait@crate::prelude::{n})", n = &trait_name)
     } else if let Some(symbol) = env.symbols.borrow().by_tid(tid) {
         let mut symbol = symbol.clone();
         symbol.make_trait(&trait_name);
@@ -805,6 +810,6 @@ pub fn get_type_manual_traits_for_implements(
     manual_trait_iters
         .into_iter()
         .flatten()
-        .map(|name| format!("[`trait@crate::prelude::{}`]", name))
+        .map(|name| format!("[`{n}`](trait@crate::prelude::{n})", n = name))
         .collect()
 }

--- a/src/codegen/doc/mod.rs
+++ b/src/codegen/doc/mod.rs
@@ -339,7 +339,7 @@ fn create_object_doc(w: &mut dyn Write, env: &Env, info: &analysis::object::Info
                 .filter(|&tid| !env.type_status(&tid.full_name(&env.library)).ignored())
                 .map(|tid| {
                     format!(
-                        "[`{n}`](struct@crate::{n})",
+                        "[`{n}`][struct@crate::{n}]",
                         n = env.library.type_(tid).get_name()
                     )
                 })
@@ -779,7 +779,7 @@ fn get_type_trait_for_implements(env: &Env, tid: TypeId) -> String {
         format!("{}Ext", env.library.type_(tid).get_name())
     };
     if tid.ns_id == MAIN_NAMESPACE {
-        format!("[`{n}`](trait@crate::prelude::{n})", n = &trait_name)
+        format!("[`{n}`][trait@crate::prelude::{n}]", n = &trait_name)
     } else if let Some(symbol) = env.symbols.borrow().by_tid(tid) {
         let mut symbol = symbol.clone();
         symbol.make_trait(&trait_name);
@@ -810,6 +810,6 @@ pub fn get_type_manual_traits_for_implements(
     manual_trait_iters
         .into_iter()
         .flatten()
-        .map(|name| format!("[`{n}`](trait@crate::prelude::{n})", n = name))
+        .map(|name| format!("[`{n}`][trait@crate::prelude::{n}]", n = name))
         .collect()
 }


### PR DESCRIPTION
As discussed in #1150, the slightly more complete version. We have #1161 in progress too, but getting this in first (and using the same format there) should make it _much_ easier to do a before-after diff on the generated docs.

---

Rustdoc treats `[foo]` as item path, and by the same rule `[fancy text][foo]` too.  Unlike `[]()`, which generates a dead link if the right-hand side is a valid Rust item path but doesn't exist in scope (common and unfortunately unavoidable with docs for C code auto-ported to Rust), the `[]` and `[][]` do not generate a link at all.