### PR TITLE
anlysis: Ignore per-type `ref_mode` override for input transfer-full

### DIFF
--- a/src/analysis/child_properties.rs
+++ b/src/analysis/child_properties.rs
@@ -100,7 +100,12 @@ fn analyze_property(
             imports.add_used_types(rust_type.used_types());
         }
 
-        let get_out_ref_mode = RefMode::of(env, typ, library::ParameterDirection::Return);
+        let get_out_ref_mode = RefMode::of(
+            env,
+            typ,
+            library::ParameterDirection::Return,
+            library::Transfer::None,
+        );
         if !is_getter_renamed {
             if let Ok(new_name) = getter_rules::try_rename_getter_suffix(
                 &getter_name,
@@ -110,7 +115,12 @@ fn analyze_property(
             }
         }
 
-        let mut set_in_ref_mode = RefMode::of(env, typ, library::ParameterDirection::In);
+        let mut set_in_ref_mode = RefMode::of(
+            env,
+            typ,
+            library::ParameterDirection::In,
+            library::Transfer::None,
+        );
         if set_in_ref_mode == RefMode::ByRefMut {
             set_in_ref_mode = RefMode::ByRef;
         }

--- a/src/analysis/properties.rs
+++ b/src/analysis/properties.rs
@@ -393,8 +393,18 @@ pub fn get_property_ref_modes(
     env: &Env,
     prop: &library::Property,
 ) -> (RefMode, RefMode, library::Nullable) {
-    let get_out_ref_mode = RefMode::of(env, prop.typ, library::ParameterDirection::Return);
-    let mut set_in_ref_mode = RefMode::of(env, prop.typ, library::ParameterDirection::In);
+    let get_out_ref_mode = RefMode::of(
+        env,
+        prop.typ,
+        library::ParameterDirection::Return,
+        library::Transfer::None,
+    );
+    let mut set_in_ref_mode = RefMode::of(
+        env,
+        prop.typ,
+        library::ParameterDirection::In,
+        library::Transfer::None,
+    );
     if set_in_ref_mode == RefMode::ByRefMut {
         set_in_ref_mode = RefMode::ByRef;
     }

--- a/src/analysis/ref_mode.rs
+++ b/src/analysis/ref_mode.rs
@@ -17,6 +17,7 @@ impl RefMode {
         env: &env::Env,
         tid: library::TypeId,
         direction: library::ParameterDirection,
+        transfer: library::Transfer,
     ) -> RefMode {
         let library = &env.library;
 
@@ -25,7 +26,7 @@ impl RefMode {
             ..
         }) = env.config.objects.get(&tid.full_name(library))
         {
-            if direction == library::ParameterDirection::In {
+            if direction == library::ParameterDirection::In && transfer != library::Transfer::Full {
                 return ref_mode;
             } else {
                 return RefMode::None;
@@ -67,7 +68,7 @@ impl RefMode {
                     RefMode::None
                 }
             }
-            Alias(alias) => RefMode::of(env, alias.typ, direction),
+            Alias(alias) => RefMode::of(env, alias.typ, direction, transfer),
             _ => RefMode::None,
         }
     }
@@ -79,7 +80,7 @@ impl RefMode {
         self_in_trait: bool,
     ) -> RefMode {
         use self::RefMode::*;
-        let ref_mode = RefMode::of(env, par.typ, par.direction);
+        let ref_mode = RefMode::of(env, par.typ, par.direction, par.transfer);
         match ref_mode {
             ByRefMut if !is_mut_ptr(&*par.c_type) => ByRef,
             ByRefMut if immutable => ByRefImmut,


### PR DESCRIPTION
This override is mainly used to turn common mutability issues for all parameters of a specific type down to immutable borrows when the underlying C source cannot be patched as it uses interior mutability for refcounting etc.

The override is only used in GStreamer, but is unfortunately applied in such a way that the few cases using `transfer-full` parameters also get their argument turned into a borrow, leading to incorrect API and
sometimes failed compilation when trait bounds can (logically) not be satisfied.  This is simply addressed by returning `RefMode::None` whenever an override is provided for an input parameter that happens to
be `transfer-full`.