### PR TITLE
enums,flags: Always analyze manual types

### DIFF
--- a/src/analysis/enums.rs
+++ b/src/analysis/enums.rs
@@ -25,14 +25,7 @@ impl Info {
 pub fn new(env: &Env, obj: &GObject, imports: &mut Imports) -> Option<Info> {
     info!("Analyzing enumeration {}", obj.name);
 
-    if !obj.status.need_generate() {
-        return None;
-    }
-
-    if !obj
-        .type_id
-        .map_or(false, |tid| tid.ns_id == namespaces::MAIN)
-    {
+    if obj.status.ignored() {
         return None;
     }
 
@@ -42,28 +35,30 @@ pub fn new(env: &Env, obj: &GObject, imports: &mut Imports) -> Option<Info> {
 
     let name = split_namespace_name(&obj.name).1;
 
-    // Mark the type as available within the enum namespace:
-    imports.add_defined(&format!("crate::{}", name));
+    if obj.status.need_generate() {
+        // Mark the type as available within the enum namespace:
+        imports.add_defined(&format!("crate::{}", name));
 
-    let imports = &mut imports.with_defaults(enumeration.version, &None);
-    imports.add("glib::translate::*");
+        let imports = &mut imports.with_defaults(enumeration.version, &None);
+        imports.add("glib::translate::*");
 
-    let has_get_quark = enumeration.error_domain.is_some();
-    if has_get_quark {
-        imports.add("glib::Quark");
-        imports.add("glib::error::ErrorDomain");
-    }
+        let has_get_quark = enumeration.error_domain.is_some();
+        if has_get_quark {
+            imports.add("glib::Quark");
+            imports.add("glib::error::ErrorDomain");
+        }
 
-    let has_get_type = enumeration.glib_get_type.is_some();
-    if has_get_type {
-        imports.add("glib::Type");
-        imports.add("glib::StaticType");
-        imports.add("glib::value::FromValue");
-        imports.add("glib::value::ToValue");
-    }
+        let has_get_type = enumeration.glib_get_type.is_some();
+        if has_get_type {
+            imports.add("glib::Type");
+            imports.add("glib::StaticType");
+            imports.add("glib::value::FromValue");
+            imports.add("glib::value::ToValue");
+        }
 
-    if obj.generate_display_trait {
-        imports.add("std::fmt");
+        if obj.generate_display_trait {
+            imports.add("std::fmt");
+        }
     }
 
     let mut functions = functions::analyze(

--- a/src/analysis/functions.rs
+++ b/src/analysis/functions.rs
@@ -130,7 +130,7 @@ pub fn analyze<F: Borrow<library::Function>>(
     'func: for func in functions {
         let func = func.borrow();
         let configured_functions = obj.functions.matched(&func.name);
-        let mut status = GStatus::Generate;
+        let mut status = obj.status;
         for f in configured_functions.iter() {
             match f.status {
                 GStatus::Ignore => continue 'func,

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -49,6 +49,7 @@ pub struct Analysis {
     pub records: BTreeMap<String, record::Info>,
     pub global_functions: Option<info_base::InfoBase>,
     pub constants: Vec<constants::Info>,
+
     pub enumerations: Vec<enums::Info>,
     pub enum_imports: Imports,
 

--- a/src/codegen/enums.rs
+++ b/src/codegen/enums.rs
@@ -21,7 +21,12 @@ use std::{
 };
 
 pub fn generate(env: &Env, root_path: &Path, mod_rs: &mut Vec<String>) {
-    if env.analysis.enumerations.is_empty() {
+    if !env
+        .analysis
+        .enumerations
+        .iter()
+        .any(|e| env.config.objects[&e.full_name].status.need_generate())
+    {
         return;
     }
 
@@ -34,6 +39,10 @@ pub fn generate(env: &Env, root_path: &Path, mod_rs: &mut Vec<String>) {
         mod_rs.push("\nmod enums;".into());
         for enum_analysis in &env.analysis.enumerations {
             let config = &env.config.objects[&enum_analysis.full_name];
+            if !config.status.need_generate() {
+                continue;
+            }
+
             let enum_ = enum_analysis.type_(&env.library);
 
             if let Some(cfg) = version_condition_string(env, enum_.version, false, 0) {

--- a/src/codegen/flags.rs
+++ b/src/codegen/flags.rs
@@ -18,7 +18,12 @@ use std::{
 };
 
 pub fn generate(env: &Env, root_path: &Path, mod_rs: &mut Vec<String>) {
-    if env.analysis.flags.is_empty() {
+    if !env
+        .analysis
+        .flags
+        .iter()
+        .any(|f| env.config.objects[&f.full_name].status.need_generate())
+    {
         return;
     }
 
@@ -31,6 +36,9 @@ pub fn generate(env: &Env, root_path: &Path, mod_rs: &mut Vec<String>) {
         mod_rs.push("\nmod flags;".into());
         for flags_analysis in &env.analysis.flags {
             let config = &env.config.objects[&flags_analysis.full_name];
+            if !config.status.need_generate() {
+                continue;
+            }
             let flags = flags_analysis.type_(&env.library);
 
             if let Some(cfg) = version_condition_string(env, flags.version, false, 0) {


### PR DESCRIPTION
Docs generation is going to look at analysis data to know what variants and functions are available on enums/flags.  External types (in the `manual = []` list) were previously omitted because of their status.  This changes enums and flags to behave like objects and records which only bail if the type is entirely ignored, and perform a `need_generate()` check at `codegen` instead.

Fixes: 50cee9e ("enums: Move rejection and glib imports from codegen to analysis")
Fixes: e549975 ("Copypaste enum analysis and function generation to bitfield")


---

CC @bilelmoussaoui, we're going to need this for #1161.