### PR TITLE
docs: filter out final types from implements trait list

### DIFF
--- a/src/codegen/doc/mod.rs
+++ b/src/codegen/doc/mod.rs
@@ -273,7 +273,10 @@ fn create_object_doc(w: &mut dyn Write, env: &Env, info: &analysis::object::Info
         let mut implements = impl_self
             .iter()
             .chain(env.class_hierarchy.supertypes(info.type_id))
-            .filter(|&tid| !env.type_status(&tid.full_name(&env.library)).ignored())
+            .filter(|&tid| {
+                !env.type_status(&tid.full_name(&env.library)).ignored()
+                    && !env.type_(*tid).is_final_type()
+            })
             .map(|&tid| get_type_trait_for_implements(env, tid))
             .collect::<Vec<_>>();
         implements.extend(manual_traits);


### PR DESCRIPTION
Because such traits don't exists for those types

Can be noticed in https://gtk-rs.org/gtk4-rs/git/docs/gsk4/struct.BlurNode.html where RenderNode is final (actually, it's fundamental, but marked as final on the gir config to avoid the usage of the `Ext` trait)

After the change, the generated doc is like this
```rust
glib::wrapper! {
    /// A render node applying a blur effect to its single child.
    #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
    pub struct BlurNode(Shared<ffi::GskBlurNode>);

    match fn {
        ref => |ptr| ffi::gsk_render_node_ref(ptr as *mut ffi::GskRenderNode),
        unref => |ptr| ffi::gsk_render_node_unref(ptr as *mut ffi::GskRenderNode),
    }
}
``` 
So no more invalid `Ext` traits :) 