### PR TITLE
enums,flags: Do not analyze imports if the type is not generated

### DIFF
--- a/src/analysis/enums.rs
+++ b/src/analysis/enums.rs
@@ -106,7 +106,9 @@ pub fn new(env: &Env, obj: &GObject, imports: &mut Imports) -> Option<Info> {
 
     let specials = special_functions::extract(&mut functions, type_, obj);
 
-    special_functions::analyze_imports(&specials, imports);
+    if obj.status.need_generate() {
+        special_functions::analyze_imports(&specials, imports);
+    }
 
     let info = Info {
         full_name: obj.name.clone(),

--- a/src/analysis/flags.rs
+++ b/src/analysis/flags.rs
@@ -101,7 +101,9 @@ pub fn new(env: &Env, obj: &GObject, imports: &mut Imports) -> Option<Info> {
 
     let specials = special_functions::extract(&mut functions, type_, obj);
 
-    special_functions::analyze_imports(&specials, imports);
+    if obj.status.need_generate() {
+        special_functions::analyze_imports(&specials, imports);
+    }
 
     let info = Info {
         full_name: obj.name.clone(),


### PR DESCRIPTION
Otherwise unused imports show up in the enums/flags files.

Fixes: 68591f1 ("enums,flags: Always analyze manual types")
