### PR TITLE
codegen/doc: Generate links for enum/flag functions/methods

### DIFF
--- a/src/analysis/functions.rs
+++ b/src/analysis/functions.rs
@@ -117,12 +117,11 @@ impl Info {
     }
 
     // returns whether the method can be linked in the docs
-    pub fn should_be_doc_linked<F: Fn(&Self) -> bool>(&self, env: &Env, search: F) -> bool {
+    pub fn should_be_doc_linked(&self, env: &Env) -> bool {
         !self.status.ignored()
             && (self.status.manual() || self.visibility.code_visible())
             && !self.is_special()
             && !self.is_async_finish(env)
-            && search(self)
     }
 
     pub fn doc_link(

--- a/src/codegen/doc/gi_docgen.rs
+++ b/src/codegen/doc/gi_docgen.rs
@@ -210,6 +210,8 @@ fn find_method_or_function_by_name(
         |f| f.name == mangle_keywords(name),
         |o| type_.map_or(true, |t| o.name == t),
         |r| type_.map_or(true, |t| r.name == t),
+        |e| type_.map_or(true, |t| e.name == t),
+        |f| type_.map_or(true, |t| f.name == t),
         is_class_method,
     )
 }


### PR DESCRIPTION
Depends on #1178.

Add the missing links (only one in GStreamer) to associated functions and methods on enumerations and flags.
