### PR TITLE
enum,flags: Take `version=` attribute in XML for members into account

### DIFF
--- a/src/codegen/enums.rs
+++ b/src/codegen/enums.rs
@@ -82,8 +82,14 @@ fn generate_enum(
             continue;
         }
         vals.insert(member.value.clone());
-        let deprecated_version = member_config.iter().find_map(|m| m.deprecated_version);
-        let version = member_config.iter().find_map(|m| m.version);
+        let deprecated_version = member_config
+            .iter()
+            .find_map(|m| m.deprecated_version)
+            .or(member.deprecated_version);
+        let version = member_config
+            .iter()
+            .find_map(|m| m.version)
+            .or(member.version);
         members.push(Member {
             name: enum_member_name(&member.name),
             c_name: member.c_identifier.clone(),

--- a/src/codegen/flags.rs
+++ b/src/codegen/flags.rs
@@ -81,8 +81,14 @@ fn generate_flags(
         }
 
         let name = bitfield_member_name(&member.name);
-        let deprecated_version = member_config.iter().find_map(|m| m.deprecated_version);
-        let version = member_config.iter().find_map(|m| m.version);
+        let deprecated_version = member_config
+            .iter()
+            .find_map(|m| m.deprecated_version)
+            .or(member.deprecated_version);
+        let version = member_config
+            .iter()
+            .find_map(|m| m.version)
+            .or(member.version);
         cfg_deprecated(w, env, deprecated_version, false, 2)?;
         version_condition(w, env, version, false, 2)?;
         if member.c_identifier != member.name {

--- a/src/codegen/sys/lib_.rs
+++ b/src/codegen/sys/lib_.rs
@@ -197,7 +197,10 @@ fn generate_bitfields(w: &mut dyn Write, env: &Env, items: &[&Bitfield]) -> Resu
                 .as_ref()
                 .map(|c| c.members.matched(&member.name))
                 .unwrap_or_else(Vec::new);
-            let version = member_config.iter().find_map(|m| m.version);
+            let version = member_config
+                .iter()
+                .find_map(|m| m.version)
+                .or(member.version);
 
             let val: i64 = member.value.parse().unwrap();
 
@@ -298,7 +301,10 @@ fn generate_enums(w: &mut dyn Write, env: &Env, items: &[&Enumeration]) -> Resul
                 .map(|c| c.members.matched(&member.name))
                 .unwrap_or_else(Vec::new);
             let is_alias = member_config.iter().any(|m| m.alias);
-            let version = member_config.iter().find_map(|m| m.version);
+            let version = member_config
+                .iter()
+                .find_map(|m| m.version)
+                .or(member.version);
 
             if is_alias {
                 continue;

--- a/src/library.rs
+++ b/src/library.rs
@@ -377,6 +377,8 @@ pub struct Member {
     pub value: String,
     pub doc: Option<String>,
     pub status: GStatus,
+    pub version: Option<Version>,
+    pub deprecated_version: Option<Version>,
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
`gir` XML contains `version=` attributes which are currently redefined manually in `Gir.toml`.  Propagate this info through to codegen to save all this redundant manual extra configuration.