### PR TITLE
Instead of taking an `&str` take `into<GString>`

### DIFF
--- a/src/analysis/child_properties.rs
+++ b/src/analysis/child_properties.rs
@@ -91,7 +91,7 @@ fn analyze_property(
         .and_then(|cp| cp.rename_getter.clone());
     let is_getter_renamed = getter_rename.is_some();
     let mut getter_name = getter_rename.unwrap_or_else(|| prop_name.clone());
-
+    eprintln!("AAA: {:?}", prop.type_name);
     if let Some(typ) = env.library.find_type(0, &prop.type_name) {
         let doc_hidden = prop.doc_hidden;
 
@@ -118,7 +118,8 @@ fn analyze_property(
 
         let mut bounds_str = String::new();
         let dir = ParameterDirection::In;
-        let set_params = if let Some(bound) = Bounds::type_for(env, typ, nullable) {
+
+        let set_params = if let Some(bound) = Bounds::type_for(env, typ, nullable, None) {
             let r_type = RustType::builder(env, typ)
                 .ref_mode(RefMode::ByRefFake)
                 .try_build()

--- a/src/analysis/class_builder.rs
+++ b/src/analysis/class_builder.rs
@@ -96,6 +96,8 @@ fn analyze_property(
         .or(prop.version)
         .or(Some(env.config.min_cfg_version));
 
+    eprintln!("BBB: {:?}", prop);
+
     let for_builder = prop.construct_only || prop.construct || prop.writable;
     if !for_builder {
         return None;
@@ -111,7 +113,7 @@ fn analyze_property(
     let (get_out_ref_mode, set_in_ref_mode, nullable) = get_property_ref_modes(env, prop);
 
     let mut bounds = Bounds::default();
-    if let Some(bound) = Bounds::type_for(env, prop.typ, nullable) {
+    if let Some(bound) = Bounds::type_for(env, prop.typ, nullable, prop.c_type.clone()) {
         imports.add("glib::object::IsA");
         bounds.add_parameter(&prop.name, &rust_type_res.into_string(), bound, false);
     }

--- a/src/analysis/functions.rs
+++ b/src/analysis/functions.rs
@@ -174,6 +174,7 @@ pub fn analyze<F: Borrow<library::Function>>(
 
     'func: for func in functions {
         let func = func.borrow();
+
         let configured_functions = obj.functions.matched(&func.name);
         let mut status = obj.status;
         for f in configured_functions.iter() {
@@ -542,6 +543,12 @@ fn analyze_function(
     configured_functions: &[&config::functions::Function],
     imports: &mut Imports,
 ) -> Info {
+    let debug = name == "set_text";
+    eprintln!("{}", func.name);
+    if debug {
+        eprintln!("{:?}", func);
+    }
+
     let r#async = func.parameters.iter().any(|parameter| {
         parameter.scope == ParameterScope::Async && parameter.c_type == "GAsyncReadyCallback"
     });
@@ -703,6 +710,10 @@ fn analyze_function(
                         used_types.extend(rust_type.into_used_types());
                     }
                 }
+                if debug {
+                    eprintln!("{:?}", par)
+                }
+
                 let (to_glib_extra, callback_info) = bounds.add_for_parameter(
                     env,
                     func,

--- a/src/analysis/rust_type.rs
+++ b/src/analysis/rust_type.rs
@@ -650,7 +650,7 @@ impl<'env> RustTypeBuilder<'env> {
             },
             CArray(..) | PtrArray(..) => match self.direction {
                 ParameterDirection::In | ParameterDirection::Out | ParameterDirection::Return => {
-                    rust_type
+                    rust_type.map_any(|rust_type| rust_type.format_parameter(self.direction))
                 }
                 _ => Err(TypeError::Unimplemented(into_inner(rust_type))),
             },

--- a/src/codegen/bound.rs
+++ b/src/codegen/bound.rs
@@ -83,7 +83,10 @@ impl Bound {
                     .or_else(|| Some(format!("'{}", lifetime)))
                     .unwrap_or_default();
 
-                format!("ToGlibPtr<{}, *{} libc::c_char>{}", lifetime, modif, post)
+                format!(
+                    "ToGlibPtr<{}, *{} libc::c_char> + ?Sized{}",
+                    lifetime, modif, post
+                )
             }
             BoundType::ToGlibPtr(_, None) => panic!("ToGlibPtr must have a lifetime"),
         }

--- a/src/codegen/function_body_chunk.rs
+++ b/src/codegen/function_body_chunk.rs
@@ -945,7 +945,7 @@ impl Builder {
             {
                 if let In = self.parameters[trans.ind_c] {
                     let value =
-                        Chunk::Custom(format!("{}.len() as {}", array_name, array_length_type));
+                        Chunk::Custom(format!("{}.len()/**/ as {}", array_name, array_length_type));
                     chunks.push(Chunk::Let {
                         name: array_length_name.clone(),
                         is_mut: false,

--- a/src/codegen/object.rs
+++ b/src/codegen/object.rs
@@ -210,6 +210,7 @@ fn generate_builder(w: &mut dyn Write, env: &Env, analysis: &analysis::object::I
         analysis.name,
     )?;
     writeln!(w, "pub struct {}Builder {{", analysis.name)?;
+
     for property in &analysis.builder_properties {
         match RustType::try_new(env, property.typ) {
             Ok(type_string) => {
@@ -223,6 +224,7 @@ fn generate_builder(w: &mut dyn Write, env: &Env, analysis: &analysis::object::I
                 } else {
                     library::ParameterDirection::Out
                 };
+
                 let mut param_type = RustType::builder(env, property.typ)
                     .direction(direction)
                     .ref_mode(property.set_in_ref_mode)
@@ -241,6 +243,7 @@ fn generate_builder(w: &mut dyn Write, env: &Env, analysis: &analysis::object::I
                                     bound.full_type_parameter_reference(
                                         RefMode::ByRef,
                                         Nullable(false),
+                                        false,
                                     )
                                 });
                         (alias, bounds, ".clone().upcast()")

--- a/src/codegen/object.rs
+++ b/src/codegen/object.rs
@@ -230,8 +230,13 @@ fn generate_builder(w: &mut dyn Write, env: &Env, analysis: &analysis::object::I
                     .ref_mode(property.set_in_ref_mode)
                     .try_build()
                     .into_string();
+                eprintln!("RIP: {}", &param_type[..]);
                 let (param_type_override, bounds, conversion) = match &param_type[..] {
-                    "&str" => (None, String::new(), ".to_string()"),
+                    typ if nameutil::is_gstring(typ) && property.set_in_ref_mode.is_ref() => (
+                        Some("P".to_string()),
+                        "<P: Into<glib::GString>>".to_string(),
+                        ".into().to_string()",
+                    ),
                     "&[&str]" => (Some("Vec<String>".to_string()), String::new(), ""),
                     _ if !property.bounds.is_empty() => {
                         let (bounds, _) = function::bounds(&property.bounds, &[], false, false);

--- a/src/codegen/parameter.rs
+++ b/src/codegen/parameter.rs
@@ -8,16 +8,18 @@ use crate::{
 };
 
 pub trait ToParameter {
-    fn to_parameter(&self, env: &Env, bounds: &Bounds) -> String;
+    fn to_parameter(&self, env: &Env, bounds: &Bounds, r#async: bool) -> String;
 }
 
 impl ToParameter for CParameter {
-    fn to_parameter(&self, env: &Env, bounds: &Bounds) -> String {
+    fn to_parameter(&self, env: &Env, bounds: &Bounds, r#async: bool) -> String {
         if self.instance_parameter {
             format!("{}self", self.ref_mode.for_rust_type())
         } else {
             let type_str = match bounds.get_parameter_bound(&self.name) {
-                Some(bound) => bound.full_type_parameter_reference(self.ref_mode, self.nullable),
+                Some(bound) => {
+                    bound.full_type_parameter_reference(self.ref_mode, self.nullable, r#async)
+                }
                 None => {
                     let type_name = RustType::builder(env, self.typ)
                         .direction(self.direction)

--- a/src/codegen/sys/functions.rs
+++ b/src/codegen/sys/functions.rs
@@ -262,7 +262,7 @@ fn generate_object_funcs(
             version_condition(w, env, version, commented, 1)?;
         }
         generate_cfg_configure(w, &configured_functions, commented)?;
-        writeln!(w, "    {}pub fn {}{};", comment, name, sig)?;
+        writeln!(w, "    /*BO*/{}pub fn {}{};", comment, name, sig)?;
     }
 
     Ok(())

--- a/src/codegen/trampoline.rs
+++ b/src/codegen/trampoline.rs
@@ -9,7 +9,7 @@ use crate::{
     },
     consts::TYPE_PARAMETERS_START,
     env::Env,
-    library,
+    library::{self},
     nameutil::{use_glib_if_needed, use_gtk_type},
     traits::IntoString,
     writer::primitives::tabs,
@@ -108,14 +108,14 @@ fn func_parameters(
             }
         }
 
-        let s = func_parameter(env, par, &analysis.bounds);
+        let s = func_parameter(env, par, &analysis.bounds, true);
         param_str.push_str(&s);
     }
 
     param_str
 }
 
-fn func_parameter(env: &Env, par: &RustParameter, bounds: &Bounds) -> String {
+fn func_parameter(env: &Env, par: &RustParameter, bounds: &Bounds, r#async: bool) -> String {
     //TODO: restore mutable support
     let ref_mode = if par.ref_mode == RefMode::ByRefMut {
         RefMode::ByRef
@@ -124,7 +124,7 @@ fn func_parameter(env: &Env, par: &RustParameter, bounds: &Bounds) -> String {
     };
 
     match bounds.get_parameter_bound(&par.name) {
-        Some(bound) => bound.full_type_parameter_reference(ref_mode, par.nullable),
+        Some(bound) => bound.full_type_parameter_reference(ref_mode, par.nullable, r#async),
         None => RustType::builder(env, par.typ)
             .direction(par.direction)
             .nullable(par.nullable)

--- a/src/codegen/trampoline.rs
+++ b/src/codegen/trampoline.rs
@@ -79,7 +79,9 @@ pub fn func_string(
 
         format!(
             "Fn({}){}{} + 'static",
-            param_str, return_str, concurrency_str
+            param_str.replace("glib::GString", "&str"),
+            return_str,
+            concurrency_str
         )
     } else {
         format!("({}){}", param_str, return_str,)

--- a/src/codegen/trampoline_from_glib.rs
+++ b/src/codegen/trampoline_from_glib.rs
@@ -30,16 +30,16 @@ impl TrampolineFromGlib for Transformation {
                     }
                 }
 
-                if !nullable {
-                    left = format!("&{}", left);
-                } else if nullable && is_borrow {
+                if nullable && is_borrow {
                     if is_gstring(&type_name) {
                         right = format!("{}.as_ref().as_deref()", right);
                     } else {
                         right = format!("{}.as_ref().as_ref()", right);
                     }
                 } else if is_gstring(&type_name) {
-                    right = format!("{}.as_deref()", right);
+                    left = format!("&*{}", left);
+                } else if !nullable {
+                    left = format!("&{}", left);
                 } else {
                     right = format!("{}.as_ref()", right);
                 }


### PR DESCRIPTION
This should be completely compatible with the old generated code, however I have not looked at all cases. Cases I did explicitly look at are:

 * `&str` parameters
 * `Option<&str>` parameters
 * function parameters that take `&str` still take `&str`

It would be ideal if there was some kind of `&GStr`, to avoid hacking around `ref_mode` like in this patch. 