### PR TITLE
Rust 1.53: Use the new nested or_patterns

### DIFF
--- a/src/analysis/bounds.rs
+++ b/src/analysis/bounds.rs
@@ -167,9 +167,7 @@ impl Bounds {
     pub fn type_for(env: &Env, type_id: TypeId, nullable: Nullable) -> Option<BoundType> {
         use self::BoundType::*;
         match env.library.type_(type_id) {
-            Type::Fundamental(Fundamental::Filename) => Some(AsRef(None)),
-            Type::Fundamental(Fundamental::OsString) => Some(AsRef(None)),
-            Type::Fundamental(Fundamental::Utf8) if *nullable => None,
+            Type::Fundamental(Fundamental::Filename | Fundamental::OsString) => Some(AsRef(None)),
             Type::Class(Class {
                 final_type: true, ..
             }) => None,

--- a/src/analysis/function_parameters.rs
+++ b/src/analysis/function_parameters.rs
@@ -452,13 +452,11 @@ fn is_length(par: &library::Parameter) -> bool {
 }
 
 fn has_length(env: &Env, typ: TypeId) -> bool {
+    use crate::library::Fundamental::*;
     use crate::library::Type;
     let typ = env.library.type_(typ);
     match typ {
-        Type::Fundamental(fund) => {
-            use crate::library::Fundamental::*;
-            matches!(fund, Utf8 | Filename | OsString)
-        }
+        Type::Fundamental(Utf8 | Filename | OsString) => true,
         Type::CArray(..)
         | Type::FixedArray(..)
         | Type::Array(..)

--- a/src/analysis/override_string_type.rs
+++ b/src/analysis/override_string_type.rs
@@ -35,9 +35,9 @@ fn apply(env: &Env, type_id: TypeId, string_type: Option<config::StringType>) ->
         }
     };
     match *env.library.type_(type_id) {
-        Type::Fundamental(Fundamental::Filename) => replace,
-        Type::Fundamental(Fundamental::OsString) => replace,
-        Type::Fundamental(Fundamental::Utf8) => replace,
+        Type::Fundamental(Fundamental::Filename | Fundamental::OsString | Fundamental::Utf8) => {
+            replace
+        }
         Type::CArray(inner_tid) if can_overriden_fundamental(env, inner_tid) => {
             Type::find_c_array(&env.library, replace, None)
         }
@@ -54,8 +54,6 @@ fn apply(env: &Env, type_id: TypeId, string_type: Option<config::StringType>) ->
 fn can_overriden_fundamental(env: &Env, type_id: TypeId) -> bool {
     matches!(
         *env.library.type_(type_id),
-        Type::Fundamental(Fundamental::Filename)
-            | Type::Fundamental(Fundamental::OsString)
-            | Type::Fundamental(Fundamental::Utf8)
+        Type::Fundamental(Fundamental::Filename | Fundamental::OsString | Fundamental::Utf8)
     )
 }

--- a/src/analysis/ref_mode.rs
+++ b/src/analysis/ref_mode.rs
@@ -34,9 +34,11 @@ impl RefMode {
 
         use crate::library::Type::*;
         match library.type_(tid) {
-            Fundamental(library::Fundamental::Utf8)
-            | Fundamental(library::Fundamental::Filename)
-            | Fundamental(library::Fundamental::OsString)
+            Fundamental(
+                library::Fundamental::Utf8
+                | library::Fundamental::Filename
+                | library::Fundamental::OsString,
+            )
             | Class(..)
             | Interface(..)
             | List(..)

--- a/src/analysis/rust_type.rs
+++ b/src/analysis/rust_type.rs
@@ -149,7 +149,7 @@ fn into_inner(res: Result) -> String {
     use self::TypeError::*;
     match res {
         Ok(rust_type) => rust_type.into_string(),
-        Err(Ignored(s)) | Err(Mismatch(s)) | Err(Unimplemented(s)) => s,
+        Err(Ignored(s) | Mismatch(s) | Unimplemented(s)) => s,
     }
 }
 
@@ -599,12 +599,13 @@ impl<'env> RustTypeBuilder<'env> {
             .try_from_glib(&self.try_from_glib)
             .try_build();
         match type_ {
-            Fundamental(library::Fundamental::Utf8)
-            | Fundamental(library::Fundamental::OsString)
-            | Fundamental(library::Fundamental::Filename)
-                if (self.direction == ParameterDirection::InOut
-                    || (self.direction == ParameterDirection::Out
-                        && self.ref_mode == RefMode::ByRefMut)) =>
+            Fundamental(
+                library::Fundamental::Utf8
+                | library::Fundamental::OsString
+                | library::Fundamental::Filename,
+            ) if (self.direction == ParameterDirection::InOut
+                || (self.direction == ParameterDirection::Out
+                    && self.ref_mode == RefMode::ByRefMut)) =>
             {
                 Err(TypeError::Unimplemented(into_inner(rust_type)))
             }

--- a/src/analysis/types.rs
+++ b/src/analysis/types.rs
@@ -134,8 +134,7 @@ impl IsIncomplete for Function {
         self.parameters.iter().any(|p| {
             matches!(
                 lib.type_(p.typ),
-                Type::Fundamental(Fundamental::Unsupported)
-                    | Type::Fundamental(Fundamental::VarArgs)
+                Type::Fundamental(Fundamental::Unsupported | Fundamental::VarArgs)
             )
         })
     }

--- a/src/codegen/function.rs
+++ b/src/codegen/function.rs
@@ -248,7 +248,7 @@ pub fn bounds(
         .iter()
         .filter(|bound| skip.contains(&bound.alias))
         .filter_map(|bound| match bound.bound_type {
-            IsA(Some(lifetime)) | AsRef(Some(lifetime)) => Some(lifetime),
+            IsA(lifetime) | AsRef(lifetime) => lifetime,
             _ => None,
         })
         .collect::<Vec<_>>();

--- a/src/codegen/function_body_chunk.rs
+++ b/src/codegen/function_body_chunk.rs
@@ -1263,9 +1263,11 @@ fn c_type_mem_mode_lib(
                 use crate::library::Type::*;
                 let type_ = env.library.type_(typ);
                 match type_ {
-                    Fundamental(library::Fundamental::Utf8)
-                    | Fundamental(library::Fundamental::OsString)
-                    | Fundamental(library::Fundamental::Filename) => {
+                    Fundamental(
+                        library::Fundamental::Utf8
+                        | library::Fundamental::OsString
+                        | library::Fundamental::Filename,
+                    ) => {
                         if transfer == library::Transfer::Full {
                             NullMutPtr
                         } else {
@@ -1300,9 +1302,11 @@ fn type_mem_mode(env: &Env, parameter: &library::Parameter) -> Chunk {
                 use crate::library::Type::*;
                 let type_ = env.library.type_(parameter.typ);
                 match type_ {
-                    Fundamental(library::Fundamental::Utf8)
-                    | Fundamental(library::Fundamental::OsString)
-                    | Fundamental(library::Fundamental::Filename) => {
+                    Fundamental(
+                        library::Fundamental::Utf8
+                        | library::Fundamental::OsString
+                        | library::Fundamental::Filename,
+                    ) => {
                         if parameter.transfer == library::Transfer::Full {
                             Chunk::NullMutPtr
                         } else {

--- a/src/codegen/trampoline_from_glib.rs
+++ b/src/codegen/trampoline_from_glib.rs
@@ -70,10 +70,7 @@ pub fn from_glib_xxx(transfer: library::Transfer, is_borrow: bool) -> (String, S
 fn is_need_type_name(env: &Env, type_id: library::TypeId) -> bool {
     if type_id.ns_id == library::INTERNAL_NAMESPACE {
         use crate::library::{Fundamental::*, Type::*};
-        matches!(
-            env.type_(type_id),
-            Fundamental(Utf8) | Fundamental(Filename) | Fundamental(OsString)
-        )
+        matches!(env.type_(type_id), Fundamental(Utf8 | Filename | OsString))
     } else {
         false
     }

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -26,7 +26,7 @@ fn normalize_path(path: impl AsRef<Path>) -> PathBuf {
     for component in path.as_ref().components() {
         match (component, parts.last()) {
             (Component::CurDir, _) | (Component::ParentDir, Some(Component::RootDir)) => {}
-            (Component::ParentDir, None) | (Component::ParentDir, Some(Component::ParentDir)) => {
+            (Component::ParentDir, None | Some(Component::ParentDir)) => {
                 parts.push(Component::ParentDir)
             }
             (Component::ParentDir, Some(_)) => {

--- a/src/config/functions.rs
+++ b/src/config/functions.rs
@@ -542,16 +542,16 @@ const = true
         let pars = f.parameters;
         assert_eq!(pars.len(), 4);
         assert_eq!(pars[0].ident, Ident::Name("par1".into()));
-        assert_eq!(pars[0].constant, false);
+        assert!(!pars[0].constant);
         assert_eq!(pars[0].nullable, None);
         assert_eq!(pars[1].ident, Ident::Name("par2".into()));
-        assert_eq!(pars[1].constant, false);
+        assert!(!pars[1].constant);
         assert_eq!(pars[1].nullable, Some(Nullable(false)));
         assert_eq!(pars[2].ident, Ident::Name("par3".into()));
-        assert_eq!(pars[2].constant, true);
+        assert!(pars[2].constant);
         assert_eq!(pars[2].nullable, Some(Nullable(true)));
         assert!(matches!(pars[3].ident, Ident::Pattern(_)));
-        assert_eq!(pars[3].constant, true);
+        assert!(pars[3].constant);
         assert_eq!(pars[3].nullable, None);
     }
 

--- a/src/config/members.rs
+++ b/src/config/members.rs
@@ -118,7 +118,7 @@ alias = true
         );
         let f = Member::parse(&toml, "a").unwrap();
         assert_eq!(f.ident, Ident::Name("name1".into()));
-        assert_eq!(f.alias, true);
+        assert!(f.alias);
     }
 
     #[test]

--- a/src/xmlparser.rs
+++ b/src/xmlparser.rs
@@ -214,7 +214,7 @@ impl<'a> XmlParser<'a> {
         loop {
             match self.parser.next() {
                 // Ignore whitespace and comments by default.
-                Ok(XmlEvent::Whitespace(..)) | Ok(XmlEvent::Comment(..)) => continue,
+                Ok(XmlEvent::Whitespace(..) | XmlEvent::Comment(..)) => continue,
                 Ok(event) => return Ok(event),
                 Err(e) => return Err(self.error_emitter.emit_error(&e)),
             }


### PR DESCRIPTION
https://blog.rust-lang.org/2021/06/17/Rust-1.53.0.html :shark: 

Previously `|` was only allowed in the top-level of patterns, requiring the circumfering enum variant (usually something wrapped in `Some`, and in `gir` `Type::Fundamental` is common) to be repeated for every inner variant that's matched against.  Not anymore, since 1.53 it is now possible to write `|` within a single variant instead of repeating it many times.