### PR TITLE
Remove the `links` annotations

### DIFF
--- a/src/codegen/sys/cargo_toml.rs
+++ b/src/codegen/sys/cargo_toml.rs
@@ -36,11 +36,6 @@ fn fill_empty(root: &mut Table, env: &Env, crate_name: &str) {
         let package = upsert_table(root, "package");
         set_string(package, "name", package_name);
         set_string(package, "version", "0.0.1");
-        set_string(
-            package,
-            "links",
-            nameutil::shared_libs_to_links(&env.namespaces.main().shared_libs),
-        );
         set_string(package, "edition", "2018");
     }
 

--- a/src/nameutil.rs
+++ b/src/nameutil.rs
@@ -139,17 +139,6 @@ pub fn shared_lib_name_to_link_name(name: &str) -> &str {
     s
 }
 
-pub fn shared_libs_to_links(shared_libs: &[String]) -> String {
-    // https://github.com/rust-lang/cargo/issues/4533
-    // links = ["foo", "bar"] or ['foo', 'bar'] is not supported.
-    // Pick the first element
-    if let Some(shared_lib) = shared_libs.get(0) {
-        return format!("\"{}\"", shared_lib_name_to_link_name(shared_lib));
-    }
-
-    panic!("empty list of shared library");
-}
-
 pub fn use_glib_type(env: &crate::env::Env, import: &str) -> String {
     format!(
         "{}::{}",
@@ -265,26 +254,5 @@ mod tests {
             shared_lib_name_to_link_name("libgdk_pixbuf-2.0.so.0"),
             "gdk_pixbuf-2.0"
         );
-    }
-
-    #[test]
-    fn shared_libs_to_links_works() {
-        let libs = vec![
-            String::from("libgobject-2.0.so.0"),
-            String::from("libglib-2.0.so.0"),
-        ];
-        // https://github.com/rust-lang/cargo/issues/4533
-        // list is not supported. Pick the first one
-        assert_eq!(shared_libs_to_links(&libs), "\"gobject-2.0\"");
-
-        let libs = vec![String::from("libgio-2.0.so.0")];
-        assert_eq!(shared_libs_to_links(&libs), "\"gio-2.0\"");
-    }
-
-    #[test]
-    #[should_panic]
-    fn shared_libs_to_links_panic() {
-        let libs = vec![];
-        shared_libs_to_links(&libs);
     }
 }

--- a/tests/sys/atk-sys/Cargo.toml
+++ b/tests/sys/atk-sys/Cargo.toml
@@ -31,7 +31,6 @@ name = "atk_sys"
 
 [package]
 build = "build.rs"
-links = "atk"
 name = "atk-sys"
 version = "0.2.0"
 edition = "2018"

--- a/tests/sys/gdk-pixbuf-sys/Cargo.toml
+++ b/tests/sys/gdk-pixbuf-sys/Cargo.toml
@@ -29,7 +29,6 @@ name = "gdk_pixbuf_sys"
 
 [package]
 build = "build.rs"
-links = "gdk_pixbuf"
 name = "gdk-pixbuf-sys"
 version = "0.2.0"
 edition = "2018"

--- a/tests/sys/gdk-sys/Cargo.toml
+++ b/tests/sys/gdk-sys/Cargo.toml
@@ -42,7 +42,6 @@ name = "gdk_sys"
 
 [package]
 build = "build.rs"
-links = "gdk"
 name = "gdk-sys"
 version = "0.2.0"
 edition = "2018"

--- a/tests/sys/gio-sys/Cargo.toml
+++ b/tests/sys/gio-sys/Cargo.toml
@@ -37,7 +37,6 @@ name = "gio_sys"
 
 [package]
 build = "build.rs"
-links = "gio"
 name = "gio-sys"
 version = "0.2.0"
 edition = "2018"

--- a/tests/sys/glib-sys/Cargo.toml
+++ b/tests/sys/glib-sys/Cargo.toml
@@ -30,7 +30,6 @@ name = "glib_sys"
 
 [package]
 build = "build.rs"
-links = "glib"
 name = "glib-sys"
 version = "0.2.0"
 edition = "2018"

--- a/tests/sys/gobject-sys/Cargo.toml
+++ b/tests/sys/gobject-sys/Cargo.toml
@@ -27,7 +27,6 @@ name = "gobject_sys"
 
 [package]
 build = "build.rs"
-links = "gobject"
 name = "gobject-sys"
 version = "0.2.0"
 edition = "2018"

--- a/tests/sys/gtk-sys/Cargo.toml
+++ b/tests/sys/gtk-sys/Cargo.toml
@@ -55,7 +55,6 @@ name = "gtk_sys"
 
 [package]
 build = "build.rs"
-links = "gtk"
 name = "gtk-sys"
 version = "0.2.0"
 edition = "2018"

--- a/tests/sys/pango-sys/Cargo.toml
+++ b/tests/sys/pango-sys/Cargo.toml
@@ -29,7 +29,6 @@ name = "pango_sys"
 
 [package]
 build = "build.rs"
-links = "pango"
 name = "pango-sys"
 version = "0.2.0"
 edition = "2018"

--- a/tests/sys/secret-sys/Cargo.toml
+++ b/tests/sys/secret-sys/Cargo.toml
@@ -25,7 +25,6 @@ name = "secret_sys"
 
 [package]
 build = "build.rs"
-links = "secret"
 name = "secret-sys"
 version = "0.2.0"
 edition = "2018"


### PR DESCRIPTION
The `links` annotation in `Cargo.toml` is intended to ensure that in the
crate graph there's at most one crate that's an implementation of
some sort concept.

This can make sense in some scenarios, most prominent of which is when
the crate defines `#[no_mangle]` symbols (e.g. by compiling a vendored C
library.) In that situation linking a binary that depends on two
versions of the library cannot work because of colliding symbol names.

There does not appear to be a similar reason to impose such a
restriction on the users of gir-generated bindings, however. All of
the generated crates link to a system library, they do not define any
`#[no_mangle]` symbols nor they vendor/build C libraries as part of
their build process.  Most likely all the different versions of the
bindings will link to the exact same system library too.