### PR TITLE
codegen/flags: Put doc attribute on struct instead of macro calls

### DIFF
--- a/src/codegen/constants.rs
+++ b/src/codegen/constants.rs
@@ -30,7 +30,7 @@ pub fn generate(env: &Env, root_path: &Path, mod_rs: &mut Vec<String>) {
             let type_ = env.type_(constant.typ);
             if let library::Type::Fundamental(library::Fundamental::Utf8) = type_ {
                 cfg_deprecated(w, env, constant.deprecated_version, false, 0)?;
-                cfg_condition(w, &constant.cfg_condition, false, 0)?;
+                cfg_condition(w, constant.cfg_condition.as_ref(), false, 0)?;
                 version_condition(w, env, constant.version, false, 0)?;
                 doc_alias(w, &constant.glib_name, "", 0)?;
                 writeln!(

--- a/src/codegen/enums.rs
+++ b/src/codegen/enums.rs
@@ -48,7 +48,7 @@ pub fn generate(env: &Env, root_path: &Path, mod_rs: &mut Vec<String>) {
             if let Some(cfg) = version_condition_string(env, enum_.version, false, 0) {
                 mod_rs.push(cfg);
             }
-            if let Some(cfg) = cfg_condition_string(&config.cfg_condition, false, 0) {
+            if let Some(cfg) = cfg_condition_string(config.cfg_condition.as_ref(), false, 0) {
                 mod_rs.push(cfg);
             }
             mod_rs.push(format!("pub use self::enums::{};", enum_.name));
@@ -106,7 +106,7 @@ fn generate_enum(
 
     cfg_deprecated(w, env, enum_.deprecated_version, false, 0)?;
     version_condition(w, env, enum_.version, false, 0)?;
-    cfg_condition(w, &config.cfg_condition, false, 0)?;
+    cfg_condition(w, config.cfg_condition.as_ref(), false, 0)?;
     if config.must_use {
         writeln!(w, "#[must_use]")?;
     }
@@ -124,7 +124,7 @@ fn generate_enum(
     for member in &members {
         cfg_deprecated(w, env, member.deprecated_version, false, 1)?;
         version_condition(w, env, member.version, false, 1)?;
-        cfg_condition(w, &member.cfg_condition, false, 1)?;
+        cfg_condition(w, member.cfg_condition.as_ref(), false, 1)?;
         // Don't generate a doc_alias if the C name is the same as the Rust one
         if member.c_name != member.name {
             doc_alias(w, &member.c_name, "", 1)?;
@@ -148,7 +148,7 @@ fn generate_enum(
     if !functions.is_empty() {
         writeln!(w)?;
         version_condition(w, env, enum_.version, false, 0)?;
-        cfg_condition_no_doc(w, &config.cfg_condition.as_ref(), false, 0)?;
+        cfg_condition_no_doc(w, config.cfg_condition.as_ref(), false, 0)?;
         write!(w, "impl {} {{", analysis.name)?;
         for func_analysis in functions {
             function::generate(
@@ -173,7 +173,7 @@ fn generate_enum(
         &analysis.specials,
         None,
         None,
-        &config.cfg_condition.as_ref(),
+        config.cfg_condition.as_ref(),
     )?;
 
     writeln!(w)?;
@@ -181,7 +181,7 @@ fn generate_enum(
     if config.generate_display_trait && !analysis.specials.has_trait(Type::Display) {
         // Generate Display trait implementation.
         version_condition(w, env, enum_.version, false, 0)?;
-        cfg_condition_no_doc(w, &config.cfg_condition.as_ref(), false, 0)?;
+        cfg_condition_no_doc(w, config.cfg_condition.as_ref(), false, 0)?;
         writeln!(
             w,
             "impl fmt::Display for {0} {{\n\
@@ -191,7 +191,7 @@ fn generate_enum(
         )?;
         for member in &members {
             version_condition_no_doc(w, env, member.version, false, 3)?;
-            cfg_condition_no_doc(w, &member.cfg_condition, false, 3)?;
+            cfg_condition_no_doc(w, member.cfg_condition.as_ref(), false, 3)?;
             writeln!(w, "\t\t\tSelf::{0} => \"{0}\",", member.name)?;
         }
         writeln!(
@@ -205,7 +205,7 @@ fn generate_enum(
 
     // Generate IntoGlib trait implementation.
     version_condition(w, env, enum_.version, false, 0)?;
-    cfg_condition_no_doc(w, &config.cfg_condition.as_ref(), false, 0)?;
+    cfg_condition_no_doc(w, config.cfg_condition.as_ref(), false, 0)?;
     writeln!(
         w,
         "#[doc(hidden)]
@@ -220,7 +220,7 @@ impl IntoGlib for {name} {{
     )?;
     for member in &members {
         version_condition_no_doc(w, env, member.version, false, 3)?;
-        cfg_condition_no_doc(w, &member.cfg_condition, false, 3)?;
+        cfg_condition_no_doc(w, member.cfg_condition.as_ref(), false, 3)?;
         writeln!(
             w,
             "\t\t\tSelf::{} => {}::{},",
@@ -245,7 +245,7 @@ impl IntoGlib for {name} {{
 
     // Generate FromGlib trait implementation.
     version_condition(w, env, enum_.version, false, 0)?;
-    cfg_condition_no_doc(w, &config.cfg_condition.as_ref(), false, 0)?;
+    cfg_condition_no_doc(w, config.cfg_condition.as_ref(), false, 0)?;
     writeln!(
         w,
         "#[doc(hidden)]
@@ -259,7 +259,7 @@ impl FromGlib<{sys_crate_name}::{ffi_name}> for {name} {{
     )?;
     for member in &members {
         version_condition_no_doc(w, env, member.version, false, 3)?;
-        cfg_condition_no_doc(w, &member.cfg_condition, false, 3)?;
+        cfg_condition_no_doc(w, member.cfg_condition.as_ref(), false, 3)?;
         writeln!(
             w,
             "\t\t\t{}::{} => Self::{},",
@@ -281,7 +281,7 @@ impl FromGlib<{sys_crate_name}::{ffi_name}> for {name} {{
         let has_failed_member = members.iter().any(|m| m.name == "Failed");
 
         version_condition(w, env, enum_.version, false, 0)?;
-        cfg_condition_no_doc(w, &config.cfg_condition.as_ref(), false, 0)?;
+        cfg_condition_no_doc(w, config.cfg_condition.as_ref(), false, 0)?;
         writeln!(
             w,
             "impl ErrorDomain for {name} {{
@@ -328,7 +328,7 @@ impl FromGlib<{sys_crate_name}::{ffi_name}> for {name} {{
 
         for member in &members {
             version_condition_no_doc(w, env, member.version, false, 3)?;
-            cfg_condition_no_doc(w, &member.cfg_condition, false, 3)?;
+            cfg_condition_no_doc(w, member.cfg_condition.as_ref(), false, 3)?;
             writeln!(
                 w,
                 "\t\t\t{}::{} => Some(Self::{}),",
@@ -360,7 +360,7 @@ impl FromGlib<{sys_crate_name}::{ffi_name}> for {name} {{
             .flatten();
 
         version_condition(w, env, version, false, 0)?;
-        cfg_condition_no_doc(w, &config.cfg_condition.as_ref(), false, 0)?;
+        cfg_condition_no_doc(w, config.cfg_condition.as_ref(), false, 0)?;
         writeln!(
             w,
             "impl StaticType for {name} {{
@@ -375,7 +375,7 @@ impl FromGlib<{sys_crate_name}::{ffi_name}> for {name} {{
         writeln!(w)?;
 
         version_condition(w, env, version, false, 0)?;
-        cfg_condition_no_doc(w, &config.cfg_condition.as_ref(), false, 0)?;
+        cfg_condition_no_doc(w, config.cfg_condition.as_ref(), false, 0)?;
         writeln!(
             w,
             "impl {valuetype} for {name} {{
@@ -387,7 +387,7 @@ impl FromGlib<{sys_crate_name}::{ffi_name}> for {name} {{
         writeln!(w)?;
 
         version_condition(w, env, version, false, 0)?;
-        cfg_condition_no_doc(w, &config.cfg_condition.as_ref(), false, 0)?;
+        cfg_condition_no_doc(w, config.cfg_condition.as_ref(), false, 0)?;
         writeln!(
             w,
             "unsafe impl<'a> FromValue<'a> for {name} {{
@@ -406,7 +406,7 @@ impl FromGlib<{sys_crate_name}::{ffi_name}> for {name} {{
         writeln!(w)?;
 
         version_condition(w, env, version, false, 0)?;
-        cfg_condition_no_doc(w, &config.cfg_condition.as_ref(), false, 0)?;
+        cfg_condition_no_doc(w, config.cfg_condition.as_ref(), false, 0)?;
         writeln!(
             w,
             "impl ToValue for {name} {{

--- a/src/codegen/flags.rs
+++ b/src/codegen/flags.rs
@@ -45,7 +45,7 @@ pub fn generate(env: &Env, root_path: &Path, mod_rs: &mut Vec<String>) {
             if let Some(cfg) = version_condition_string(env, flags.version, false, 0) {
                 mod_rs.push(cfg);
             }
-            if let Some(cfg) = cfg_condition_string(&config.cfg_condition, false, 0) {
+            if let Some(cfg) = cfg_condition_string(config.cfg_condition.as_ref(), false, 0) {
                 mod_rs.push(cfg);
             }
             mod_rs.push(format!("pub use self::flags::{};", flags.name));
@@ -67,7 +67,7 @@ fn generate_flags(
     let sys_crate_name = env.main_sys_crate_name();
     cfg_deprecated(w, env, flags.deprecated_version, false, 0)?;
     version_condition(w, env, flags.version, false, 0)?;
-    cfg_condition(w, &config.cfg_condition.as_ref(), false, 0)?;
+    cfg_condition(w, config.cfg_condition.as_ref(), false, 0)?;
     writeln!(w, "bitflags! {{")?;
     if config.must_use {
         writeln!(w, "    #[must_use]")?;
@@ -97,7 +97,7 @@ fn generate_flags(
         let cfg_cond = member_config.iter().find_map(|m| m.cfg_condition.as_ref());
         cfg_deprecated(w, env, deprecated_version, false, 2)?;
         version_condition(w, env, version, false, 2)?;
-        cfg_condition(w, &cfg_cond, false, 2)?;
+        cfg_condition(w, cfg_cond, false, 2)?;
         if member.c_identifier != member.name {
             doc_alias(w, &member.c_identifier, "", 2)?;
         }
@@ -123,7 +123,7 @@ fn generate_flags(
     if !functions.is_empty() {
         writeln!(w)?;
         version_condition(w, env, flags.version, false, 0)?;
-        cfg_condition_no_doc(w, &config.cfg_condition.as_ref(), false, 0)?;
+        cfg_condition_no_doc(w, config.cfg_condition.as_ref(), false, 0)?;
         write!(w, "impl {} {{", analysis.name)?;
         for func_analysis in functions {
             function::generate(
@@ -148,7 +148,7 @@ fn generate_flags(
         &analysis.specials,
         None,
         None,
-        &config.cfg_condition.as_ref(),
+        config.cfg_condition.as_ref(),
     )?;
 
     writeln!(w)?;
@@ -156,7 +156,7 @@ fn generate_flags(
     if config.generate_display_trait && !analysis.specials.has_trait(Type::Display) {
         // Generate Display trait implementation.
         version_condition(w, env, flags.version, false, 0)?;
-        cfg_condition_no_doc(w, &config.cfg_condition.as_ref(), false, 0)?;
+        cfg_condition_no_doc(w, config.cfg_condition.as_ref(), false, 0)?;
         writeln!(
             w,
             "impl fmt::Display for {0} {{\n\
@@ -169,7 +169,7 @@ fn generate_flags(
     }
 
     version_condition(w, env, flags.version, false, 0)?;
-    cfg_condition_no_doc(w, &config.cfg_condition.as_ref(), false, 0)?;
+    cfg_condition_no_doc(w, config.cfg_condition.as_ref(), false, 0)?;
     writeln!(
         w,
         "#[doc(hidden)]
@@ -193,7 +193,7 @@ impl IntoGlib for {name} {{
     };
 
     version_condition(w, env, flags.version, false, 0)?;
-    cfg_condition_no_doc(w, &config.cfg_condition.as_ref(), false, 0)?;
+    cfg_condition_no_doc(w, config.cfg_condition.as_ref(), false, 0)?;
     writeln!(
         w,
         "#[doc(hidden)]
@@ -217,7 +217,7 @@ impl FromGlib<{sys_crate_name}::{ffi_name}> for {name} {{
             .flatten();
 
         version_condition(w, env, version, false, 0)?;
-        cfg_condition_no_doc(w, &config.cfg_condition.as_ref(), false, 0)?;
+        cfg_condition_no_doc(w, config.cfg_condition.as_ref(), false, 0)?;
         writeln!(
             w,
             "impl StaticType for {name} {{
@@ -232,7 +232,7 @@ impl FromGlib<{sys_crate_name}::{ffi_name}> for {name} {{
         writeln!(w)?;
 
         version_condition(w, env, version, false, 0)?;
-        cfg_condition_no_doc(w, &config.cfg_condition.as_ref(), false, 0)?;
+        cfg_condition_no_doc(w, config.cfg_condition.as_ref(), false, 0)?;
         writeln!(
             w,
             "impl {valuetype} for {name} {{
@@ -244,7 +244,7 @@ impl FromGlib<{sys_crate_name}::{ffi_name}> for {name} {{
         writeln!(w)?;
 
         version_condition(w, env, version, false, 0)?;
-        cfg_condition_no_doc(w, &config.cfg_condition.as_ref(), false, 0)?;
+        cfg_condition_no_doc(w, config.cfg_condition.as_ref(), false, 0)?;
         writeln!(
             w,
             "unsafe impl<'a> FromValue<'a> for {name} {{
@@ -263,7 +263,7 @@ impl FromGlib<{sys_crate_name}::{ffi_name}> for {name} {{
         writeln!(w)?;
 
         version_condition(w, env, version, false, 0)?;
-        cfg_condition_no_doc(w, &config.cfg_condition.as_ref(), false, 0)?;
+        cfg_condition_no_doc(w, config.cfg_condition.as_ref(), false, 0)?;
         writeln!(
             w,
             "impl ToValue for {name} {{

--- a/src/codegen/flags.rs
+++ b/src/codegen/flags.rs
@@ -3,8 +3,9 @@ use crate::{
     analysis::flags::Info,
     analysis::special_functions::Type,
     codegen::general::{
-        self, cfg_condition, cfg_condition_no_doc, cfg_condition_string, cfg_deprecated, derives,
-        doc_alias, version_condition, version_condition_string,
+        self, cfg_condition, cfg_condition_doc, cfg_condition_no_doc, cfg_condition_string,
+        cfg_deprecated, derives, doc_alias, version_condition, version_condition_doc,
+        version_condition_no_doc, version_condition_string,
     },
     config::gobjects::GObject,
     env::Env,
@@ -65,10 +66,12 @@ fn generate_flags(
     analysis: &Info,
 ) -> Result<()> {
     let sys_crate_name = env.main_sys_crate_name();
-    cfg_deprecated(w, env, flags.deprecated_version, false, 0)?;
-    version_condition(w, env, flags.version, false, 0)?;
-    cfg_condition(w, config.cfg_condition.as_ref(), false, 0)?;
+    cfg_condition_no_doc(w, config.cfg_condition.as_ref(), false, 0)?;
+    version_condition_no_doc(w, env, flags.version, false, 0)?;
     writeln!(w, "bitflags! {{")?;
+    cfg_condition_doc(w, config.cfg_condition.as_ref(), false, 1)?;
+    version_condition_doc(w, env, flags.version, false, 1)?;
+    cfg_deprecated(w, env, flags.deprecated_version, false, 1)?;
     if config.must_use {
         writeln!(w, "    #[must_use]")?;
     }

--- a/src/codegen/function.rs
+++ b/src/codegen/function.rs
@@ -79,7 +79,7 @@ pub fn generate(
     if !in_trait || only_declaration {
         cfg_deprecated(w, env, analysis.deprecated_version, commented, indent)?;
     }
-    cfg_condition(w, &analysis.cfg_condition, commented, indent)?;
+    cfg_condition(w, analysis.cfg_condition.as_ref(), commented, indent)?;
     let version = Version::if_stricter_than(analysis.version, scope_version);
     version_condition(w, env, version, commented, indent)?;
     not_version_condition(w, analysis.not_version, commented, indent)?;
@@ -118,7 +118,7 @@ pub fn generate(
         }
 
         writeln!(w, "{}{}", tabs(indent), comment_prefix)?;
-        cfg_condition(w, &analysis.cfg_condition, commented, indent)?;
+        cfg_condition(w, analysis.cfg_condition.as_ref(), commented, indent)?;
         version_condition(w, env, version, commented, indent)?;
         not_version_condition(w, analysis.not_version, commented, indent)?;
         doc_hidden(w, analysis.doc_hidden, comment_prefix, indent)?;

--- a/src/codegen/general.rs
+++ b/src/codegen/general.rs
@@ -547,6 +547,23 @@ pub fn version_condition_no_doc(
     }
     Ok(())
 }
+pub fn version_condition_doc(
+    w: &mut dyn Write,
+    env: &Env,
+    version: Option<Version>,
+    commented: bool,
+    indent: usize,
+) -> Result<()> {
+    match version {
+        Some(v) if v > env.config.min_cfg_version => {
+            if let Some(s) = cfg_condition_string_doc(Some(&v.to_cfg()), commented, indent) {
+                writeln!(w, "{}", s)?
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
 
 pub fn version_condition_string(
     env: &Env,
@@ -624,14 +641,42 @@ pub fn cfg_condition_string_no_doc(
     commented: bool,
     indent: usize,
 ) -> Option<String> {
-    cfg_condition.and_then(|cfg| {
+    cfg_condition.map(|cfg| {
         let comment = if commented { "//" } else { "" };
-        Some(format!(
+        format!(
             "{0}{1}#[cfg(any({2}, feature = \"dox\"))]",
             tabs(indent),
             comment,
             cfg,
-        ))
+        )
+    })
+}
+
+pub fn cfg_condition_doc(
+    w: &mut dyn Write,
+    cfg_condition: Option<&impl Display>,
+    commented: bool,
+    indent: usize,
+) -> Result<()> {
+    if let Some(s) = cfg_condition_string_doc(cfg_condition, commented, indent) {
+        writeln!(w, "{}", s)?;
+    }
+    Ok(())
+}
+
+pub fn cfg_condition_string_doc(
+    cfg_condition: Option<&impl Display>,
+    commented: bool,
+    indent: usize,
+) -> Option<String> {
+    cfg_condition.map(|cfg| {
+        let comment = if commented { "//" } else { "" };
+        format!(
+            "{0}{1}#[cfg_attr(feature = \"dox\", doc(cfg({2})))]",
+            tabs(indent),
+            comment,
+            cfg,
+        )
     })
 }
 
@@ -640,19 +685,13 @@ pub fn cfg_condition_string(
     commented: bool,
     indent: usize,
 ) -> Option<String> {
-    match cfg_condition.as_ref() {
-        Some(v) => {
-            let comment = if commented { "//" } else { "" };
-            Some(format!(
-                "{0}{1}#[cfg(any({2}, feature = \"dox\"))]\n\
-                 {0}{1}#[cfg_attr(feature = \"dox\", doc(cfg({2})))]",
-                tabs(indent),
-                comment,
-                v
-            ))
-        }
-        None => None,
-    }
+    cfg_condition.map(|_| {
+        format!(
+            "{}\n{}",
+            cfg_condition_string_no_doc(cfg_condition, commented, indent).unwrap(),
+            cfg_condition_string_doc(cfg_condition, commented, indent).unwrap(),
+        )
+    })
 }
 
 pub fn derives(w: &mut dyn Write, derives: &[Derive], indent: usize) -> Result<()> {

--- a/src/codegen/general.rs
+++ b/src/codegen/general.rs
@@ -539,7 +539,7 @@ pub fn version_condition_no_doc(
 ) -> Result<()> {
     match version {
         Some(v) if v > env.config.min_cfg_version => {
-            if let Some(s) = cfg_condition_string_no_doc(&Some(&v.to_cfg()), commented, indent) {
+            if let Some(s) = cfg_condition_string_no_doc(Some(&v.to_cfg()), commented, indent) {
                 writeln!(w, "{}", s)?
             }
         }
@@ -556,7 +556,7 @@ pub fn version_condition_string(
 ) -> Option<String> {
     match version {
         Some(v) if v > env.config.min_cfg_version => {
-            cfg_condition_string(&Some(v.to_cfg()), commented, indent)
+            cfg_condition_string(Some(&v.to_cfg()), commented, indent)
         }
         _ => None,
     }
@@ -569,7 +569,7 @@ pub fn not_version_condition(
     indent: usize,
 ) -> Result<()> {
     if let Some(s) = version.and_then(|v| {
-        cfg_condition_string(&Some(format!("not({})", v.to_cfg())), commented, indent)
+        cfg_condition_string(Some(&format!("not({})", v.to_cfg())), commented, indent)
     }) {
         writeln!(w, "{}", s)?;
     }
@@ -595,9 +595,9 @@ pub fn not_version_condition_no_dox(
     Ok(())
 }
 
-pub fn cfg_condition<S: AsRef<str> + Display>(
+pub fn cfg_condition(
     w: &mut dyn Write,
-    cfg_condition: &Option<S>,
+    cfg_condition: Option<&impl Display>,
     commented: bool,
     indent: usize,
 ) -> Result<()> {
@@ -609,7 +609,7 @@ pub fn cfg_condition<S: AsRef<str> + Display>(
 
 pub fn cfg_condition_no_doc(
     w: &mut dyn Write,
-    cfg_condition: &Option<&String>,
+    cfg_condition: Option<&impl Display>,
     commented: bool,
     indent: usize,
 ) -> Result<()> {
@@ -620,7 +620,7 @@ pub fn cfg_condition_no_doc(
 }
 
 pub fn cfg_condition_string_no_doc(
-    cfg_condition: &Option<&String>,
+    cfg_condition: Option<&impl Display>,
     commented: bool,
     indent: usize,
 ) -> Option<String> {
@@ -635,8 +635,8 @@ pub fn cfg_condition_string_no_doc(
     })
 }
 
-pub fn cfg_condition_string<S: AsRef<str> + Display>(
-    cfg_condition: &Option<S>,
+pub fn cfg_condition_string(
+    cfg_condition: Option<&impl Display>,
     commented: bool,
     indent: usize,
 ) -> Option<String> {

--- a/src/codegen/object.rs
+++ b/src/codegen/object.rs
@@ -131,7 +131,7 @@ pub fn generate(
             None
         },
         analysis.version,
-        &None, // There is no need for #[cfg()] since it's applied on the whole file.
+        None, // There is no need for #[cfg()] since it's applied on the whole file.
     )?;
 
     if !analysis.builder_properties.is_empty() {
@@ -444,7 +444,7 @@ pub fn generate_reexports(
     traits: &mut Vec<String>,
 ) {
     let mut cfgs: Vec<String> = Vec::new();
-    if let Some(cfg) = general::cfg_condition_string(&analysis.cfg_condition, false, 0) {
+    if let Some(cfg) = general::cfg_condition_string(analysis.cfg_condition.as_ref(), false, 0) {
         cfgs.push(cfg);
     }
     if let Some(cfg) = general::version_condition_string(env, analysis.version, false, 0) {

--- a/src/codegen/record.rs
+++ b/src/codegen/record.rs
@@ -113,7 +113,7 @@ pub fn generate(w: &mut dyn Write, env: &Env, analysis: &analysis::record::Info)
         &analysis.specials,
         None,
         analysis.version,
-        &None, // There is no need for #[cfg()] since it's applied on the whole file.
+        None, // There is no need for #[cfg()] since it's applied on the whole file.
     )?;
 
     if analysis.concurrency != library::Concurrency::None {
@@ -143,7 +143,7 @@ pub fn generate_reexports(
     module_name: &str,
     contents: &mut Vec<String>,
 ) {
-    let cfg_condition = general::cfg_condition_string(&analysis.cfg_condition, false, 0);
+    let cfg_condition = general::cfg_condition_string(analysis.cfg_condition.as_ref(), false, 0);
     let version_cfg = general::version_condition_string(env, analysis.version, false, 0);
     let mut cfg = String::new();
     if let Some(s) = cfg_condition {

--- a/src/codegen/sys/functions.rs
+++ b/src/codegen/sys/functions.rs
@@ -180,8 +180,8 @@ fn generate_cfg_configure(
 ) -> Result<()> {
     let cfg_condition_ = configured_functions
         .iter()
-        .find_map(|f| f.cfg_condition.clone());
-    cfg_condition(w, &cfg_condition_, commented, 1)?;
+        .find_map(|f| f.cfg_condition.as_ref());
+    cfg_condition(w, cfg_condition_, commented, 1)?;
     Ok(())
 }
 

--- a/src/codegen/sys/lib_.rs
+++ b/src/codegen/sys/lib_.rs
@@ -224,8 +224,8 @@ fn generate_constant_cfg_configure(
 ) -> Result<()> {
     let cfg_condition_ = configured_constants
         .iter()
-        .find_map(|f| f.cfg_condition.clone());
-    cfg_condition(w, &cfg_condition_, commented, 1)?;
+        .find_map(|f| f.cfg_condition.as_ref());
+    cfg_condition(w, cfg_condition_, commented, 1)?;
     Ok(())
 }
 
@@ -476,7 +476,7 @@ fn generate_from_fields(
     fields: &fields::Fields,
     align: Option<u32>,
 ) -> Result<()> {
-    cfg_condition(w, &fields.cfg_condition, false, 0)?;
+    cfg_condition(w, fields.cfg_condition.as_ref(), false, 0)?;
     writeln!(w, "#[repr(C)]")?;
     if let Some(align) = align {
         writeln!(w, "#[repr(align({}))]", align)?;
@@ -513,7 +513,7 @@ fn generate_from_fields(
     }
     writeln!(w)?;
 
-    cfg_condition(w, &fields.cfg_condition, false, 0)?;
+    cfg_condition(w, fields.cfg_condition.as_ref(), false, 0)?;
     writeln!(
         w,
         "impl ::std::fmt::Debug for {name} {{",

--- a/src/codegen/sys/tests.rs
+++ b/src/codegen/sys/tests.rs
@@ -515,7 +515,7 @@ fn get_c_output(name: &str) -> Result<String, Box<dyn Error>> {
 const RUST_LAYOUTS: &[(&str, Layout)] = &["####
     )?;
     for ctype in ctypes {
-        general::cfg_condition(w, &ctype.cfg_condition, false, 1)?;
+        general::cfg_condition(w, ctype.cfg_condition.as_ref(), false, 1)?;
         writeln!(w, "    (\"{ctype}\", Layout {{size: size_of::<{ctype}>(), alignment: align_of::<{ctype}>()}}),",
                  ctype=ctype.name)?;
     }

--- a/src/codegen/trait_impls.rs
+++ b/src/codegen/trait_impls.rs
@@ -17,7 +17,7 @@ pub fn generate(
     specials: &Infos,
     trait_name: Option<&str>,
     scope_version: Option<Version>,
-    cfg_condition: &Option<&String>,
+    cfg_condition: Option<&String>,
 ) -> Result<()> {
     for (type_, special_info) in specials.traits().iter() {
         if let Some(info) = lookup(functions, &special_info.glib_name) {
@@ -122,7 +122,7 @@ fn generate_display(
     func: &Info,
     trait_name: Option<&str>,
     scope_version: Option<Version>,
-    cfg_condition: &Option<&String>,
+    cfg_condition: Option<&String>,
 ) -> Result<()> {
     writeln!(w)?;
     let version = Version::if_stricter_than(func.version, scope_version);
@@ -167,7 +167,7 @@ fn generate_hash(
     func: &Info,
     trait_name: Option<&str>,
     scope_version: Option<Version>,
-    cfg_condition: &Option<&String>,
+    cfg_condition: Option<&String>,
 ) -> Result<()> {
     writeln!(w)?;
     let version = Version::if_stricter_than(func.version, scope_version);
@@ -197,7 +197,7 @@ fn generate_eq(
     func: &Info,
     trait_name: Option<&str>,
     scope_version: Option<Version>,
-    cfg_condition: &Option<&String>,
+    cfg_condition: Option<&String>,
 ) -> Result<()> {
     writeln!(w)?;
     let version = Version::if_stricter_than(func.version, scope_version);
@@ -229,7 +229,7 @@ fn generate_eq_compare(
     func: &Info,
     trait_name: Option<&str>,
     scope_version: Option<Version>,
-    cfg_condition: &Option<&String>,
+    cfg_condition: Option<&String>,
 ) -> Result<()> {
     writeln!(w)?;
     let version = Version::if_stricter_than(func.version, scope_version);
@@ -261,7 +261,7 @@ fn generate_ord(
     func: &Info,
     trait_name: Option<&str>,
     scope_version: Option<Version>,
-    cfg_condition: &Option<&String>,
+    cfg_condition: Option<&String>,
 ) -> Result<()> {
     writeln!(w)?;
     let version = Version::if_stricter_than(func.version, scope_version);


### PR DESCRIPTION
Attributes on macro-calls don't have any meaning, as indicated by this warning and the feature requirement not showing up in docs:

    warning: unused attribute `doc`
       --> gstreamer/src/auto/flags.rs:663:29
        |
    663 | #[cfg_attr(feature = "dox", doc(cfg(feature = "v1_20")))]
        |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
        |
    note: the built-in attribute `doc` will be ignored, since it's applied to the macro invocation `bitflags`
       --> gstreamer/src/auto/flags.rs:664:1
        |
    664 | bitflags! {
        | ^^^^^^^^

Separate the attribute functions out to be able to generate this `doc(cfg())` attribute inside the macro call on the `struct` (and just
the `struct`, not the `impl` blocks and anything else `bitflags!` generates) while still having the `#[cfg]` guard the entire macro call.