### PR TITLE
Add default impls for all objects

### DIFF
--- a/src/codegen/general.rs
+++ b/src/codegen/general.rs
@@ -744,7 +744,7 @@ pub fn declare_default_from_new(
     env: &Env,
     name: &str,
     functions: &[analysis::functions::Info],
-    is_object: bool,
+    has_builder: bool,
 ) -> Result<()> {
     if let Some(func) = functions.iter().find(|f| {
         !f.visibility.hidden()
@@ -756,23 +756,29 @@ pub fn declare_default_from_new(
         if func.parameters.rust_parameters.is_empty() {
             writeln!(w)?;
             version_condition(w, env, func.version, false, 0)?;
-            writeln!(w, "impl Default for {} {{", name)?;
-            writeln!(w, "    fn default() -> Self {{")?;
-            writeln!(w, "        Self::new()")?;
-            writeln!(w, "    }}")?;
-            writeln!(w, "}}")?;
-        } else if is_object {
+            writeln!(
+                w,
+                "impl Default for {} {{
+                     fn default() -> Self {{
+                         Self::new()
+                     }}
+                 }}",
+                name
+            )?;
+        } else if has_builder {
             // create an alternative default implementation the uses `glib::object::Object::new()`
             writeln!(w)?;
             version_condition(w, env, func.version, false, 0)?;
-            writeln!(w, "impl Default for {} {{", name)?;
-            writeln!(w, "    fn default() -> Self {{")?;
-            writeln!(w, "        match glib::object::Object::new::<Self>(&[]) {{")?;
-            writeln!(w, "            Ok(obj) => obj,")?;
-            writeln!(w, "            Err(err) => panic!(\"Can't construct {} object with default parameters: {{}}\", err),", name)?;
-            writeln!(w, "        }}")?;
-            writeln!(w, "    }}")?;
-            writeln!(w, "}}")?;
+            writeln!(
+                w,
+                "impl Default for {} {{
+                     fn default() -> Self {{
+                         match glib::object::Object::new::<Self>(&[]) {{
+                              Ok(obj) => obj,
+                              Err(err) => panic!(\"Can't construct {} object with default parameters: {{}}\", err),
+                         }}
+                     }}
+                 }}", name, name)?;
         }
     }
 

--- a/src/codegen/general.rs
+++ b/src/codegen/general.rs
@@ -767,7 +767,10 @@ pub fn declare_default_from_new(
             version_condition(w, env, func.version, false, 0)?;
             writeln!(w, "impl Default for {} {{", name)?;
             writeln!(w, "    fn default() -> Self {{")?;
-            writeln!(w, "        ::glib::object::Object::new::<Self>(&[]).expect(\"Can't construct {} object with default parameters\")", name)?;
+            writeln!(w, "        match glib::object::Object::new::<Self>(&[]) {{")?;
+            writeln!(w, "            Ok(obj) => obj,")?;
+            writeln!(w, "            Err(err) => panic!(\"Can't construct {} object with default parameters: {{}}\", err),", name)?;
+            writeln!(w, "        }}")?;
             writeln!(w, "    }}")?;
             writeln!(w, "}}")?;
         }

--- a/src/codegen/general.rs
+++ b/src/codegen/general.rs
@@ -771,14 +771,12 @@ pub fn declare_default_from_new(
             version_condition(w, env, func.version, false, 0)?;
             writeln!(
                 w,
-                "impl Default for {} {{
+                "impl Default for {0} {{
                      fn default() -> Self {{
-                         match glib::object::Object::new::<Self>(&[]) {{
-                              Ok(obj) => obj,
-                              Err(err) => panic!(\"Can't construct {} object with default parameters: {{}}\", err),
-                         }}
+                         glib::object::Object::new::<Self>(&[])
+                            .expect(\"Can't construct {0} object with default parameters\")
                      }}
-                 }}", name, name)?;
+                 }}", name)?;
         }
     }
 

--- a/src/codegen/object.rs
+++ b/src/codegen/object.rs
@@ -116,7 +116,7 @@ pub fn generate(
 
         writeln!(w, "}}")?;
 
-        general::declare_default_from_new(w, env, &analysis.name, &analysis.functions)?;
+        general::declare_default_from_new(w, env, &analysis.name, &analysis.functions, true)?;
     }
 
     trait_impls::generate(

--- a/src/codegen/object.rs
+++ b/src/codegen/object.rs
@@ -116,7 +116,13 @@ pub fn generate(
 
         writeln!(w, "}}")?;
 
-        general::declare_default_from_new(w, env, &analysis.name, &analysis.functions, true)?;
+        general::declare_default_from_new(
+            w,
+            env,
+            &analysis.name,
+            &analysis.functions,
+            !analysis.builder_properties.is_empty(),
+        )?;
     }
 
     trait_impls::generate(

--- a/src/codegen/record.rs
+++ b/src/codegen/record.rs
@@ -103,7 +103,7 @@ pub fn generate(w: &mut dyn Write, env: &Env, analysis: &analysis::record::Info)
         writeln!(w, "}}")?;
     }
 
-    general::declare_default_from_new(w, env, &analysis.name, &analysis.functions)?;
+    general::declare_default_from_new(w, env, &analysis.name, &analysis.functions, false)?;
 
     trait_impls::generate(
         w,


### PR DESCRIPTION
Fix #1221

Currently, `Default` is only implemented for objects that don't take parameters in their `new()` function. This PR adds `Default` implementations for all objects that take parameters in their `new()` function. This makes the workaround  using `Object::builder().build()` obsolete.

The generated code looks like this:

```rust
impl Default for Box {
    fn default() -> Self {
        match glib::object::Object::new::<Self>(&[]) {
            Ok(obj) => obj,
            Err(err) => panic!(
                "Can't construct Box object with default parameters: {}",
                err
            ),
        }
    }
}
```