### PR TITLE
build: Emit rerun-if-changed for branch file on `ref: ` HEAD

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -7,10 +7,14 @@ mod git;
 
 fn main() {
     let repo_path = git::git_dir(".").unwrap();
-    println!(
-        "cargo:rerun-if-changed={}",
-        repo_path.join("HEAD").display()
-    );
+    let head_path = repo_path.join("HEAD");
+    println!("cargo:rerun-if-changed={}", head_path.display());
+    let head = std::fs::read_to_string(&head_path).unwrap();
+    if let Some(ref_) = head.trim_end().strip_prefix("ref: ") {
+        let ref_path = repo_path.join(ref_);
+        assert!(ref_path.is_file());
+        println!("cargo:rerun-if-changed={}", ref_path.display());
+    }
     let ver = git::repo_hash(".").unwrap_or_else(|| "???".into());
 
     File::create("src/gir_version.rs")


### PR DESCRIPTION
We already ran into the issue of git hashes not updating when checked out to a branch, because the `HEAD` file doesn't change.  `HEAD` does however tell us what branch (ref) the user is checked out to, which is a file much like `HEAD` containing the hash of the commit it is currently pointing to, and will inevitably change if the user "moves around" (ie.  rebasing or committing).  Emitting a `rerun-if-changed` on this file should make the git hash much more reliable.
