### PR TITLE
[Fix] Implement default for all objects with builders

### DIFF
--- a/src/codegen/object.rs
+++ b/src/codegen/object.rs
@@ -116,7 +116,7 @@ pub fn generate(
 
         writeln!(w, "}}")?;
 
-        general::declare_default_from_new(
+        general::implement_default_from_new_or_builder(
             w,
             env,
             &analysis.name,

--- a/src/codegen/record.rs
+++ b/src/codegen/record.rs
@@ -103,7 +103,13 @@ pub fn generate(w: &mut dyn Write, env: &Env, analysis: &analysis::record::Info)
         writeln!(w, "}}")?;
     }
 
-    general::declare_default_from_new(w, env, &analysis.name, &analysis.functions, false)?;
+    general::implement_default_from_new_or_builder(
+        w,
+        env,
+        &analysis.name,
+        &analysis.functions,
+        false,
+    )?;
 
     trait_impls::generate(
         w,


### PR DESCRIPTION
When updating Relm4 to use the new `Default` implementations in gtk4-rs (see https://github.com/gtk-rs/gir/pull/1222) I've noticed a regression because widgets such as `MessageDialog` still don't implement `Default` despite having a builder. 

This PR fixes this problem by adding a `Default` implementation for all objects with a builder pattern.