### PR TITLE
Remove type version heuristics

### DIFF
--- a/src/analysis/info_base.rs
+++ b/src/analysis/info_base.rs
@@ -1,6 +1,5 @@
-use super::{functions::Visibility, imports::Imports, *};
-use crate::{config::gobjects::GObject, env::Env, library, version::Version};
-use std::cmp;
+use super::{imports::Imports, *};
+use crate::{library, version::Version};
 
 #[derive(Debug, Default)]
 pub struct InfoBase {
@@ -38,42 +37,4 @@ impl InfoBase {
             .filter(|f| f.status.need_generate() && f.kind == library::FunctionKind::Function)
             .collect()
     }
-}
-
-pub fn versions(
-    env: &Env,
-    obj: &GObject,
-    functions: &[functions::Info],
-    version: Option<Version>,
-    deprecated_version: Option<Version>,
-) -> (Option<Version>, Option<Version>) {
-    let version = if obj.version.is_some() {
-        obj.version
-    } else {
-        let fn_version = functions
-            .iter()
-            .filter(|f| f.visibility == Visibility::Public)
-            .map(|f| f.version)
-            .min()
-            .unwrap_or(None);
-        cmp::max(version, fn_version)
-    };
-    let version = env.config.filter_version(version);
-
-    let fn_deprecated_max = functions
-        .iter()
-        .filter(|f| f.visibility == Visibility::Public)
-        .map(|f| f.deprecated_version)
-        .max()
-        .unwrap_or(None);
-    let fn_deprecated_min = functions
-        .iter()
-        .filter(|f| f.visibility == Visibility::Public)
-        .map(|f| f.deprecated_version)
-        .min()
-        .unwrap_or(None);
-    let deprecated_version =
-        deprecated_version.or_else(|| fn_deprecated_min.and(fn_deprecated_max));
-
-    (version, deprecated_version)
 }

--- a/src/analysis/object.rs
+++ b/src/analysis/object.rs
@@ -177,13 +177,8 @@ pub fn class(env: &Env, obj: &GObject, deps: &[library::TypeId]) -> Option<Info>
     let builder_properties =
         class_builder::analyze(env, &klass.properties, class_tid, obj, &mut imports);
 
-    let (version, deprecated_version) = info_base::versions(
-        env,
-        obj,
-        &functions,
-        klass.version,
-        klass.deprecated_version,
-    );
+    let version = obj.version.or(klass.version);
+    let deprecated_version = klass.deprecated_version;
 
     let child_properties =
         child_properties::analyze(env, obj.child_properties.as_ref(), class_tid, &mut imports);
@@ -317,13 +312,8 @@ pub fn interface(env: &Env, obj: &GObject, deps: &[library::TypeId]) -> Option<I
         deps,
     );
 
-    let (version, deprecated_version) = info_base::versions(
-        env,
-        obj,
-        &functions,
-        iface.version,
-        iface.deprecated_version,
-    );
+    let version = obj.version.or(iface.version);
+    let deprecated_version = iface.deprecated_version;
 
     if obj.concurrency == library::Concurrency::SendUnique {
         imports.add("glib::ObjectExt");

--- a/src/analysis/record.rs
+++ b/src/analysis/record.rs
@@ -94,13 +94,8 @@ pub fn new(env: &Env, obj: &GObject) -> Option<Info> {
     );
     let specials = special_functions::extract(&mut functions, type_, obj);
 
-    let (version, deprecated_version) = info_base::versions(
-        env,
-        obj,
-        &functions,
-        record.version,
-        record.deprecated_version,
-    );
+    let version = obj.version.or(record.version);
+    let deprecated_version = record.deprecated_version;
 
     let is_shared = specials.has_trait(special_functions::Type::Ref)
         && specials.has_trait(special_functions::Type::Unref);


### PR DESCRIPTION
Previously we would infer the minimum version of a type by the minimum
version of all its functions if not type version information was
available. This causes unnecessarily high minimum version constraints if
the type was available without functions before and later got functions.

Instead this should be fixed in the C library's annotations, and for now
this can also be overridden via Gir.toml if needed.