### PR TITLE
Handle objects correctly where a supertype has a newer version than the type itself

### DIFF
--- a/src/analysis/object.rs
+++ b/src/analysis/object.rs
@@ -113,12 +113,15 @@ pub fn class(env: &Env, obj: &GObject, deps: &[library::TypeId]) -> Option<Info>
 
     let klass: &library::Class = type_.maybe_ref()?;
 
+    let version = obj.version.or(klass.version);
+    let deprecated_version = klass.deprecated_version;
+
     let mut imports = Imports::with_defined(&env.library, &name);
     if obj.generate_display_trait {
         imports.add("std::fmt");
     }
 
-    let supertypes = supertypes::analyze(env, class_tid, &mut imports);
+    let supertypes = supertypes::analyze(env, class_tid, version, &mut imports);
 
     let final_type = klass.final_type;
     let trait_name = obj
@@ -176,9 +179,6 @@ pub fn class(env: &Env, obj: &GObject, deps: &[library::TypeId]) -> Option<Info>
 
     let builder_properties =
         class_builder::analyze(env, &klass.properties, class_tid, obj, &mut imports);
-
-    let version = obj.version.or(klass.version);
-    let deprecated_version = klass.deprecated_version;
 
     let child_properties =
         child_properties::analyze(env, obj.child_properties.as_ref(), class_tid, &mut imports);
@@ -272,13 +272,16 @@ pub fn interface(env: &Env, obj: &GObject, deps: &[library::TypeId]) -> Option<I
 
     let iface: &library::Interface = type_.maybe_ref()?;
 
+    let version = obj.version.or(iface.version);
+    let deprecated_version = iface.deprecated_version;
+
     let mut imports = Imports::with_defined(&env.library, &name);
     imports.add("glib::object::IsA");
     if obj.generate_display_trait {
         imports.add("std::fmt");
     }
 
-    let supertypes = supertypes::analyze(env, iface_tid, &mut imports);
+    let supertypes = supertypes::analyze(env, iface_tid, version, &mut imports);
 
     let trait_name = obj
         .trait_name
@@ -311,9 +314,6 @@ pub fn interface(env: &Env, obj: &GObject, deps: &[library::TypeId]) -> Option<I
         &signatures,
         deps,
     );
-
-    let version = obj.version.or(iface.version);
-    let deprecated_version = iface.deprecated_version;
 
     if obj.concurrency == library::Concurrency::SendUnique {
         imports.add("glib::ObjectExt");

--- a/src/codegen/general.rs
+++ b/src/codegen/general.rs
@@ -138,7 +138,6 @@ pub fn define_object_type(
         .cloned()
         .collect();
 
-    writeln!(w)?;
     writeln!(w, "{} {{", use_glib_type(env, "wrapper!"))?;
     doc_alias(w, glib_name, "", 1)?;
     if parents.is_empty() {

--- a/src/config/functions.rs
+++ b/src/config/functions.rs
@@ -514,7 +514,7 @@ version = "3.20"
 "#,
         );
         let f = Function::parse(&toml, "a").unwrap();
-        assert_eq!(f.version, Some(Version::Full(3, 20, 0)));
+        assert_eq!(f.version, Some(Version(3, 20, 0)));
     }
 
     #[test]

--- a/src/config/members.rs
+++ b/src/config/members.rs
@@ -141,6 +141,6 @@ version = "3.20"
 "#,
         );
         let f = Member::parse(&toml, "a").unwrap();
-        assert_eq!(f.version, Some(Version::Full(3, 20, 0)));
+        assert_eq!(f.version, Some(Version(3, 20, 0)));
     }
 }

--- a/src/config/properties.rs
+++ b/src/config/properties.rs
@@ -180,7 +180,7 @@ version = "3.20"
 "#,
         );
         let p = Property::parse(&toml, "a").unwrap();
-        assert_eq!(p.version, Some(Version::Full(3, 20, 0)));
+        assert_eq!(p.version, Some(Version(3, 20, 0)));
     }
 
     #[test]


### PR DESCRIPTION
    In that case it is necessary to create multiple glib::wrapper! calls
    with the different sets of the supertypes.

----

Also a fix for the `Version` type in general. This has no effect at all on the gtk-rs crates but in GStreamer has this important diff:

```diff
diff --git a/gstreamer-editing-services/src/auto/uri_clip_asset.rs b/gstreamer-editing-services/src/auto/uri_clip_asset.rs
index 1b55c5b8..28c5757c 100644
--- a/gstreamer-editing-services/src/auto/uri_clip_asset.rs
+++ b/gstreamer-editing-services/src/auto/uri_clip_asset.rs
@@ -1,11 +1,13 @@
 // This file was generated by gir (https://github.com/gtk-rs/gir)
 // from gir-files (https://github.com/gtk-rs/gir-files)
 // from gst-gir-files (https://gitlab.freedesktop.org/gstreamer/gir-files-rs.git)
 // DO NOT EDIT
 
 use crate::Asset;
 use crate::ClipAsset;
 use crate::MetaContainer;
+#[cfg(any(feature = "v1_18", feature = "dox"))]
+#[cfg_attr(feature = "dox", doc(cfg(feature = "v1_18")))]
 use crate::SourceClipAsset;
 use crate::UriSourceAsset;
 use glib::object::Cast;
@@ -21,6 +23,8 @@ use std::boxed::Box as Box_;
 use std::mem::transmute;
 use std::ptr;
 
+#[cfg(any(feature = "v1_18", feature = "dox"))]
+#[cfg_attr(feature = "dox", doc(cfg(feature = "v1_18")))]
 glib::wrapper! {
     #[doc(alias = "GESUriClipAsset")]
     pub struct UriClipAsset(Object<ffi::GESUriClipAsset, ffi::GESUriClipAssetClass>) @extends SourceClipAsset, ClipAsset, Asset, @implements MetaContainer;
@@ -30,6 +34,16 @@ glib::wrapper! {
     }
 }
 
+#[cfg(not(any(feature = "v1_18", feature = "dox")))]
+glib::wrapper! {
+    #[doc(alias = "GESUriClipAsset")]
+    pub struct UriClipAsset(Object<ffi::GESUriClipAsset, ffi::GESUriClipAssetClass>) @extends ClipAsset, Asset, @implements MetaContainer;
+
+    match fn {
+        type_ => || ffi::ges_uri_clip_asset_get_type(),
+    }
+}
+
 impl UriClipAsset {
     //#[cfg(any(feature = "v1_16", feature = "dox"))]
     //#[cfg_attr(feature = "dox", doc(cfg(feature = "v1_16")))]
```

@bilelmoussaoui I remember there was something in GTK4 where an interface impl was added at a later time? You might want to add configuration for that to Gir.toml now. That can then be directly hooked into the place where I added a `TODO` comment :)