### PR TITLE
book: Fix references to the `girs_dir` config option

### DIFF
--- a/book/src/tutorial/high_level_rust_api.md
+++ b/book/src/tutorial/high_level_rust_api.md
@@ -10,7 +10,7 @@ As you certainly guessed, we'll need a new `Gir.toml` file. Let's write it:
 
 ```toml
 [options]
-girs_dir = "../gir-files"
+girs_directories = ["../gir-files"]
 library = "GtkSource"
 version = "3.0"
 min_cfg_version = "3.0"

--- a/book/src/tutorial/sys_library.md
+++ b/book/src/tutorial/sys_library.md
@@ -115,7 +115,7 @@ Now we regenerate it then rebuild it:
 
 Should work just fine!
 
-We can cleanup the command line a bit now. You can actually give the work mode ("-m" option) and the gir files repository through the `Gir.toml` file using "work_mode" and "girs_dir" options:
+We can cleanup the command line a bit now. You can actually give the work mode ("-m" option) and the gir files repository through the `Gir.toml` file using "work_mode" and "girs_directories" options:
 
 ```toml
 [options]
@@ -124,7 +124,7 @@ version = "3.0"
 target_path = "."
 min_cfg_version = "3.0"
 work_mode = "sys"
-girs_dir = "../../gir-files/"
+girs_directories = ["../../gir-files/"]
 
 external_libraries = [
     "Cairo",


### PR DESCRIPTION
This configuration option was replaced by `girs_directories`, so the tutorial no longer worked as written.