### PR TITLE
codgen: generate deprecated cfg attribute for Default trait

### DIFF
--- a/src/codegen/general.rs
+++ b/src/codegen/general.rs
@@ -789,6 +789,7 @@ pub fn declare_default_from_new(
         if func.parameters.rust_parameters.is_empty() {
             writeln!(w)?;
             version_condition(w, env, func.version, false, 0)?;
+            cfg_deprecated(w, env, func.deprecated_version, false, 0)?;
             writeln!(
                 w,
                 "impl Default for {} {{
@@ -802,6 +803,7 @@ pub fn declare_default_from_new(
             // create an alternative default implementation the uses `glib::object::Object::new()`
             writeln!(w)?;
             version_condition(w, env, func.version, false, 0)?;
+            cfg_deprecated(w, env, func.deprecated_version, false, 0)?;
             writeln!(
                 w,
                 "impl Default for {0} {{


### PR DESCRIPTION
If the constructor method is deprecated, the builder pattern should have a guard
as well

Needed for gtk4-rs

cc @GuillaumeGomez, @sdroege 