### PR TITLE
codgen: simplify properties getters/setters

### DIFF
--- a/src/codegen/signal.rs
+++ b/src/codegen/signal.rs
@@ -7,7 +7,6 @@ use crate::{
     analysis,
     chunk::Chunk,
     env::Env,
-    nameutil::use_glib_type,
     writer::{primitives::tabs, ToCode},
 };
 use std::io::{Result, Write};
@@ -134,14 +133,13 @@ pub fn generate(
 
             writeln!(
                 w,
-                "{}let {} = unsafe {{ glib::Object::from_glib_borrow(self.as_ptr() as *mut {}).emit_by_name(\"{}\", &[{}]).unwrap() }};",
+                "{}let {} = self.emit_by_name(\"{}\", &[{}]);",
                 tabs(indent + 1),
                 if trampoline.ret.typ != Default::default() {
                     "res"
                 } else {
                     "_"
                 },
-                use_glib_type(env, "gobject_ffi::GObject"),
                 analysis.signal_name,
                 args,
             )?;


### PR DESCRIPTION
This PR simplifies the properties getters/setters generation code so we don't go through ffi and use ObjectExt trait directly. This drops a huge amount of code.

It also adapts emit_signal_by_name usages so they are "compatible" with changes in https://github.com/gtk-rs/gtk-rs-core/pull/323

The generated code looks fine, it needs ObjectExt trait to be in-scope, something I have to figure out first before getting this one merged.

Note, this merge request, at least the first commit of it is required for https://github.com/gtk-rs/gtk-rs-core/pull/323 to be merged. As otherwise almost all the usages of the emit_$signal in generated code will panic.