### PR TITLE
codgen: don't re-export builder types on crate root

### DIFF
--- a/src/codegen/object.rs
+++ b/src/codegen/object.rs
@@ -439,6 +439,7 @@ impl {name}Builder {{
         "
     // rustdoc-stripper-ignore-next
     /// Build the [`{name}`].
+    #[must_use = \"The builder must be built to be used\"]
     pub fn build(self) -> {name} {{
         let mut properties: Vec<(&str, &dyn ToValue)> = vec![];",
         name = analysis.name

--- a/src/codegen/object.rs
+++ b/src/codegen/object.rs
@@ -606,12 +606,4 @@ pub fn generate_reexports(
             module_name, analysis.trait_name
         ));
     }
-
-    if has_builder_properties(&analysis.builder_properties) {
-        contents.extend_from_slice(&cfgs);
-        contents.push(format!(
-            "pub use self::{}::{}Builder;",
-            module_name, analysis.name
-        ));
-    }
 }


### PR DESCRIPTION
they are available nowadays through Type::builder method

cc @sdroege 