### PR TITLE
codgen: generate builders inside a builders module

### DIFF
--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -71,15 +71,20 @@ pub fn generate_mod_rs(
         general::start_comments(w, &env.config)?;
         general::write_vec(w, mod_rs)?;
         writeln!(w)?;
-        writeln!(w, "#[doc(hidden)]")?;
-        writeln!(w, "pub mod traits {{")?;
-        general::write_vec(w, traits)?;
-        writeln!(w, "}}")?;
+        if !traits.is_empty() {
+            writeln!(w, "#[doc(hidden)]")?;
+            writeln!(w, "pub mod traits {{")?;
+            general::write_vec(w, traits)?;
+            writeln!(w, "}}")?;
+        }
 
-        writeln!(w, "#[doc(hidden)]")?;
-        writeln!(w, "pub mod builders {{")?;
-        general::write_vec(w, builders)?;
-        writeln!(w, "}}")
+        if !builders.is_empty() {
+            writeln!(w, "#[doc(hidden)]")?;
+            writeln!(w, "pub mod builders {{")?;
+            general::write_vec(w, builders)?;
+            writeln!(w, "}}")?;
+        }
+        Ok(())
     });
 }
 

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -44,10 +44,11 @@ pub fn generate(env: &Env) {
 fn normal_generate(env: &Env) {
     let mut mod_rs: Vec<String> = Vec::new();
     let mut traits: Vec<String> = Vec::new();
+    let mut builders: Vec<String> = Vec::new();
     let root_path = env.config.auto_path.as_path();
 
     generate_single_version_file(env);
-    objects::generate(env, root_path, &mut mod_rs, &mut traits);
+    objects::generate(env, root_path, &mut mod_rs, &mut traits, &mut builders);
     records::generate(env, root_path, &mut mod_rs);
     enums::generate(env, root_path, &mut mod_rs);
     flags::generate(env, root_path, &mut mod_rs);
@@ -55,10 +56,16 @@ fn normal_generate(env: &Env) {
     functions::generate(env, root_path, &mut mod_rs);
     constants::generate(env, root_path, &mut mod_rs);
 
-    generate_mod_rs(env, root_path, &mod_rs, &traits);
+    generate_mod_rs(env, root_path, &mod_rs, &traits, &builders);
 }
 
-pub fn generate_mod_rs(env: &Env, root_path: &Path, mod_rs: &[String], traits: &[String]) {
+pub fn generate_mod_rs(
+    env: &Env,
+    root_path: &Path,
+    mod_rs: &[String],
+    traits: &[String],
+    builders: &[String],
+) {
     let path = root_path.join("mod.rs");
     save_to_file(path, env.config.make_backup, |w| {
         general::start_comments(w, &env.config)?;
@@ -67,6 +74,11 @@ pub fn generate_mod_rs(env: &Env, root_path: &Path, mod_rs: &[String], traits: &
         writeln!(w, "#[doc(hidden)]")?;
         writeln!(w, "pub mod traits {{")?;
         general::write_vec(w, traits)?;
+        writeln!(w, "}}")?;
+
+        writeln!(w, "#[doc(hidden)]")?;
+        writeln!(w, "pub mod builders {{")?;
+        general::write_vec(w, builders)?;
         writeln!(w, "}}")
     });
 }

--- a/src/codegen/object.rs
+++ b/src/codegen/object.rs
@@ -164,7 +164,7 @@ pub fn generate(
             // rustdoc-stripper-ignore-next
             /// Creates a new builder-pattern struct instance to construct [`{name}`] objects.
             ///
-            /// This method returns an instance of [`{builder_name}`] which can be used to create [`{name}`] objects.
+            /// This method returns an instance of [`{builder_name}`](crate::builders::{builder_name}) which can be used to create [`{name}`] objects.
             pub fn builder() -> {builder_name} {{
                 {builder_name}::default()
             }}
@@ -573,6 +573,7 @@ pub fn generate_reexports(
     module_name: &str,
     contents: &mut Vec<String>,
     traits: &mut Vec<String>,
+    builders: &mut Vec<String>,
 ) {
     let mut cfgs: Vec<String> = Vec::new();
     if let Some(cfg) = general::cfg_condition_string(analysis.cfg_condition.as_ref(), false, 0) {
@@ -605,6 +606,16 @@ pub fn generate_reexports(
         traits.push(format!(
             "\tpub use super::{}::{};",
             module_name, analysis.trait_name
+        ));
+    }
+
+    if has_builder_properties(&analysis.builder_properties) {
+        for cfg in &cfgs {
+            builders.push(format!("\t{}", cfg));
+        }
+        builders.push(format!(
+            "\tpub use super::{}::{}Builder;",
+            module_name, analysis.name
         ));
     }
 }

--- a/src/codegen/objects.rs
+++ b/src/codegen/objects.rs
@@ -2,7 +2,13 @@ use crate::{env::Env, file_saver::*, nameutil::*};
 use log::info;
 use std::path::Path;
 
-pub fn generate(env: &Env, root_path: &Path, mod_rs: &mut Vec<String>, traits: &mut Vec<String>) {
+pub fn generate(
+    env: &Env,
+    root_path: &Path,
+    mod_rs: &mut Vec<String>,
+    traits: &mut Vec<String>,
+    builders: &mut Vec<String>,
+) {
     info!("Generate objects");
     for class_analysis in env.analysis.objects.values() {
         let obj = &env.config.objects[&class_analysis.full_name];
@@ -24,6 +30,6 @@ pub fn generate(env: &Env, root_path: &Path, mod_rs: &mut Vec<String>, traits: &
             super::object::generate(w, env, class_analysis, generate_display_trait)
         });
 
-        super::object::generate_reexports(env, class_analysis, &mod_name, mod_rs, traits);
+        super::object::generate_reexports(env, class_analysis, &mod_name, mod_rs, traits, builders);
     }
 }


### PR DESCRIPTION
This is a workaround to make sure the builders are usable from outside
without making the modules public nor clutering the main root docs