### PR TITLE
codegen: stop renaming crates inside sys generated code

### DIFF
--- a/tests/sys/atk-sys/Cargo.toml
+++ b/tests/sys/atk-sys/Cargo.toml
@@ -6,10 +6,12 @@ system-deps = "5"
 bitflags = "1.0"
 libc = "0.2"
 
-[dependencies.glib-sys]
+[dependencies.glib]
+package = "glib-sys"
 path = "../glib-sys"
 
-[dependencies.gobject-sys]
+[dependencies.gobject]
+package = "gobject-sys"
 path = "../gobject-sys"
 
 [features]

--- a/tests/sys/gdk-pixbuf-sys/Cargo.toml
+++ b/tests/sys/gdk-pixbuf-sys/Cargo.toml
@@ -6,13 +6,16 @@ system-deps = "5"
 bitflags = "1.0"
 libc = "0.2"
 
-[dependencies.gio-sys]
+[dependencies.gio]
+package = "gio-sys"
 path = "../gio-sys"
 
-[dependencies.glib-sys]
+[dependencies.glib]
+package = "glib-sys"
 path = "../glib-sys"
 
-[dependencies.gobject-sys]
+[dependencies.gobject]
+package = "gobject-sys"
 path = "../gobject-sys"
 
 [features]

--- a/tests/sys/gdk-sys/Cargo.toml
+++ b/tests/sys/gdk-sys/Cargo.toml
@@ -6,22 +6,28 @@ system-deps = "5"
 bitflags = "1.0"
 libc = "0.2"
 
-[dependencies.cairo-sys-rs]
+[dependencies.cairo]
+package = "cairo-sys-rs"
 git = "https://github.com/gtk-rs/cairo"
 
-[dependencies.gdk-pixbuf-sys]
+[dependencies.gdk-pixbuf]
+package = "gdk-pixbuf-sys"
 path = "../gdk-pixbuf-sys"
 
-[dependencies.gio-sys]
+[dependencies.gio]
+package = "gio-sys"
 path = "../gio-sys"
 
-[dependencies.glib-sys]
+[dependencies.glib]
+package = "glib-sys"
 path = "../glib-sys"
 
-[dependencies.gobject-sys]
+[dependencies.gobject]
+package = "gobject-sys"
 path = "../gobject-sys"
 
-[dependencies.pango-sys]
+[dependencies.pango]
+package = "pango-sys"
 path = "../pango-sys"
 
 [features]

--- a/tests/sys/gio-sys/Cargo.toml
+++ b/tests/sys/gio-sys/Cargo.toml
@@ -6,10 +6,12 @@ system-deps = "5"
 bitflags = "1.0"
 libc = "0.2"
 
-[dependencies.glib-sys]
+[dependencies.glib]
+package = "glib-sys"
 path = "../glib-sys"
 
-[dependencies.gobject-sys]
+[dependencies.gobject]
+package = "gobject-sys"
 path = "../gobject-sys"
 
 [features]

--- a/tests/sys/gobject-sys/Cargo.toml
+++ b/tests/sys/gobject-sys/Cargo.toml
@@ -6,7 +6,8 @@ system-deps = "5"
 bitflags = "1.0"
 libc = "0.2"
 
-[dependencies.glib-sys]
+[dependencies.glib]
+package = "glib-sys"
 path = "../glib-sys"
 
 [features]

--- a/tests/sys/gtk-sys/Cargo.toml
+++ b/tests/sys/gtk-sys/Cargo.toml
@@ -6,28 +6,36 @@ system-deps = "5"
 bitflags = "1.0"
 libc = "0.2"
 
-[dependencies.atk-sys]
+[dependencies.atk]
+package = "atk-sys"
 path = "../atk-sys"
 
-[dependencies.cairo-sys-rs]
+[dependencies.cairo]
+package = "cairo-sys-rs"
 git = "https://github.com/gtk-rs/cairo"
 
-[dependencies.gdk-pixbuf-sys]
+[dependencies.gdk-pixbuf]
+package = "gdk-pixbuf-sys"
 path = "../gdk-pixbuf-sys"
 
-[dependencies.gdk-sys]
+[dependencies.gdk]
+package = "gdk-sys"
 path = "../gdk-sys"
 
-[dependencies.gio-sys]
+[dependencies.gio]
+package = "gio-sys"
 path = "../gio-sys"
 
-[dependencies.glib-sys]
+[dependencies.glib]
+package = "glib-sys"
 path = "../glib-sys"
 
-[dependencies.gobject-sys]
+[dependencies.gobject]
+package = "gobject-sys"
 path = "../gobject-sys"
 
-[dependencies.pango-sys]
+[dependencies.pango]
+package = "pango-sys"
 path = "../pango-sys"
 
 [features]

--- a/tests/sys/pango-sys/Cargo.toml
+++ b/tests/sys/pango-sys/Cargo.toml
@@ -6,10 +6,12 @@ system-deps = "5"
 bitflags = "1.0"
 libc = "0.2"
 
-[dependencies.glib-sys]
+[dependencies.glib]
+package = "glib-sys"
 path = "../glib-sys"
 
-[dependencies.gobject-sys]
+[dependencies.gobject]
+package = "gobject-sys"
 path = "../gobject-sys"
 
 [features]

--- a/tests/sys/sys_build/Cargo.toml
+++ b/tests/sys/sys_build/Cargo.toml
@@ -5,10 +5,11 @@ edition = "2021"
 
 [features]
 full = []
-v3_16 = ["gtk-sys/v3_16"]
-v3_18 = ["v3_16", "gtk-sys/v3_18"]
-v3_20 = ["v3_18", "gtk-sys/v3_20"]
-v3_22 = ["v3_20", "gtk-sys/v3_22"]
+v3_16 = ["gtk/v3_16"]
+v3_18 = ["v3_16", "gtk/v3_18"]
+v3_20 = ["v3_18", "gtk/v3_20"]
+v3_22 = ["v3_20", "gtk/v3_22"]
 
-[dependencies.gtk-sys]
+[dependencies.gtk]
+package = "gtk-sys"
 path = "../gtk-sys"

--- a/tests/sys/sys_build/src/main.rs
+++ b/tests/sys/sys_build/src/main.rs
@@ -1,8 +1,7 @@
-extern crate gtk_sys;
 use std::ptr;
 
 fn main() {
     unsafe {
-        gtk_sys::gtk_init(ptr::null_mut(), ptr::null_mut());
+        gtk::gtk_init(ptr::null_mut(), ptr::null_mut());
     }
 }


### PR DESCRIPTION
As per other 2018 edition changes, the renames should be done on Cargo.toml instead
Fixes #998