### PR TITLE
codgen: don't append () to gi-docgen not found functions

### DIFF
--- a/src/codegen/doc/gi_docgen.rs
+++ b/src/codegen/doc/gi_docgen.rs
@@ -317,7 +317,7 @@ impl GiDocgen {
                     |f| f.name == mangle_keywords(name),
                 )
                 .map_or_else(
-                    || format!("`{}::{}()`", ns_type_to_doc(namespace, type_), name),
+                    || format!("`{}::{}`", ns_type_to_doc(namespace, type_), name),
                     |(obj_info, fn_info)| {
                         gen_object_fn_doc_link(obj_info, fn_info, env, in_type, type_)
                     },
@@ -329,9 +329,9 @@ impl GiDocgen {
             } => find_method_or_function_by_name(type_.as_deref(), name, env, in_type, false)
                 .unwrap_or_else(|| {
                     if let Some(ty) = type_ {
-                        format!("`{}::{}()`", ns_type_to_doc(namespace, ty), name)
+                        format!("`{}::{}`", ns_type_to_doc(namespace, ty), name)
                     } else {
-                        format!("`{}()`", name)
+                        format!("`{}`", name)
                     }
                 }),
             GiDocgen::Alias(alias) => gen_alias_doc_link(alias),
@@ -341,7 +341,7 @@ impl GiDocgen {
                 name,
                 is_class_method,
             } => find_method_or_function_by_name(Some(type_), name, env, in_type, *is_class_method)
-                .unwrap_or_else(|| format!("`{}::{}()`", ns_type_to_doc(namespace, type_), name)),
+                .unwrap_or_else(|| format!("`{}::{}`", ns_type_to_doc(namespace, type_), name)),
             GiDocgen::Callback { namespace, name } => {
                 gen_callback_doc_link(&ns_type_to_doc(namespace, name))
             }


### PR DESCRIPTION
Otherwise, the gtk-doc style parsing code, will detect those as functions which ends up breaking
the whole docs, such as issues seen in #1200. Ideally, we would have more robust code
that detects whether the detected item is already a rust item or an item we couldn't found the first time with gi-docgen
to avoid breaking things. But such features are not possible with the currently use regex rust crate

cc @MarijnS95 , what do you think? This only affects gtk4/pango & other crates that uses gi-docgen

Fixes #1200 