### PR TITLE
Remove useless `#[must_use]`

### DIFF
--- a/src/codegen/object.rs
+++ b/src/codegen/object.rs
@@ -440,7 +440,6 @@ impl {name}Builder {{
         "
     // rustdoc-stripper-ignore-next
     /// Build the [`{name}`].
-    #[must_use = \"The builder must be built to be used\"]
     pub fn build(self) -> {name} {{
         let mut properties: Vec<(&str, &dyn ToValue)> = vec![];",
         name = analysis.name


### PR DESCRIPTION
Added in #1263.

What would be nice would be to panic if the `builder` wasn't "built" in a `Drop` implementation.