### PR TITLE
Add `#[must_use]` to the autogenerated builder types

### DIFF
--- a/src/analysis/bounds.rs
+++ b/src/analysis/bounds.rs
@@ -52,7 +52,6 @@ pub struct Bound {
 pub struct Bounds {
     unused: VecDeque<char>,
     used: Vec<Bound>,
-    unused_lifetimes: VecDeque<char>,
     lifetimes: Vec<char>,
 }
 
@@ -63,7 +62,6 @@ impl Default for Bounds {
                 .take_while(|x| *x <= 'Z')
                 .collect(),
             used: Vec::new(),
-            unused_lifetimes: "abcdefg".chars().collect(),
             lifetimes: Vec::new(),
         }
     }

--- a/src/codegen/doc/gi_docgen.rs
+++ b/src/codegen/doc/gi_docgen.rs
@@ -258,7 +258,7 @@ impl GiDocgen {
                 .find(|c| &c.name == type_)
                 .map_or_else(
                     || format!("`{}`", ns_type_to_doc(namespace, type_)),
-                    |info| gen_const_doc_link(info),
+                    gen_const_doc_link,
                 ),
             GiDocgen::Property {
                 type_,

--- a/src/codegen/object.rs
+++ b/src/codegen/object.rs
@@ -440,7 +440,7 @@ impl {name}Builder {{
         "
     // rustdoc-stripper-ignore-next
     /// Build the [`{name}`].
-    #[must_use = \"The builder must be built to be used\"]
+    #[must_use = \"Building the object from the builder is usually expensive and is not expected to have side effects\"]
     pub fn build(self) -> {name} {{
         let mut properties: Vec<(&str, &dyn ToValue)> = vec![];",
         name = analysis.name

--- a/src/codegen/object.rs
+++ b/src/codegen/object.rs
@@ -326,6 +326,7 @@ fn generate_builder(w: &mut dyn Write, env: &Env, analysis: &analysis::object::I
         /// [builder-pattern]: https://doc.rust-lang.org/1.0.0/style/ownership/builders.html",
         analysis.name,
     )?;
+    writeln!(w, "#[must_use = \"The builder must be built to be used\"]")?;
     writeln!(w, "pub struct {}Builder {{", analysis.name)?;
     for (builder_props, super_tid) in &analysis.builder_properties {
         for property in builder_props {

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -64,7 +64,6 @@ fn test_normalize_path() {
 #[derive(Debug)]
 pub struct GirVersion {
     pub gir_dir: PathBuf,
-    file_name: Option<String>,
     hash: Option<String>,
     url: Option<String>,
 }
@@ -74,9 +73,6 @@ impl GirVersion {
         let gir_dir = normalize_path(gir_dir);
         let is_submodule = toplevel(&gir_dir) != Path::new(".").canonicalize().ok();
         Self {
-            file_name: gir_dir
-                .file_name()
-                .map(|s| s.to_str().expect("OsStr::to_str failed").to_owned()),
             hash: is_submodule.then(|| repo_hash(&gir_dir).unwrap_or_else(|| "???".to_string())),
             url: is_submodule.then(|| repo_remote_url(&gir_dir)).flatten(),
             gir_dir,

--- a/src/version.rs
+++ b/src/version.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 /// Major, minor and patch version
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Default, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Version(pub u16, pub u16, pub u16);
 
 impl Version {
@@ -73,12 +73,6 @@ impl Display for Version {
             Version(major, minor, 0) => write!(f, "{}.{}", major, minor),
             Version(major, minor, patch) => write!(f, "{}.{}.{}", major, minor, patch),
         }
-    }
-}
-
-impl Default for Version {
-    fn default() -> Version {
-        Version(0, 0, 0)
     }
 }
 


### PR DESCRIPTION
They don't do anything on their own and must be built to have any effect.

Fixes https://github.com/gtk-rs/gir/issues/1278