### PR TITLE
codegen/function: assert sane GError behavior

### DIFF
--- a/src/chunk/chunk.rs
+++ b/src/chunk/chunk.rs
@@ -51,7 +51,9 @@ pub enum Chunk {
         condition: String,
         value: Box<Chunk>,
     },
+    AssertErrorSanity,
     ErrorResultReturn {
+        ret: Option<Box<Chunk>>,
         value: Box<Chunk>,
     },
     AssertInit(SafetyAssertionMode),

--- a/src/codegen/function_body_chunk.rs
+++ b/src/codegen/function_body_chunk.rs
@@ -864,6 +864,7 @@ impl Builder {
             name: "result".to_string(),
             is_mut: false,
             value: Box::new(Chunk::ErrorResultReturn {
+                ret: None,
                 value: Box::new(result),
             }),
             type_: None,
@@ -1190,7 +1191,9 @@ impl Builder {
                     panic!("Call without Chunk::FfiCallConversion")
                 };
                 self.remove_extra_assume_init(&array_length_name, uninitialized_vars);
+                let assert_safe_ret;
                 let call = if use_ret {
+                    assert_safe_ret = Option::None;
                     Chunk::Let {
                         name: "ret".into(),
                         is_mut: false,
@@ -1198,8 +1201,9 @@ impl Builder {
                         type_: Option::None,
                     }
                 } else {
+                    assert_safe_ret = Some(Box::new(Chunk::AssertErrorSanity));
                     Chunk::Let {
-                        name: "_".into(),
+                        name: "is_ok".into(),
                         is_mut: false,
                         value: boxed_call,
                         type_: Option::None,
@@ -1221,6 +1225,7 @@ impl Builder {
                     panic!("Return is not Tuple")
                 }
                 ret = Chunk::ErrorResultReturn {
+                    ret: assert_safe_ret,
                     value: Box::new(ret),
                 };
                 (call, Some(ret))

--- a/src/writer/to_code.rs
+++ b/src/writer/to_code.rs
@@ -116,12 +116,21 @@ impl ToCode for Chunk {
                 let s = format_block_one_line(&prefix, suffix, &value_strings, "", "");
                 vec![s]
             }
-            ErrorResultReturn { ref value } => {
+            AssertErrorSanity => {
+                let assert = "assert_eq!(is_ok == 0, !error.is_null());";
+                vec![assert.to_string()]
+            }
+            ErrorResultReturn { ref ret, ref value } => {
+                let mut lines = match ret {
+                    Some(r) => r.to_code(env),
+                    None => vec![],
+                };
                 let value_strings = value.to_code(env);
                 let prefix = "if error.is_null() { Ok(";
                 let suffix = ") } else { Err(from_glib_full(error)) }";
                 let s = format_block_one_line(prefix, suffix, &value_strings, "", "");
-                vec![s]
+                lines.push(s);
+                lines
             }
             AssertInit(x) => vec![safety_assertion_mode_to_str(x).to_owned()],
             Connect {


### PR DESCRIPTION
This introduces an assertion in generated code for FFI logic
making use of GError.
When the wrapped function returns an error code, there are some
idioms like `g_return_val_if_fail (..., FALSE)` where the GError
does not get properly set and the two mechanisms end up disagreeing.
Such case is considered undefined behavior by glib, and may indeed
result in buggy execution flow not detected as such.
In order to avoid that, gir now cross-checks the returned code and
the GError value before proceeding further.

Closes: https://github.com/gtk-rs/gir/issues/1279