### PR TITLE
 docs: allow documenting global functions in traits 

### DIFF
--- a/src/analysis/functions.rs
+++ b/src/analysis/functions.rs
@@ -93,6 +93,7 @@ pub struct Info {
     pub cfg_condition: Option<String>,
     pub assertion: SafetyAssertionMode,
     pub doc_hidden: bool,
+    pub doc_trait_name: Option<String>,
     pub doc_ignore_parameters: HashSet<String>,
     pub r#async: bool,
     pub unsafe_: bool,
@@ -640,6 +641,9 @@ fn analyze_function(
         .iter()
         .find_map(|f| f.cfg_condition.clone());
     let doc_hidden = configured_functions.iter().any(|f| f.doc_hidden);
+    let doc_trait_name = configured_functions
+        .iter()
+        .find_map(|f| f.doc_trait_name.clone());
     let doc_ignore_parameters = configured_functions
         .iter()
         .find(|f| !f.doc_ignore_parameters.is_empty())
@@ -902,6 +906,7 @@ fn analyze_function(
         cfg_condition,
         assertion,
         doc_hidden,
+        doc_trait_name,
         doc_ignore_parameters,
         r#async,
         unsafe_,

--- a/src/codegen/doc/mod.rs
+++ b/src/codegen/doc/mod.rs
@@ -174,6 +174,12 @@ fn generate_doc(w: &mut dyn Write, env: &Env) -> Result<()> {
                     .iter()
                     .find(move |f| &f.glib_name == c_identifier)
                     .and_then(|analysed_f| analysed_f.new_name.clone());
+                let doc_trait_name = (&global_functions.functions)
+                    .iter()
+                    .find(move |f| &f.glib_name == c_identifier)
+                    .map(|f| f.doc_trait_name.as_ref())
+                    .flatten();
+                let parent = doc_trait_name.map(|p| Box::new(TypeStruct::new(SType::Trait, p)));
 
                 let doc_ignored_parameters = (&global_functions.functions)
                     .iter()
@@ -184,7 +190,7 @@ fn generate_doc(w: &mut dyn Write, env: &Env) -> Result<()> {
                     w,
                     env,
                     function,
-                    None,
+                    parent,
                     fn_new_name,
                     doc_ignored_parameters,
                     None,


### PR DESCRIPTION
Allow documenting global functions in a specific trait by making use of `doc_trait_name` and rustdoc-stripper takes care of the rest.

Fixes #799
