### PR TITLE
docs: allow to set doc_struct_name for global functions

### DIFF
--- a/book/src/config_api.md
+++ b/book/src/config_api.md
@@ -265,6 +265,10 @@ status = "generate"
     name = "stock_list_ids"
     # allows to ignore global functions
     ignore = true
+    # allows to define if the function was moved to a trait 
+    doc_trait_name = "StockExt"
+    # allows to define if the function was moved to a struct
+    doc_struct_name = "Stock"
 ```
 
 Which will prevent gir from generating `stock_list_ids`. If you want to specify

--- a/src/analysis/functions.rs
+++ b/src/analysis/functions.rs
@@ -120,10 +120,12 @@ impl Info {
 
     // returns whether the method can be linked in the docs
     pub fn should_be_doc_linked(&self, env: &Env) -> bool {
-        !self.status.ignored()
+        self.should_docs_be_generated(env)
             && (self.status.manual() || self.visibility.code_visible())
-            && !self.is_special()
-            && !self.is_async_finish(env)
+    }
+
+    pub fn should_docs_be_generated(&self, env: &Env) -> bool {
+        !self.status.ignored() && !self.is_special() && !self.is_async_finish(env)
     }
 
     pub fn doc_link(

--- a/src/analysis/functions.rs
+++ b/src/analysis/functions.rs
@@ -94,6 +94,7 @@ pub struct Info {
     pub assertion: SafetyAssertionMode,
     pub doc_hidden: bool,
     pub doc_trait_name: Option<String>,
+    pub doc_struct_name: Option<String>,
     pub doc_ignore_parameters: HashSet<String>,
     pub r#async: bool,
     pub unsafe_: bool,
@@ -644,6 +645,9 @@ fn analyze_function(
     let doc_trait_name = configured_functions
         .iter()
         .find_map(|f| f.doc_trait_name.clone());
+    let doc_struct_name = configured_functions
+        .iter()
+        .find_map(|f| f.doc_struct_name.clone());
     let doc_ignore_parameters = configured_functions
         .iter()
         .find(|f| !f.doc_ignore_parameters.is_empty())
@@ -907,6 +911,7 @@ fn analyze_function(
         assertion,
         doc_hidden,
         doc_trait_name,
+        doc_struct_name,
         doc_ignore_parameters,
         r#async,
         unsafe_,

--- a/src/codegen/doc/mod.rs
+++ b/src/codegen/doc/mod.rs
@@ -415,9 +415,18 @@ fn create_object_doc(w: &mut dyn Write, env: &Env, info: &analysis::object::Info
             && function.parameters.iter().any(|p| p.instance_parameter)
             && !info.final_type
         {
+            if let Some(struct_name) = configured_functions
+                .iter()
+                .find_map(|f| f.doc_struct_name.as_ref())
+            {
+                (
+                    TypeStruct::new(SType::Impl, struct_name),
+                    Some(LocationInObject::Impl),
+                )
+            }
             // We use "original_name" here to be sure to get the correct object since the "name"
             // field could have been renamed.
-            if let Some(trait_name) = configured_functions
+            else if let Some(trait_name) = configured_functions
                 .iter()
                 .find_map(|f| f.doc_trait_name.as_ref())
             {

--- a/src/codegen/doc/mod.rs
+++ b/src/codegen/doc/mod.rs
@@ -170,18 +170,12 @@ fn generate_doc(w: &mut dyn Write, env: &Env) -> Result<()> {
 
         for function in functions {
             if let Some(ref c_identifier) = function.c_identifier {
-                let fn_new_name = (&global_functions.functions)
+                let f_info = (&global_functions.functions)
                     .iter()
-                    .find(move |f| &f.glib_name == c_identifier)
-                    .and_then(|analysed_f| analysed_f.new_name.clone());
-                let doc_trait_name = (&global_functions.functions)
-                    .iter()
-                    .find(move |f| &f.glib_name == c_identifier)
-                    .and_then(|f| f.doc_trait_name.as_ref());
-                let doc_struct_name = (&global_functions.functions)
-                    .iter()
-                    .find(move |f| &f.glib_name == c_identifier)
-                    .and_then(|f| f.doc_struct_name.as_ref());
+                    .find(move |f| &f.glib_name == c_identifier);
+                let fn_new_name = f_info.and_then(|analysed_f| analysed_f.new_name.clone());
+                let doc_trait_name = f_info.and_then(|f| f.doc_trait_name.as_ref());
+                let doc_struct_name = f_info.and_then(|f| f.doc_struct_name.as_ref());
                 if doc_trait_name.is_some() && doc_struct_name.is_some() {
                     panic!(
                         "Can't use both doc_trait_name and doc_struct_name on the same function"
@@ -196,11 +190,17 @@ fn generate_doc(w: &mut dyn Write, env: &Env) -> Result<()> {
                     None
                 };
 
-                let doc_ignored_parameters = (&global_functions.functions)
-                    .iter()
-                    .find(|f| &f.glib_name == c_identifier)
+                let doc_ignored_parameters = f_info
                     .map(|analyzed_f| analyzed_f.doc_ignore_parameters.clone())
                     .unwrap_or_default();
+
+                let should_be_documented = f_info
+                    .map(|f| f.should_docs_be_generated(env))
+                    .unwrap_or(false);
+                if !should_be_documented {
+                    continue;
+                }
+
                 create_fn_doc(
                     w,
                     env,
@@ -441,16 +441,18 @@ fn create_object_doc(w: &mut dyn Write, env: &Env, info: &analysis::object::Info
             (ty.clone(), Some(LocationInObject::Impl))
         };
         if let Some(c_identifier) = &function.c_identifier {
+            let f_info = info.functions.iter().find(|f| &f.glib_name == c_identifier);
+            let should_be_documented = f_info
+                .map(|f| f.should_docs_be_generated(env))
+                .unwrap_or(false);
+
+            if !should_be_documented {
+                continue;
+            }
+
             // Retrieve the new_name computed during analysis, if any
-            let fn_new_name = info
-                .functions
-                .iter()
-                .find(|f| &f.glib_name == c_identifier)
-                .and_then(|analysed_f| analysed_f.new_name.clone());
-            let doc_ignored_parameters = info
-                .functions
-                .iter()
-                .find(|f| &f.glib_name == c_identifier)
+            let fn_new_name = f_info.and_then(|analysed_f| analysed_f.new_name.clone());
+            let doc_ignored_parameters = f_info
                 .map(|analyzed_f| analyzed_f.doc_ignore_parameters.clone())
                 .unwrap_or_default();
             create_fn_doc(
@@ -554,11 +556,15 @@ fn create_record_doc(w: &mut dyn Write, env: &Env, info: &analysis::record::Info
     };
     for function in &record.functions {
         if let Some(c_identifier) = &function.c_identifier {
-            let fn_new_name = info
-                .functions
-                .iter()
-                .find(|f| &f.glib_name == c_identifier)
-                .and_then(|analysed_f| analysed_f.new_name.clone());
+            let f_info = info.functions.iter().find(|f| &f.glib_name == c_identifier);
+            let should_be_documented = f_info
+                .map(|f| f.should_docs_be_generated(env))
+                .unwrap_or(false);
+            if !should_be_documented {
+                continue;
+            }
+            let fn_new_name = f_info.and_then(|analysed_f| analysed_f.new_name.clone());
+
             create_fn_doc(
                 w,
                 env,

--- a/src/codegen/doc/mod.rs
+++ b/src/codegen/doc/mod.rs
@@ -177,9 +177,24 @@ fn generate_doc(w: &mut dyn Write, env: &Env) -> Result<()> {
                 let doc_trait_name = (&global_functions.functions)
                     .iter()
                     .find(move |f| &f.glib_name == c_identifier)
-                    .map(|f| f.doc_trait_name.as_ref())
-                    .flatten();
-                let parent = doc_trait_name.map(|p| Box::new(TypeStruct::new(SType::Trait, p)));
+                    .and_then(|f| f.doc_trait_name.as_ref());
+                let doc_struct_name = (&global_functions.functions)
+                    .iter()
+                    .find(move |f| &f.glib_name == c_identifier)
+                    .and_then(|f| f.doc_struct_name.as_ref());
+                if doc_trait_name.is_some() && doc_struct_name.is_some() {
+                    panic!(
+                        "Can't use both doc_trait_name and doc_struct_name on the same function"
+                    );
+                }
+
+                let parent = if doc_trait_name.is_some() {
+                    doc_trait_name.map(|p| Box::new(TypeStruct::new(SType::Trait, p)))
+                } else if doc_struct_name.is_some() {
+                    doc_struct_name.map(|p| Box::new(TypeStruct::new(SType::Impl, p)))
+                } else {
+                    None
+                };
 
                 let doc_ignored_parameters = (&global_functions.functions)
                     .iter()

--- a/src/config/functions.rs
+++ b/src/config/functions.rs
@@ -279,6 +279,7 @@ pub struct Function {
     pub is_windows_utf8: bool,
     pub disable_length_detect: bool,
     pub doc_trait_name: Option<String>,
+    pub doc_struct_name: Option<String>,
     pub no_future: bool,
     pub unsafe_: bool,
     pub rename: Option<String>,
@@ -314,6 +315,7 @@ impl Parse for Function {
                 "disable_length_detect",
                 "pattern",
                 "doc_trait_name",
+                "doc_struct_name",
                 "no_future",
                 "unsafe",
                 "rename",
@@ -375,6 +377,10 @@ impl Parse for Function {
             .lookup("doc_trait_name")
             .and_then(Value::as_str)
             .map(ToOwned::to_owned);
+        let doc_struct_name = toml
+            .lookup("doc_struct_name")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned);
         let no_future = toml
             .lookup("no_future")
             .and_then(Value::as_bool)
@@ -417,6 +423,7 @@ impl Parse for Function {
             is_windows_utf8,
             disable_length_detect,
             doc_trait_name,
+            doc_struct_name,
             no_future,
             unsafe_,
             rename,


### PR DESCRIPTION
Some of those are moved to a different struct in some cases
like gdk::Key and would be nice to have them documented