### PR TITLE
docs: avoid generating docs for uneeded properties getters/setters

### DIFF
--- a/src/codegen/doc/mod.rs
+++ b/src/codegen/doc/mod.rs
@@ -860,7 +860,7 @@ fn create_property_doc(
             ..TypeStruct::new(SType::Fn, &getter_name)
         });
     }
-    if property.writable && !has_setter_method {
+    if property.writable && !property.construct_only && !has_setter_method {
         v.push(TypeStruct {
             parent,
             ..TypeStruct::new(SType::Fn, &setter_name)

--- a/src/codegen/doc/mod.rs
+++ b/src/codegen/doc/mod.rs
@@ -338,10 +338,10 @@ fn create_object_doc(w: &mut dyn Write, env: &Env, info: &analysis::object::Info
         for parent_info in &info.supertypes {
             match env.library.type_(parent_info.type_id) {
                 Type::Class(cl) => {
-                    builder_properties.extend(cl.properties.iter());
+                    builder_properties.extend(cl.properties.iter().filter(|p| p.writable));
                 }
                 Type::Interface(iface) => {
-                    builder_properties.extend(iface.properties.iter());
+                    builder_properties.extend(iface.properties.iter().filter(|p| p.writable));
                 }
                 _ => (),
             }


### PR DESCRIPTION
There are still some cases left like when a function has a getter but the getter was renamed to something else so we can't do a match between the "expected getter name" & the one we get at the end.