### PR TITLE
parser: support properties getters/setters

### DIFF
--- a/src/analysis/functions.rs
+++ b/src/analysis/functions.rs
@@ -98,6 +98,8 @@ pub struct Info {
     /// this potential global function is defined
     pub ns_id: NsId,
     pub generate_doc: bool,
+    pub getter_prop: Option<String>,
+    pub setter_prop: Option<String>,
 }
 
 impl Info {
@@ -921,6 +923,8 @@ fn analyze_function(
         async_future,
         callbacks,
         destroys,
+        getter_prop: func.getter_prop.clone(),
+        setter_prop: func.setter_prop.clone(),
         remove_params: cross_user_data_check.values().cloned().collect::<Vec<_>>(),
         commented,
         hidden: false,

--- a/src/analysis/properties.rs
+++ b/src/analysis/properties.rs
@@ -124,14 +124,20 @@ fn analyze_property(
     let bypass_auto_rename = configured_properties.iter().any(|f| f.bypass_auto_rename);
     let (check_get_func_names, mut get_func_name) = if bypass_auto_rename {
         (
-            vec![format!("get_{}", name_for_func)],
+            vec![prop
+                .getter
+                .clone()
+                .unwrap_or_else(|| format!("get_{}", name_for_func))],
             get_prop_name.take().expect("defined 10 lines above"),
         )
     } else {
         get_func_name(&name_for_func, prop.typ == library::TypeId::tid_bool())
     };
 
-    let mut set_func_name = format!("set_{}", name_for_func);
+    let mut set_func_name = prop
+        .setter
+        .clone()
+        .unwrap_or_else(|| format!("set_{}", name_for_func));
     let mut set_prop_name = Some(format!("set_property_{}", name_for_func));
 
     let mut readable = prop.readable;

--- a/src/codegen/doc/mod.rs
+++ b/src/codegen/doc/mod.rs
@@ -511,21 +511,6 @@ fn create_object_doc(w: &mut dyn Write, env: &Env, info: &analysis::object::Info
         )?;
     }
     for property in properties {
-        let getter_name = property.getter.clone().or_else(|| {
-            info.properties
-                .iter()
-                .filter(|p| p.is_get)
-                .find(|p| p.name == property.name)
-                .map(|p| p.func_name.clone())
-        });
-
-        let setter_name = property.setter.clone().or_else(|| {
-            info.properties
-                .iter()
-                .filter(|p| !p.is_get)
-                .find(|p| p.name == property.name)
-                .map(|p| p.func_name.clone())
-        });
         let (ty, object_location) = if has_trait {
             let configured_properties = obj.properties.matched(&property.name);
             if let Some(trait_name) = configured_properties
@@ -545,8 +530,6 @@ fn create_object_doc(w: &mut dyn Write, env: &Env, info: &analysis::object::Info
             property,
             Some(Box::new(ty)),
             (&info.type_id, object_location),
-            getter_name,
-            setter_name,
             info,
         )?;
     }
@@ -883,8 +866,6 @@ fn create_property_doc(
     property: &Property,
     parent: Option<Box<TypeStruct>>,
     in_type: (&TypeId, Option<LocationInObject>),
-    getter_name: Option<String>,
-    setter_name: Option<String>,
     obj_info: &analysis::object::Info,
 ) -> Result<()> {
     if env.is_totally_deprecated(Some(in_type.0.ns_id), property.deprecated_version) {
@@ -904,30 +885,48 @@ fn create_property_doc(
     {
         return Ok(());
     }
-    let name_for_func = nameutil::signal_to_snake(&property.name);
-    let getter_name = getter_name.unwrap_or_else(|| name_for_func.clone());
-    let has_getter_method = obj_info.functions.iter().any(|f| {
-        f.func_name == getter_name || f.new_name.as_ref().map_or(false, |n| n == &getter_name)
-    });
-
-    let setter_name = setter_name.unwrap_or_else(|| format!("set_{}", &name_for_func));
-    let has_setter_method = obj_info.functions.iter().any(|f| {
-        f.func_name == setter_name || f.new_name.as_ref().map_or(false, |n| n == &setter_name)
-    });
+    let has_getter_method = property.getter.is_some()
+        && obj_info
+            .functions
+            .iter()
+            .any(|f| Some(&f.func_name) == property.getter.as_ref());
+    let has_setter_method = property.setter.is_some()
+        && obj_info
+            .functions
+            .iter()
+            .any(|f| Some(&f.func_name) == property.setter.as_ref());
 
     let mut v = Vec::with_capacity(2);
 
     if property.readable && !has_getter_method {
-        v.push(TypeStruct {
-            parent: parent.clone(),
-            ..TypeStruct::new(SType::Fn, &getter_name)
+        let getter_name = obj_info.properties.iter().find_map(|p| {
+            if p.name == property.name && p.is_get {
+                Some(p.func_name.clone())
+            } else {
+                None
+            }
         });
+        if let Some(getter) = getter_name {
+            v.push(TypeStruct {
+                parent: parent.clone(),
+                ..TypeStruct::new(SType::Fn, &getter)
+            });
+        }
     }
     if property.writable && !property.construct_only && !has_setter_method {
-        v.push(TypeStruct {
-            parent,
-            ..TypeStruct::new(SType::Fn, &setter_name)
+        let setter_name = obj_info.properties.iter().find_map(|p| {
+            if p.name == property.name && !p.is_get {
+                Some(p.func_name.clone())
+            } else {
+                None
+            }
         });
+        if let Some(setter) = setter_name {
+            v.push(TypeStruct {
+                parent,
+                ..TypeStruct::new(SType::Fn, &setter)
+            });
+        }
     }
 
     for item in &v {

--- a/src/codegen/doc/mod.rs
+++ b/src/codegen/doc/mod.rs
@@ -511,19 +511,21 @@ fn create_object_doc(w: &mut dyn Write, env: &Env, info: &analysis::object::Info
         )?;
     }
     for property in properties {
-        let getter_name = info
-            .properties
-            .iter()
-            .filter(|p| p.is_get)
-            .find(|p| p.name == property.name)
-            .map(|p| p.func_name.clone());
+        let getter_name = property.getter.clone().or_else(|| {
+            info.properties
+                .iter()
+                .filter(|p| p.is_get)
+                .find(|p| p.name == property.name)
+                .map(|p| p.func_name.clone())
+        });
 
-        let setter_name = info
-            .properties
-            .iter()
-            .filter(|p| !p.is_get)
-            .find(|p| p.name == property.name)
-            .map(|p| p.func_name.clone());
+        let setter_name = property.setter.clone().or_else(|| {
+            info.properties
+                .iter()
+                .filter(|p| !p.is_get)
+                .find(|p| p.name == property.name)
+                .map(|p| p.func_name.clone())
+        });
         let (ty, object_location) = if has_trait {
             let configured_properties = obj.properties.matched(&property.name);
             if let Some(trait_name) = configured_properties

--- a/src/library.rs
+++ b/src/library.rs
@@ -541,6 +541,8 @@ pub struct Function {
     pub deprecated_version: Option<Version>,
     pub doc: Option<String>,
     pub doc_deprecated: Option<String>,
+    pub getter_prop: Option<String>,
+    pub setter_prop: Option<String>,
 }
 
 #[derive(Debug)]

--- a/src/library.rs
+++ b/src/library.rs
@@ -496,6 +496,8 @@ pub struct Property {
     pub readable: bool,
     pub writable: bool,
     pub construct: bool,
+    pub getter: Option<String>,
+    pub setter: Option<String>,
     pub construct_only: bool,
     pub typ: TypeId,
     pub c_type: Option<String>,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1234,6 +1234,8 @@ impl Library {
         let writable = elem.attr_bool("writable", false);
         let construct = elem.attr_bool("construct", false);
         let construct_only = elem.attr_bool("construct-only", false);
+        let getter = elem.attr("getter").map(|g| g.to_string());
+        let setter = elem.attr("setter").map(|g| g.to_string());
         let transfer = Transfer::from_str(elem.attr("transfer-ownership").unwrap_or("none"))
             .map_err(|why| parser.fail_with_position(&why, elem.position()))?;
 
@@ -1282,6 +1284,8 @@ impl Library {
                 construct_only,
                 transfer,
                 typ: tid,
+                getter,
+                setter,
                 c_type,
                 version,
                 deprecated_version,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -934,6 +934,8 @@ impl Library {
     ) -> Result<Function, String> {
         let fn_name = elem.attr_required("name")?;
         let c_identifier = elem.attr("identifier").or_else(|| elem.attr("type"));
+        let getter_prop = elem.attr("glib:get-property").map(|g| g.to_string());
+        let setter_prop = elem.attr("glib:set-property").map(|g| g.to_string());
         let kind = FunctionKind::from_str(kind_str).map_err(|why| parser.fail(&why))?;
         let is_method = kind == FunctionKind::Method;
         let version = self.read_version(parser, ns_id, elem)?;
@@ -998,6 +1000,8 @@ impl Library {
                 deprecated_version,
                 doc,
                 doc_deprecated,
+                getter_prop,
+                setter_prop,
             })
         } else {
             Err(parser.fail_with_position(


### PR DESCRIPTION
The change requires the Gir files to be generated with gobject-introspection 1.70. With the current changes, the number of generated but unneeded docs for properties getters/setters 

cc @fengalin 