### PR TITLE
Allow tweaking visibility 

### DIFF
--- a/book/src/config_api.md
+++ b/book/src/config_api.md
@@ -108,6 +108,8 @@ generate_builder = true
 # trust return value nullability annotations for this specific type.
 # See above for details and use with care
 trust_return_value_nullability = false
+# Tweak the visibility of the type
+visibility = "pub" # or 'crate' / 'private' / 'super'
     # define overrides for function
     [[object.function]]
     # filter functions from object
@@ -137,6 +139,8 @@ trust_return_value_nullability = false
     # to override the default safety assertions: "none", "skip",
     # "not-initialized", "in-main-thread"
     assertion = "in-main-thread"
+    # Tweak the visibility of the function
+    visibility = "pub" # or 'crate' / 'private' / 'super'
         # override for parameter
         [[object.function.parameter]]
         # filter by name

--- a/src/analysis/enums.rs
+++ b/src/analysis/enums.rs
@@ -1,5 +1,5 @@
 use super::{function_parameters::TransformationType, imports::Imports, *};
-use crate::{config::gobjects::GObject, env::Env, nameutil::*, traits::*};
+use crate::{codegen::Visibility, config::gobjects::GObject, env::Env, nameutil::*, traits::*};
 
 use log::info;
 
@@ -10,6 +10,7 @@ pub struct Info {
     pub name: String,
     pub functions: Vec<functions::Info>,
     pub specials: special_functions::Infos,
+    pub visibility: Visibility,
 }
 
 impl Info {
@@ -116,6 +117,7 @@ pub fn new(env: &Env, obj: &GObject, imports: &mut Imports) -> Option<Info> {
         name: name.to_owned(),
         functions,
         specials,
+        visibility: obj.visibility,
     };
 
     Some(info)

--- a/src/analysis/flags.rs
+++ b/src/analysis/flags.rs
@@ -1,5 +1,5 @@
 use super::{function_parameters::TransformationType, imports::Imports, *};
-use crate::{config::gobjects::GObject, env::Env, nameutil::*, traits::*};
+use crate::{codegen::Visibility, config::gobjects::GObject, env::Env, nameutil::*, traits::*};
 
 use log::info;
 
@@ -10,6 +10,7 @@ pub struct Info {
     pub name: String,
     pub functions: Vec<functions::Info>,
     pub specials: special_functions::Infos,
+    pub visibility: Visibility,
 }
 
 impl Info {
@@ -111,6 +112,7 @@ pub fn new(env: &Env, obj: &GObject, imports: &mut Imports) -> Option<Info> {
         name: name.to_owned(),
         functions,
         specials,
+        visibility: obj.visibility,
     };
 
     Some(info)

--- a/src/analysis/info_base.rs
+++ b/src/analysis/info_base.rs
@@ -1,5 +1,5 @@
 use super::{imports::Imports, *};
-use crate::{library, version::Version};
+use crate::{codegen::Visibility, library, version::Version};
 
 #[derive(Debug, Default)]
 pub struct InfoBase {
@@ -13,6 +13,7 @@ pub struct InfoBase {
     pub deprecated_version: Option<Version>,
     pub cfg_condition: Option<String>,
     pub concurrency: library::Concurrency,
+    pub visibility: Visibility,
 }
 
 impl InfoBase {

--- a/src/analysis/object.rs
+++ b/src/analysis/object.rs
@@ -255,6 +255,7 @@ pub fn class(env: &Env, obj: &GObject, deps: &[library::TypeId]) -> Option<Info>
         deprecated_version,
         cfg_condition: obj.cfg_condition.clone(),
         concurrency: obj.concurrency,
+        visibility: obj.visibility,
     };
 
     // patch up trait methods in the symbol table
@@ -364,6 +365,7 @@ pub fn interface(env: &Env, obj: &GObject, deps: &[library::TypeId]) -> Option<I
         deprecated_version,
         cfg_condition: obj.cfg_condition.clone(),
         concurrency: obj.concurrency,
+        visibility: obj.visibility,
     };
 
     let has_functions = !base.functions().is_empty();

--- a/src/analysis/record.rs
+++ b/src/analysis/record.rs
@@ -206,6 +206,7 @@ pub fn new(env: &Env, obj: &GObject) -> Option<Info> {
         deprecated_version,
         cfg_condition: obj.cfg_condition.clone(),
         concurrency: obj.concurrency,
+        visibility: obj.visibility,
     };
 
     let info = Info {

--- a/src/codegen/enums.rs
+++ b/src/codegen/enums.rs
@@ -127,7 +127,7 @@ fn generate_enum(
     writeln!(w, "#[non_exhaustive]")?;
     doc_alias(w, &enum_.c_type, "", 0)?;
 
-    writeln!(w, "pub enum {} {{", enum_.name)?;
+    writeln!(w, "{} enum {} {{", config.visibility, enum_.name)?;
     for member in &members {
         cfg_deprecated(
             w,

--- a/src/codegen/enums.rs
+++ b/src/codegen/enums.rs
@@ -45,15 +45,18 @@ pub fn generate(env: &Env, root_path: &Path, mod_rs: &mut Vec<String>) {
 
             let enum_ = enum_analysis.type_(&env.library);
 
-            if enum_analysis.visibility.is_public() {
-                if let Some(cfg) = version_condition_string(env, None, enum_.version, false, 0) {
-                    mod_rs.push(cfg);
-                }
-                if let Some(cfg) = cfg_condition_string(config.cfg_condition.as_ref(), false, 0) {
-                    mod_rs.push(cfg);
-                }
-                mod_rs.push(format!("pub use self::enums::{};", enum_.name));
+            if let Some(cfg) = version_condition_string(env, None, enum_.version, false, 0) {
+                mod_rs.push(cfg);
             }
+            if let Some(cfg) = cfg_condition_string(config.cfg_condition.as_ref(), false, 0) {
+                mod_rs.push(cfg);
+            }
+            mod_rs.push(format!(
+                "{} use self::enums::{};",
+                enum_analysis.visibility.export_visibility(),
+                enum_.name
+            ));
+
             generate_enum(env, w, enum_, config, enum_analysis)?;
         }
 

--- a/src/codegen/flags.rs
+++ b/src/codegen/flags.rs
@@ -88,7 +88,7 @@ fn generate_flags(
     }
 
     doc_alias(w, &flags.c_type, "", 1)?;
-    writeln!(w, "    pub struct {}: u32 {{", flags.name)?;
+    writeln!(w, "    {} struct {}: u32 {{", config.visibility, flags.name)?;
     for member in &flags.members {
         let member_config = config.members.matched(&member.name);
         if member.status.ignored() {

--- a/src/codegen/flags.rs
+++ b/src/codegen/flags.rs
@@ -43,15 +43,17 @@ pub fn generate(env: &Env, root_path: &Path, mod_rs: &mut Vec<String>) {
             }
             let flags = flags_analysis.type_(&env.library);
 
-            if flags_analysis.visibility.is_public() {
-                if let Some(cfg) = version_condition_string(env, None, flags.version, false, 0) {
-                    mod_rs.push(cfg);
-                }
-                if let Some(cfg) = cfg_condition_string(config.cfg_condition.as_ref(), false, 0) {
-                    mod_rs.push(cfg);
-                }
-                mod_rs.push(format!("pub use self::flags::{};", flags.name));
+            if let Some(cfg) = version_condition_string(env, None, flags.version, false, 0) {
+                mod_rs.push(cfg);
             }
+            if let Some(cfg) = cfg_condition_string(config.cfg_condition.as_ref(), false, 0) {
+                mod_rs.push(cfg);
+            }
+            mod_rs.push(format!(
+                "{} use self::flags::{};",
+                flags_analysis.visibility.export_visibility(),
+                flags.name
+            ));
             generate_flags(env, w, flags, config, flags_analysis)?;
         }
 

--- a/src/codegen/function.rs
+++ b/src/codegen/function.rs
@@ -94,9 +94,16 @@ pub fn generate(
             doc_alias(w, &analysis.func_name, comment_prefix, indent)?;
         }
     }
+    let dead_code_cfg = if !analysis.visibility.is_public() {
+        "#[allow(dead_code)]"
+    } else {
+        ""
+    };
+
     writeln!(
         w,
-        "{}{}{}{}{}{}",
+        "{}{}{}{}{}{}{}",
+        dead_code_cfg,
         tabs(indent),
         comment_prefix,
         pub_prefix,

--- a/src/codegen/general.rs
+++ b/src/codegen/general.rs
@@ -236,6 +236,7 @@ fn define_boxed_type_internal(
     clear_function_expression: &Option<String>,
     get_type_fn: Option<&str>,
     derive: &[Derive],
+    visibility: Visibility,
 ) -> Result<()> {
     let sys_crate_name = env.main_sys_crate_name();
     writeln!(w, "{} {{", use_glib_type(env, "wrapper!"))?;
@@ -243,7 +244,8 @@ fn define_boxed_type_internal(
     derives(w, derive, 1)?;
     writeln!(
         w,
-        "\tpub struct {}(Boxed{}<{}::{}>);",
+        "\t{} struct {}(Boxed{}<{}::{}>);",
+        visibility,
         type_name,
         if boxed_inline { "Inline" } else { "" },
         sys_crate_name,
@@ -299,6 +301,7 @@ pub fn define_boxed_type(
     clear_function_expression: &Option<String>,
     get_type_fn: Option<(String, Option<Version>)>,
     derive: &[Derive],
+    visibility: Visibility,
 ) -> Result<()> {
     writeln!(w)?;
 
@@ -318,6 +321,7 @@ pub fn define_boxed_type(
                 clear_function_expression,
                 Some(get_type_fn),
                 derive,
+                visibility,
             )?;
 
             writeln!(w)?;
@@ -335,6 +339,7 @@ pub fn define_boxed_type(
                 clear_function_expression,
                 None,
                 derive,
+                visibility,
             )?;
         } else {
             define_boxed_type_internal(
@@ -350,6 +355,7 @@ pub fn define_boxed_type(
                 clear_function_expression,
                 Some(get_type_fn),
                 derive,
+                visibility,
             )?;
         }
     } else {
@@ -366,6 +372,7 @@ pub fn define_boxed_type(
             clear_function_expression,
             None,
             derive,
+            visibility,
         )?;
     }
 
@@ -383,6 +390,7 @@ pub fn define_auto_boxed_type(
     clear_function_expression: &Option<String>,
     get_type_fn: &str,
     derive: &[Derive],
+    visibility: Visibility,
 ) -> Result<()> {
     let sys_crate_name = env.main_sys_crate_name();
     writeln!(w)?;
@@ -390,7 +398,8 @@ pub fn define_auto_boxed_type(
     derives(w, derive, 1)?;
     writeln!(
         w,
-        "\tpub struct {}(Boxed{}<{}::{}>);",
+        "\t{} struct {}(Boxed{}<{}::{}>);",
+        visibility,
         type_name,
         if boxed_inline { "Inline" } else { "" },
         sys_crate_name,
@@ -445,14 +454,15 @@ fn define_shared_type_internal(
     unref_fn: &str,
     get_type_fn: Option<&str>,
     derive: &[Derive],
+    visibility: Visibility,
 ) -> Result<()> {
     let sys_crate_name = env.main_sys_crate_name();
     writeln!(w, "{} {{", use_glib_type(env, "wrapper!"))?;
     derives(w, derive, 1)?;
     writeln!(
         w,
-        "\tpub struct {}(Shared<{}::{}>);",
-        type_name, sys_crate_name, glib_name
+        "\t{} struct {}(Shared<{}::{}>);",
+        visibility, type_name, sys_crate_name, glib_name
     )?;
     writeln!(w)?;
     writeln!(w, "\tmatch fn {{")?;
@@ -480,6 +490,7 @@ pub fn define_shared_type(
     unref_fn: &str,
     get_type_fn: Option<(String, Option<Version>)>,
     derive: &[Derive],
+    visibility: Visibility,
 ) -> Result<()> {
     writeln!(w)?;
 
@@ -495,12 +506,13 @@ pub fn define_shared_type(
                 unref_fn,
                 Some(get_type_fn),
                 derive,
+                visibility,
             )?;
 
             writeln!(w)?;
             not_version_condition_no_dox(w, env, None, get_type_version, false, 0)?;
             define_shared_type_internal(
-                w, env, type_name, glib_name, ref_fn, unref_fn, None, derive,
+                w, env, type_name, glib_name, ref_fn, unref_fn, None, derive, visibility,
             )?;
         } else {
             define_shared_type_internal(
@@ -512,10 +524,13 @@ pub fn define_shared_type(
                 unref_fn,
                 Some(get_type_fn),
                 derive,
+                visibility,
             )?;
         }
     } else {
-        define_shared_type_internal(w, env, type_name, glib_name, ref_fn, unref_fn, None, derive)?;
+        define_shared_type_internal(
+            w, env, type_name, glib_name, ref_fn, unref_fn, None, derive, visibility,
+        )?;
     }
 
     Ok(())

--- a/src/codegen/general.rs
+++ b/src/codegen/general.rs
@@ -828,7 +828,7 @@ pub fn declare_default_from_new(
     has_builder: bool,
 ) -> Result<()> {
     if let Some(func) = functions.iter().find(|f| {
-        !f.visibility.hidden()
+        !f.func_visibility.hidden()
             && f.status.need_generate()
             && f.name == "new"
             // Cannot generate Default implementation for Option<>

--- a/src/codegen/general.rs
+++ b/src/codegen/general.rs
@@ -16,6 +16,8 @@ use std::{
     ops::Index,
 };
 
+use super::Visibility;
+
 pub fn start_comments(w: &mut dyn Write, conf: &Config) -> Result<()> {
     if conf.single_version_file.is_some() {
         start_comments_no_version(w, conf)
@@ -122,6 +124,7 @@ pub fn define_object_type(
     glib_func_name: &str,
     is_interface: bool,
     parents: &[StatusedTypeId],
+    visibility: Visibility,
 ) -> Result<()> {
     let sys_crate_name = env.main_sys_crate_name();
     let class_name = {
@@ -145,8 +148,8 @@ pub fn define_object_type(
     if parents.is_empty() {
         writeln!(
             w,
-            "\tpub struct {}({}<{}::{}{}>);",
-            type_name, kind_name, sys_crate_name, glib_name, class_name
+            "\t{} struct {}({}<{}::{}{}>);",
+            visibility, type_name, kind_name, sys_crate_name, glib_name, class_name
         )?;
     } else if is_interface {
         let prerequisites: Vec<String> =
@@ -154,7 +157,8 @@ pub fn define_object_type(
 
         writeln!(
             w,
-            "\tpub struct {}(Interface<{}::{}{}>) @requires {};",
+            "\t{} struct {}(Interface<{}::{}{}>) @requires {};",
+            visibility,
             type_name,
             sys_crate_name,
             glib_name,
@@ -202,8 +206,8 @@ pub fn define_object_type(
 
         writeln!(
             w,
-            "\tpub struct {}(Object<{}::{}{}>){};",
-            type_name, sys_crate_name, glib_name, class_name, parents_string,
+            "\t{} struct {}(Object<{}::{}{}>){};",
+            visibility, type_name, sys_crate_name, glib_name, class_name, parents_string,
         )?;
     }
     writeln!(w)?;

--- a/src/codegen/general.rs
+++ b/src/codegen/general.rs
@@ -847,7 +847,7 @@ pub fn declare_default_from_new(
     has_builder: bool,
 ) -> Result<()> {
     if let Some(func) = functions.iter().find(|f| {
-        !f.func_visibility.hidden()
+        !f.hidden
             && f.status.need_generate()
             && f.name == "new"
             // Cannot generate Default implementation for Option<>

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -28,6 +28,8 @@ mod sys;
 mod trait_impls;
 mod trampoline;
 mod trampoline_from_glib;
+mod visibility;
+pub use visibility::Visibility;
 mod trampoline_to_glib;
 pub mod translate_from_glib;
 pub mod translate_to_glib;

--- a/src/codegen/object.rs
+++ b/src/codegen/object.rs
@@ -591,18 +591,21 @@ pub fn generate_reexports(
     contents.push(format!("mod {};", module_name));
     contents.extend_from_slice(&cfgs);
 
-    if analysis.visibility.is_public() {
-        contents.push(format!("pub use self::{}::{};", module_name, analysis.name,));
+    contents.push(format!(
+        "{} use self::{}::{};",
+        analysis.visibility.export_visibility(),
+        module_name,
+        analysis.name,
+    ));
 
-        if analysis.need_generate_trait() {
-            for cfg in &cfgs {
-                traits.push(format!("\t{}", cfg));
-            }
-            traits.push(format!(
-                "\tpub use super::{}::{};",
-                module_name, analysis.trait_name
-            ));
+    if analysis.need_generate_trait() {
+        for cfg in &cfgs {
+            traits.push(format!("\t{}", cfg));
         }
+        traits.push(format!(
+            "\tpub use super::{}::{};",
+            module_name, analysis.trait_name
+        ));
     }
 
     if has_builder_properties(&analysis.builder_properties) {

--- a/src/codegen/object.rs
+++ b/src/codegen/object.rs
@@ -591,16 +591,18 @@ pub fn generate_reexports(
     contents.push(format!("mod {};", module_name));
     contents.extend_from_slice(&cfgs);
 
-    contents.push(format!("pub use self::{}::{};", module_name, analysis.name,));
+    if analysis.visibility.is_public() {
+        contents.push(format!("pub use self::{}::{};", module_name, analysis.name,));
 
-    if analysis.need_generate_trait() {
-        for cfg in &cfgs {
-            traits.push(format!("\t{}", cfg));
+        if analysis.need_generate_trait() {
+            for cfg in &cfgs {
+                traits.push(format!("\t{}", cfg));
+            }
+            traits.push(format!(
+                "\tpub use super::{}::{};",
+                module_name, analysis.trait_name
+            ));
         }
-        traits.push(format!(
-            "\tpub use super::{}::{};",
-            module_name, analysis.trait_name
-        ));
     }
 
     if has_builder_properties(&analysis.builder_properties) {

--- a/src/codegen/object.rs
+++ b/src/codegen/object.rs
@@ -74,6 +74,7 @@ pub fn generate(
             &analysis.get_type,
             analysis.is_interface,
             &analysis.supertypes,
+            analysis.visibility,
         )?;
     } else {
         // Write the `glib::wrapper!` calls from the highest version to the lowest and remember
@@ -107,6 +108,7 @@ pub fn generate(
                     &analysis.get_type,
                     analysis.is_interface,
                     &supertypes,
+                    analysis.visibility,
                 )?;
 
                 for t in stypes {
@@ -136,6 +138,7 @@ pub fn generate(
             &analysis.get_type,
             analysis.is_interface,
             &supertypes,
+            analysis.visibility,
         )?;
     }
 

--- a/src/codegen/record.rs
+++ b/src/codegen/record.rs
@@ -170,8 +170,10 @@ pub fn generate_reexports(
     };
     contents.push("".to_owned());
     contents.push(format!("{}mod {};", cfg, module_name));
-    contents.push(format!(
-        "{}pub use self::{}::{};",
-        cfg, module_name, analysis.name
-    ));
+    if analysis.visibility.is_public() {
+        contents.push(format!(
+            "{}pub use self::{}::{};",
+            cfg, module_name, analysis.name
+        ));
+    }
 }

--- a/src/codegen/record.rs
+++ b/src/codegen/record.rs
@@ -90,7 +90,7 @@ pub fn generate(w: &mut dyn Write, env: &Env, analysis: &analysis::record::Info)
     if analysis
         .functions
         .iter()
-        .any(|f| f.status.need_generate() && !f.func_visibility.hidden())
+        .any(|f| f.status.need_generate() && !f.hidden)
     {
         writeln!(w)?;
         write!(w, "impl {} {{", analysis.name)?;

--- a/src/codegen/record.rs
+++ b/src/codegen/record.rs
@@ -26,6 +26,7 @@ pub fn generate(w: &mut dyn Write, env: &Env, analysis: &analysis::record::Info)
                 &analysis.clear_function_expression,
                 glib_get_type,
                 &analysis.derives,
+                analysis.visibility,
             )?;
         } else {
             panic!(
@@ -52,6 +53,7 @@ pub fn generate(w: &mut dyn Write, env: &Env, analysis: &analysis::record::Info)
                 }
             }),
             &analysis.derives,
+            analysis.visibility,
         )?;
     } else if let (Some(copy_fn), Some(free_fn)) = (
         analysis.specials.traits().get(&Type::Copy),
@@ -76,6 +78,7 @@ pub fn generate(w: &mut dyn Write, env: &Env, analysis: &analysis::record::Info)
                 }
             }),
             &analysis.derives,
+            analysis.visibility,
         )?;
     } else {
         panic!(

--- a/src/codegen/record.rs
+++ b/src/codegen/record.rs
@@ -87,7 +87,7 @@ pub fn generate(w: &mut dyn Write, env: &Env, analysis: &analysis::record::Info)
     if analysis
         .functions
         .iter()
-        .any(|f| f.status.need_generate() && !f.visibility.hidden())
+        .any(|f| f.status.need_generate() && !f.func_visibility.hidden())
     {
         writeln!(w)?;
         write!(w, "impl {} {{", analysis.name)?;

--- a/src/codegen/record.rs
+++ b/src/codegen/record.rs
@@ -170,10 +170,11 @@ pub fn generate_reexports(
     };
     contents.push("".to_owned());
     contents.push(format!("{}mod {};", cfg, module_name));
-    if analysis.visibility.is_public() {
-        contents.push(format!(
-            "{}pub use self::{}::{};",
-            cfg, module_name, analysis.name
-        ));
-    }
+    contents.push(format!(
+        "{}{} use self::{}::{};",
+        cfg,
+        analysis.visibility.export_visibility(),
+        module_name,
+        analysis.name
+    ));
 }

--- a/src/codegen/special_functions.rs
+++ b/src/codegen/special_functions.rs
@@ -1,7 +1,7 @@
 use std::io::{Result, Write};
 
 use crate::{
-    analysis::{self, functions::FuncVisibility, special_functions::FunctionType},
+    analysis::{self, special_functions::FunctionType},
     version::Version,
     Env,
 };
@@ -37,11 +37,6 @@ pub(super) fn generate_static_to_str(
     let version = Version::if_stricter_than(function.version, scope_version);
     version_condition(w, env, None, version, false, 1)?;
 
-    let visibility = match function.func_visibility {
-        FuncVisibility::Public => "pub ",
-        _ => "",
-    };
-
     writeln!(
         w,
         "\
@@ -56,7 +51,7 @@ pub(super) fn generate_static_to_str(
 \t\t\t.expect(\"{glib_fn_name} returned an invalid string\")
 \t\t}}
 \t}}",
-        visibility = visibility,
+        visibility = function.visibility,
         rust_fn_name = function.codegen_name(),
         ns = env.main_sys_crate_name(),
         glib_fn_name = function.glib_name,

--- a/src/codegen/special_functions.rs
+++ b/src/codegen/special_functions.rs
@@ -1,7 +1,7 @@
 use std::io::{Result, Write};
 
 use crate::{
-    analysis::{self, functions::Visibility, special_functions::FunctionType},
+    analysis::{self, functions::FuncVisibility, special_functions::FunctionType},
     version::Version,
     Env,
 };
@@ -37,8 +37,8 @@ pub(super) fn generate_static_to_str(
     let version = Version::if_stricter_than(function.version, scope_version);
     version_condition(w, env, None, version, false, 1)?;
 
-    let visibility = match function.visibility {
-        Visibility::Public => "pub ",
+    let visibility = match function.func_visibility {
+        FuncVisibility::Public => "pub ",
         _ => "",
     };
 

--- a/src/codegen/visibility.rs
+++ b/src/codegen/visibility.rs
@@ -1,0 +1,71 @@
+use std::fmt;
+use std::str::FromStr;
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum Visibility {
+    Public,
+    Crate,
+    Super,
+    Private,
+}
+
+impl Visibility {
+    pub fn is_public(&self) -> bool {
+        matches!(self, Self::Public)
+    }
+
+    pub fn export_visibility(&self) -> String {
+        match self {
+            Self::Public => "pub",
+            Self::Private => "",
+            Self::Crate => "pub(crate)",
+            Self::Super => "pub(super)",
+        }
+        .to_owned()
+    }
+}
+
+impl Default for Visibility {
+    fn default() -> Self {
+        Self::Public
+    }
+}
+
+impl fmt::Display for Visibility {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Public => write!(f, "pub"),
+            Self::Crate => write!(f, "pub(crate)"),
+            Self::Private => write!(f, ""),
+            Self::Super => write!(f, "pub(super)"),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct ParseVisibilityError(String);
+
+impl std::error::Error for ParseVisibilityError {}
+
+impl fmt::Display for ParseVisibilityError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl FromStr for Visibility {
+    type Err = ParseVisibilityError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "pub" => Ok(Self::Public),
+            "super" => Ok(Self::Super),
+            "private" => Ok(Self::Private),
+            "crate" => Ok(Self::Crate),
+            e => Err(ParseVisibilityError(format!(
+                "Wrong visibility type '{}'",
+                e
+            ))),
+        }
+    }
+}

--- a/src/config/functions.rs
+++ b/src/config/functions.rs
@@ -8,6 +8,7 @@ use super::{
 };
 use crate::{
     analysis::safety_assertion_mode::SafetyAssertionMode,
+    codegen::Visibility,
     library::{Infallible, Mandatory, Nullable},
     version::Version,
 };
@@ -283,6 +284,7 @@ pub struct Function {
     pub no_future: bool,
     pub unsafe_: bool,
     pub rename: Option<String>,
+    pub visibility: Option<Visibility>,
     pub bypass_auto_rename: bool,
     pub is_constructor: Option<bool>,
     pub assertion: Option<SafetyAssertionMode>,
@@ -322,6 +324,7 @@ impl Parse for Function {
                 "bypass_auto_rename",
                 "constructor",
                 "assertion",
+                "visibility",
             ],
             &format!("function {}", object_name),
         );
@@ -410,7 +413,15 @@ impl Parse for Function {
             error!("{}", err);
         }
         let assertion = assertion.ok().flatten();
-
+        let visibility = toml
+            .lookup("visibility")
+            .and_then(Value::as_str)
+            .map(std::str::FromStr::from_str)
+            .transpose();
+        if let Err(ref err) = visibility {
+            error!("{}", err);
+        }
+        let visibility = visibility.ok().flatten();
         Some(Function {
             ident,
             status,
@@ -430,6 +441,7 @@ impl Parse for Function {
             bypass_auto_rename,
             is_constructor,
             assertion,
+            visibility,
         })
     }
 }

--- a/src/config/gobjects.rs
+++ b/src/config/gobjects.rs
@@ -415,7 +415,7 @@ fn parse_object(
     let visibility = toml_object
         .lookup("visibility")
         .and_then(Value::as_str)
-        .map(|s| std::str::FromStr::from_str(s))
+        .map(std::str::FromStr::from_str)
         .transpose();
     if let Err(ref err) = visibility {
         error!("{}", err);

--- a/src/config/gobjects.rs
+++ b/src/config/gobjects.rs
@@ -10,6 +10,7 @@ use super::{
 };
 use crate::{
     analysis::{conversion_type::ConversionType, ref_mode},
+    codegen::Visibility,
     config::{
         error::TomlHelper,
         parsable::{Parsable, Parse},
@@ -94,6 +95,7 @@ pub struct GObject {
     pub init_function_expression: Option<String>,
     pub copy_into_function_expression: Option<String>,
     pub clear_function_expression: Option<String>,
+    pub visibility: Visibility,
 }
 
 impl Default for GObject {
@@ -128,6 +130,7 @@ impl Default for GObject {
             init_function_expression: None,
             copy_into_function_expression: None,
             clear_function_expression: None,
+            visibility: Default::default(),
         }
     }
 }
@@ -278,6 +281,7 @@ fn parse_object(
             "init_function_expression",
             "copy_into_function_expression",
             "clear_function_expression",
+            "visibility",
         ],
         &format!("object {}", name),
     );
@@ -408,6 +412,15 @@ fn parse_object(
         .and_then(Value::as_str)
         .map(ToOwned::to_owned);
 
+    let visibility = toml_object
+        .lookup("visibility")
+        .and_then(Value::as_str)
+        .map(|s| std::str::FromStr::from_str(s))
+        .transpose();
+    if let Err(ref err) = visibility {
+        error!("{}", err);
+    }
+    let visibility = visibility.ok().flatten().unwrap_or_default();
     if boxed_inline
         && !((init_function_expression.is_none()
             && copy_into_function_expression.is_none()
@@ -483,6 +496,7 @@ fn parse_object(
         init_function_expression,
         copy_into_function_expression,
         clear_function_expression,
+        visibility,
     }
 }
 


### PR DESCRIPTION
This PR allows to tweak the visibility of functions/enums/flags & also objects/records. For global functions that are marked as non-public, they also have a `#[allow(dead_code)]` guard added to avoid any clippy complaints.

Fixes #1238 
cc @lucab 