### PR TITLE
analysis: don't take a slice of copy types by ref

### DIFF
--- a/src/analysis/record_type.rs
+++ b/src/analysis/record_type.rs
@@ -15,29 +15,9 @@ pub enum RecordType {
 
 impl RecordType {
     pub fn of(record: &library::Record) -> RecordType {
-        let mut has_copy = false;
-        let mut has_free = false;
-        let mut has_ref = false;
-        let mut has_unref = false;
-        let mut has_destroy = false;
-        for func in &record.functions {
-            match &func.name[..] {
-                "copy" => has_copy = true,
-                "free" => has_free = true,
-                "destroy" => has_destroy = true,
-                "ref" => has_ref = true,
-                "unref" => has_unref = true,
-                _ => (),
-            }
-        }
-
-        if has_destroy && has_copy {
-            has_free = true;
-        }
-
-        if has_ref && has_unref {
+        if record.has_ref() && record.has_unref() {
             RecordType::Refcounted
-        } else if has_copy && has_free {
+        } else if record.has_copy() && record.has_free() {
             RecordType::Boxed
         } else {
             RecordType::AutoBoxed

--- a/src/library.rs
+++ b/src/library.rs
@@ -445,6 +445,30 @@ pub struct Record {
     pub disguised: bool,
 }
 
+impl Record {
+    pub fn has_free(&self) -> bool {
+        self.functions.iter().any(|f| f.name == "free") || (self.has_copy() && self.has_destroy())
+    }
+
+    pub fn has_copy(&self) -> bool {
+        self.functions
+            .iter()
+            .any(|f| f.name == "copy" || f.name == "copy_into")
+    }
+
+    pub fn has_destroy(&self) -> bool {
+        self.functions.iter().any(|f| f.name == "destroy")
+    }
+
+    pub fn has_unref(&self) -> bool {
+        self.functions.iter().any(|f| f.name == "unref")
+    }
+
+    pub fn has_ref(&self) -> bool {
+        self.functions.iter().any(|f| f.name == "ref")
+    }
+}
+
 #[derive(Default, Debug)]
 pub struct Field {
     pub name: String,


### PR DESCRIPTION
Currently, gir generates the following &[&SomeCopyType] instead of &[SomeCopyType]

Fixes #1247