### PR TITLE
Support BoxedInline without a get_type function #1295 #1236

### DIFF
--- a/src/codegen/general.rs
+++ b/src/codegen/general.rs
@@ -377,7 +377,7 @@ pub fn define_auto_boxed_type(
     init_function_expression: &Option<String>,
     copy_into_function_expression: &Option<String>,
     clear_function_expression: &Option<String>,
-    get_type_fn: Option<(String, Option<Version>)>,
+    get_type_fn: &Option<(String, Option<Version>)>,
     derive: &[Derive],
 ) -> Result<()> {
     let sys_crate_name = env.main_sys_crate_name();
@@ -394,13 +394,13 @@ pub fn define_auto_boxed_type(
     )?;
     writeln!(w)?;
     writeln!(w, "\tmatch fn {{")?;
-    if let Some(get_type_fn) = get_type_fn.clone() {
+    if let Some((ref get_type_fn, _get_type_version)) = get_type_fn {
         writeln!(
             w,
             "\t\tcopy => |ptr| {}({}::{}(), ptr as *mut _) as *mut {}::{},",
             use_glib_type(env, "gobject_ffi::g_boxed_copy"),
             sys_crate_name,
-            get_type_fn.0,
+            get_type_fn,
             sys_crate_name,
             glib_name
         )?;
@@ -409,7 +409,7 @@ pub fn define_auto_boxed_type(
             "\t\tfree => |ptr| {}({}::{}(), ptr as *mut _),",
             use_glib_type(env, "gobject_ffi::g_boxed_free"),
             sys_crate_name,
-            get_type_fn.0
+            get_type_fn
         )?;
     }
 
@@ -426,11 +426,11 @@ pub fn define_auto_boxed_type(
         writeln!(w, "\t\tcopy_into => {},", copy_into_function_expression,)?;
         writeln!(w, "\t\tclear => {},", clear_function_expression,)?;
     }
-    if let Some(get_type_fn) = get_type_fn {
+    if let Some((ref get_type_fn, _get_type_version)) = get_type_fn {
         writeln!(
             w,
             "\t\ttype_ => || {}::{}(),",
-            sys_crate_name, get_type_fn.0
+            sys_crate_name, get_type_fn
         )?;
     }
     writeln!(w, "\t}}")?;

--- a/src/codegen/general.rs
+++ b/src/codegen/general.rs
@@ -377,7 +377,7 @@ pub fn define_auto_boxed_type(
     init_function_expression: &Option<String>,
     copy_into_function_expression: &Option<String>,
     clear_function_expression: &Option<String>,
-    get_type_fn: &str,
+    get_type_fn: Option<(String, Option<Version>)>,
     derive: &[Derive],
 ) -> Result<()> {
     let sys_crate_name = env.main_sys_crate_name();
@@ -394,22 +394,24 @@ pub fn define_auto_boxed_type(
     )?;
     writeln!(w)?;
     writeln!(w, "\tmatch fn {{")?;
-    writeln!(
-        w,
-        "\t\tcopy => |ptr| {}({}::{}(), ptr as *mut _) as *mut {}::{},",
-        use_glib_type(env, "gobject_ffi::g_boxed_copy"),
-        sys_crate_name,
-        get_type_fn,
-        sys_crate_name,
-        glib_name
-    )?;
-    writeln!(
-        w,
-        "\t\tfree => |ptr| {}({}::{}(), ptr as *mut _),",
-        use_glib_type(env, "gobject_ffi::g_boxed_free"),
-        sys_crate_name,
-        get_type_fn
-    )?;
+    if let Some(get_type_fn) = get_type_fn.clone() {
+        writeln!(
+            w,
+            "\t\tcopy => |ptr| {}({}::{}(), ptr as *mut _) as *mut {}::{},",
+            use_glib_type(env, "gobject_ffi::g_boxed_copy"),
+            sys_crate_name,
+            get_type_fn.0,
+            sys_crate_name,
+            glib_name
+        )?;
+        writeln!(
+            w,
+            "\t\tfree => |ptr| {}({}::{}(), ptr as *mut _),",
+            use_glib_type(env, "gobject_ffi::g_boxed_free"),
+            sys_crate_name,
+            get_type_fn.0
+        )?;
+    }
 
     if let (
         Some(init_function_expression),
@@ -424,8 +426,13 @@ pub fn define_auto_boxed_type(
         writeln!(w, "\t\tcopy_into => {},", copy_into_function_expression,)?;
         writeln!(w, "\t\tclear => {},", clear_function_expression,)?;
     }
-
-    writeln!(w, "\t\ttype_ => || {}::{}(),", sys_crate_name, get_type_fn)?;
+    if let Some(get_type_fn) = get_type_fn {
+        writeln!(
+            w,
+            "\t\ttype_ => || {}::{}(),",
+            sys_crate_name, get_type_fn.0
+        )?;
+    }
     writeln!(w, "\t}}")?;
     writeln!(w, "}}")?;
 

--- a/src/codegen/record.rs
+++ b/src/codegen/record.rs
@@ -14,25 +14,18 @@ pub fn generate(w: &mut dyn Write, env: &Env, analysis: &analysis::record::Info)
     general::uses(w, env, &analysis.imports, type_.version)?;
 
     if RecordType::of(env.type_(analysis.type_id).maybe_ref().unwrap()) == RecordType::AutoBoxed {
-        if let Some((ref glib_get_type, _)) = analysis.glib_get_type {
-            general::define_auto_boxed_type(
-                w,
-                env,
-                &analysis.name,
-                &type_.c_type,
-                analysis.boxed_inline,
-                &analysis.init_function_expression,
-                &analysis.copy_into_function_expression,
-                &analysis.clear_function_expression,
-                glib_get_type,
-                &analysis.derives,
-            )?;
-        } else {
-            panic!(
-                "Record {} has record_boxed=true but don't have glib:get_type function",
-                analysis.name
-            );
-        }
+        general::define_auto_boxed_type(
+            w,
+            env,
+            &analysis.name,
+            &type_.c_type,
+            analysis.boxed_inline,
+            &analysis.init_function_expression,
+            &analysis.copy_into_function_expression,
+            &analysis.clear_function_expression,
+            analysis.glib_get_type.clone(),
+            &analysis.derives,
+        )?;
     } else if let (Some(ref_fn), Some(unref_fn)) = (
         analysis.specials.traits().get(&Type::Ref),
         analysis.specials.traits().get(&Type::Unref),

--- a/src/codegen/record.rs
+++ b/src/codegen/record.rs
@@ -23,7 +23,7 @@ pub fn generate(w: &mut dyn Write, env: &Env, analysis: &analysis::record::Info)
             &analysis.init_function_expression,
             &analysis.copy_into_function_expression,
             &analysis.clear_function_expression,
-            analysis.glib_get_type.clone(),
+            &analysis.glib_get_type,
             &analysis.derives,
         )?;
     } else if let (Some(ref_fn), Some(unref_fn)) = (

--- a/src/library.rs
+++ b/src/library.rs
@@ -1085,18 +1085,19 @@ impl Library {
                 }
             }
             if let Some(tid) = env.library.find_type(0, &full_name) {
-                let gobject_id = env.library.find_type(0, "GObject.Object").unwrap();
+                let gobject_id = env.library.find_type(0, "GObject.Object");
 
                 for &super_tid in env.class_hierarchy.supertypes(tid) {
                     let ty = env.library.type_(super_tid);
                     let ns_id = super_tid.ns_id as usize;
                     let full_parent_name =
                         format!("{}.{}", self.namespaces[ns_id].name, ty.get_name());
-                    if super_tid != gobject_id
-                        && env
-                            .type_status(&super_tid.full_name(&env.library))
-                            .ignored()
-                        && parents.insert(full_parent_name.clone())
+                    if gobject_id.is_none()
+                        || super_tid != gobject_id.unwrap()
+                            && env
+                                .type_status(&super_tid.full_name(&env.library))
+                                .ignored()
+                            && parents.insert(full_parent_name.clone())
                     {
                         if let Some(version) = ty.get_deprecated_version() {
                             println!(


### PR DESCRIPTION
This is my attempt at supporting BoxedInline without a get_type function. Generating the bindings for gmodule does not panic and now outputs:
```
[WARN  libgir::analysis::functions] Function g_module_symbol has unsupported outs
[WARN  libgir::analysis::functions] Function g_module_open_full has unsupported outs
[ERROR libgir::analysis::record] Missing memory management functions for GModule.Module
```
