### PR TITLE
feature: Add a 'static' cargo feature

### DIFF
--- a/src/codegen/sys/cargo_toml.rs
+++ b/src/codegen/sys/cargo_toml.rs
@@ -104,6 +104,16 @@ fn fill_in(root: &mut Table, env: &Env) {
                     .collect(),
             ),
         );
+        features.insert(
+            "static".to_string(),
+            Value::Array(
+                env.config
+                    .external_libraries
+                    .iter()
+                    .map(|l| Value::String(format!("{}/static", l.crate_name)))
+                    .collect(),
+            ),
+        );
     }
 
     {

--- a/src/codegen/sys/lib_.rs
+++ b/src/codegen/sys/lib_.rs
@@ -25,10 +25,16 @@ pub fn generate(env: &Env) {
 
 fn write_link_attr(w: &mut dyn Write, shared_libs: &[String]) -> Result<()> {
     for it in shared_libs {
+        let link_name = shared_lib_name_to_link_name(it);
         writeln!(
             w,
-            "#[link(name = \"{}\")]",
-            shared_lib_name_to_link_name(it)
+            r#"#[cfg_attr(feature = "static", link(name = "{}", kind = "static"))]"#,
+            link_name
+        )?;
+        writeln!(
+            w,
+            r#"#[cfg_attr(not(feature = "static"), link(name = "{}"))]"#,
+            link_name
         )?;
     }
 


### PR DESCRIPTION
...and use it to generate a static or non-static `#[link]` attribute.

This adds generation in `-sys` crates `Cargo.toml` and in their `lib.rs`.

I'll fill in more details, just opening this draft PR so I don't forget about it.

(Also I had discussed this general idea with @sdroege)

---

edit: It would appear the gdk-pixbuf special case is ruining my day.