### PR TITLE
codegen/special_functions: Add missing space between `pub` and `fn`

### DIFF
--- a/src/codegen/special_functions.rs
+++ b/src/codegen/special_functions.rs
@@ -40,7 +40,7 @@ pub(super) fn generate_static_to_str(
     writeln!(
         w,
         "\
-\t{visibility}fn {rust_fn_name}<'a>(self) -> &'a str {{
+\t{visibility} fn {rust_fn_name}<'a>(self) -> &'a str {{
 \t\tunsafe {{
 \t\t\tCStr::from_ptr(
 \t\t\t\t{ns}::{glib_fn_name}(self.into_glib())

--- a/src/codegen/visibility.rs
+++ b/src/codegen/visibility.rs
@@ -10,18 +10,17 @@ pub enum Visibility {
 }
 
 impl Visibility {
-    pub fn is_public(&self) -> bool {
-        matches!(self, Self::Public)
+    pub fn is_public(self) -> bool {
+        self == Self::Public
     }
 
-    pub fn export_visibility(&self) -> String {
+    pub fn export_visibility(self) -> &'static str {
         match self {
             Self::Public => "pub",
             Self::Private => "",
             Self::Crate => "pub(crate)",
             Self::Super => "pub(super)",
         }
-        .to_owned()
     }
 }
 
@@ -33,12 +32,7 @@ impl Default for Visibility {
 
 impl fmt::Display for Visibility {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Public => write!(f, "pub"),
-            Self::Crate => write!(f, "pub(crate)"),
-            Self::Private => write!(f, ""),
-            Self::Super => write!(f, "pub(super)"),
-        }
+        f.write_str(self.export_visibility())
     }
 }
 


### PR DESCRIPTION
Originally the `visibility` modifier contained this space ("pub ") to keep indentation in check.  A recent change however formats the visibility modifier from configuration directly into the file, without inserting the necessary trailing space, resulting in the text `pubfn` in `special_functions`, which is invalid syntax.

Since output is almost always formatted with rustfmt anyway, this indentation mismatch is irrelevant to allocate a string for here.

Fixes: e3bd76a3 ("replace FunctionVisibility with hidden/commented attributes"), cc @bilelmoussaoui
