### PR TITLE
Don't require `Send` closures for GIO-style async functions

### DIFF
--- a/src/analysis/bounds.rs
+++ b/src/analysis/bounds.rs
@@ -133,10 +133,8 @@ impl Bounds {
                         }
                         let parameters = format_out_parameters(&out_parameters);
                         let error_type = find_error_type(env, function);
-                        type_string = format!(
-                            "FnOnce(Result<{}, {}>) + Send + 'static",
-                            parameters, error_type
-                        );
+                        type_string =
+                            format!("FnOnce(Result<{}, {}>) + 'static", parameters, error_type);
                         let bound_name = *self.unused.front().unwrap();
                         callback_info = Some(CallbackInfo {
                             callback_type: type_string.clone(),


### PR DESCRIPTION
Instead make sure that they're only ever called from the thread that
owns the thread default main context, and check at runtime that they're
really only called from the correct thread.

While this sounds like adding new constraints at runtime, anything else
was already not allowed before but not checked.

Fixes https://github.com/gtk-rs/gir/issues/1305