### PR TITLE
codegen: Use GString::as_str instead of Option<GString>::as_deref

### DIFF
--- a/src/codegen/function_body_chunk.rs
+++ b/src/codegen/function_body_chunk.rs
@@ -422,7 +422,10 @@ impl Builder {
                 add_chunk_for_type(env, par.typ, par, &mut body, &ty_name, nullable);
             if is_gstring(&ty_name) {
                 if *nullable {
-                    arguments.push(Chunk::Name(format!("{}.as_ref().as_deref()", par.name)));
+                    arguments.push(Chunk::Name(format!(
+                        "(*{}).as_ref().map(|s| s.as_str())",
+                        par.name
+                    )));
                 } else {
                     arguments.push(Chunk::Name(format!("{}.as_str()", par.name)));
                 }

--- a/src/codegen/trampoline_from_glib.rs
+++ b/src/codegen/trampoline_from_glib.rs
@@ -38,12 +38,12 @@ impl TrampolineFromGlib for Transformation {
                     );
                 } else if nullable && is_borrow {
                     if is_gstring(&type_name) {
-                        right = format!("{}.as_ref().as_deref()", right);
+                        right = format!("(*{}).as_ref().map(|s| s.as_str())", right);
                     } else {
                         right = format!("{}.as_ref().as_ref()", right);
                     }
                 } else if is_gstring(&type_name) {
-                    right = format!("{}.as_deref()", right);
+                    right = format!("{}.as_str()", right);
                 } else {
                     right = format!("{}.as_ref()", right);
                 }


### PR DESCRIPTION
Needed for https://github.com/gtk-rs/gtk-rs-core/pull/600, but doesn't depend on it (this PR shouldn't break anything)