### PR TITLE
docs: Never use ExtManual trait with GObject

### DIFF
--- a/src/analysis/object.rs
+++ b/src/analysis/object.rs
@@ -93,7 +93,7 @@ impl Info {
             )
         {
             LocationInObject::Impl
-        } else if fn_info.status == GStatus::Generate {
+        } else if fn_info.status == GStatus::Generate || self.full_name == "GObject.Object" {
             LocationInObject::Ext
         } else {
             LocationInObject::ExtManual


### PR DESCRIPTION
Fixes a few links like [here](https://gtk-rs.org/gtk-rs-core/stable/latest/docs/glib/struct.ParamFlags.html#associatedconstant.EXPLICIT_NOTIFY) and [here](https://gtk-rs.org/gtk-rs-core/stable/latest/docs/glib/struct.Binding.html#method.unbind)

There's still some left that refer to nonexisting rust functions however, like `ObjectExt::set` and `ObjectSet::bind_property_full`