### PR TITLE
suppress insertion of assertion for result of throw function to return void

### DIFF
--- a/src/analysis/out_parameters.rs
+++ b/src/analysis/out_parameters.rs
@@ -202,12 +202,10 @@ fn decide_throw_function_return_strategy(
         .unwrap_or_default();
     if env.type_(typ).eq(&Type::Fundamental(Fundamental::None)) {
         ThrowFunctionReturnStrategy::Void
+    } else if use_function_return_for_result(env, typ, func_name, configured_functions) {
+        ThrowFunctionReturnStrategy::ReturnResult
     } else {
-        if use_function_return_for_result(env, typ, func_name, configured_functions) {
-            ThrowFunctionReturnStrategy::ReturnResult
-        } else {
-            ThrowFunctionReturnStrategy::CheckError
-        }
+        ThrowFunctionReturnStrategy::CheckError
     }
 }
 

--- a/src/analysis/out_parameters.rs
+++ b/src/analysis/out_parameters.rs
@@ -15,13 +15,24 @@ use log::error;
 use std::slice::Iter;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ThrowFunctionReturnStrategy {
+    ReturnResult,
+    CheckError,
+}
+
+impl Default for ThrowFunctionReturnStrategy {
+    fn default() -> Self {
+        Self::ReturnResult
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Mode {
     None,
     Normal,
     Optional,
     Combined,
-    //<use function return>
-    Throws(bool),
+    Throws(ThrowFunctionReturnStrategy),
 }
 
 impl Default for Mode {
@@ -58,8 +69,9 @@ pub fn analyze(
 
     let nullable_override = configured_functions.iter().find_map(|f| f.ret.nullable);
     if func.throws {
-        let use_ret = use_return_value_for_result(env, func_ret, &func.name, configured_functions);
-        info.mode = Mode::Throws(use_ret);
+        let return_strategy =
+            decide_throw_function_return_strategy(env, func_ret, &func.name, configured_functions);
+        info.mode = Mode::Throws(return_strategy);
     } else if func.ret.typ == TypeId::tid_none() {
         info.mode = Mode::Normal;
     } else if func.ret.typ == TypeId::tid_bool() || func.ret.typ == TypeId::tid_c_bool() {
@@ -102,7 +114,9 @@ pub fn analyze(
     if info.params.is_empty() {
         info.mode = Mode::None;
     }
-    if info.mode == Mode::Combined || info.mode == Mode::Throws(true) {
+    if info.mode == Mode::Combined
+        || info.mode == Mode::Throws(ThrowFunctionReturnStrategy::ReturnResult)
+    {
         let mut ret = analysis::Parameter::from_return_value(env, &func.ret, configured_functions);
 
         //TODO: fully switch to use analyzed returns (it add too many Return<Option<>>)
@@ -174,18 +188,23 @@ pub fn can_as_return(env: &Env, par: &library::Parameter) -> bool {
     }
 }
 
-pub fn use_return_value_for_result(
+fn decide_throw_function_return_strategy(
     env: &Env,
     ret: &return_value::Info,
     func_name: &str,
     configured_functions: &[&config::functions::Function],
-) -> bool {
+) -> ThrowFunctionReturnStrategy {
     let typ = ret
         .parameter
         .as_ref()
         .map(|par| par.lib_par.typ)
         .unwrap_or_default();
-    use_function_return_for_result(env, typ, func_name, configured_functions)
+    let use_ret = use_function_return_for_result(env, typ, func_name, configured_functions);
+    if use_ret {
+        ThrowFunctionReturnStrategy::ReturnResult
+    } else {
+        ThrowFunctionReturnStrategy::CheckError
+    }
 }
 
 pub fn use_function_return_for_result(

--- a/src/analysis/out_parameters.rs
+++ b/src/analysis/out_parameters.rs
@@ -18,6 +18,7 @@ use std::slice::Iter;
 pub enum ThrowFunctionReturnStrategy {
     ReturnResult,
     CheckError,
+    Void,
 }
 
 impl Default for ThrowFunctionReturnStrategy {
@@ -199,11 +200,14 @@ fn decide_throw_function_return_strategy(
         .as_ref()
         .map(|par| par.lib_par.typ)
         .unwrap_or_default();
-    let use_ret = use_function_return_for_result(env, typ, func_name, configured_functions);
-    if use_ret {
-        ThrowFunctionReturnStrategy::ReturnResult
+    if env.type_(typ).eq(&Type::Fundamental(Fundamental::None)) {
+        ThrowFunctionReturnStrategy::Void
     } else {
-        ThrowFunctionReturnStrategy::CheckError
+        if use_function_return_for_result(env, typ, func_name, configured_functions) {
+            ThrowFunctionReturnStrategy::ReturnResult
+        } else {
+            ThrowFunctionReturnStrategy::CheckError
+        }
     }
 }
 

--- a/src/codegen/function_body_chunk.rs
+++ b/src/codegen/function_body_chunk.rs
@@ -1227,6 +1227,7 @@ impl Builder {
                     ThrowFunctionReturnStrategy::CheckError => {
                         ("is_ok", Some(Box::new(Chunk::AssertErrorSanity)))
                     }
+                    ThrowFunctionReturnStrategy::Void => ("_", Option::None),
                 };
                 let call = Chunk::Let {
                     name: name.into(),

--- a/src/codegen/function_body_chunk.rs
+++ b/src/codegen/function_body_chunk.rs
@@ -1222,23 +1222,16 @@ impl Builder {
                     panic!("Call without Chunk::FfiCallConversion")
                 };
                 self.remove_extra_assume_init(&array_length_name, uninitialized_vars);
-                let assert_safe_ret;
-                let call = if use_ret {
-                    assert_safe_ret = Option::None;
-                    Chunk::Let {
-                        name: "ret".into(),
-                        is_mut: false,
-                        value: boxed_call,
-                        type_: Option::None,
-                    }
+                let (name, assert_safe_ret) = if use_ret {
+                    ("ret", Option::None)
                 } else {
-                    assert_safe_ret = Some(Box::new(Chunk::AssertErrorSanity));
-                    Chunk::Let {
-                        name: "is_ok".into(),
-                        is_mut: false,
-                        value: boxed_call,
-                        type_: Option::None,
-                    }
+                    ("is_ok", Some(Box::new(Chunk::AssertErrorSanity)))
+                };
+                let call = Chunk::Let {
+                    name: name.into(),
+                    is_mut: false,
+                    value: boxed_call,
+                    type_: Option::None,
                 };
                 let mut ret = ret.expect("No return in throws outs mode");
                 if let Chunk::Tuple(ref mut vec, ref mut mode) = ret {


### PR DESCRIPTION
Hi,

As I filed #1331 , gir v0.15 or later inserts assertion for result of throw function even if the function returns void. It's based on GNOME convention that throw function should return boolean value to express whether GError argument is set or not. However we have some libraries which don't follow to the convention yet.

This patchset adds enumeration to express the strategy of return value for throw function,
then suppress the insertion for throw function returning void. As a result, the generated code is almost the same as the one generated gir v0.14 or before in regards of throw function to return void.