### PR TITLE
sys, statics: Add "use" libc in6_addr and stat

### DIFF
--- a/src/codegen/sys/statics.rs
+++ b/src/codegen/sys/statics.rs
@@ -19,7 +19,7 @@ pub fn after_extern_crates(w: &mut dyn Write) -> Result<()> {
         "#[allow(unused_imports)]",
         "use libc::{c_int, c_char, c_uchar, c_float, c_uint, c_double,",
         "    c_short, c_ushort, c_long, c_ulong,",
-        "    c_void, size_t, ssize_t, intptr_t, uintptr_t, FILE};",
+        "    c_void, size_t, ssize_t, intptr_t, uintptr_t, FILE, in6_addr, stat};",
     ];
 
     write_vec(w, &v)


### PR DESCRIPTION
When using gir to generate NetworkManager sys bindings a pair of libc
artifacts are missing "in6_addr" and "stat". This change add them to
the generated "use" directive.