### PR TITLE
codegen/sys/tests: Don't trim whitespace on C constant output

### DIFF
--- a/src/codegen/sys/tests.rs
+++ b/src/codegen/sys/tests.rs
@@ -417,13 +417,8 @@ fn cross_validate_constants_with_c() {
     let mut c_constants: Vec<(String, String)> = Vec::new();
 
     for l in get_c_output("constant").unwrap().lines() {
-        let mut words = l.trim().split(';');
-        let name = words.next().expect("Failed to parse name").to_owned();
-        let value = words
-            .next()
-            .and_then(|s| s.parse().ok())
-            .expect("Failed to parse value");
-        c_constants.push((name, value));
+        let (name, value) = l.split_once(';').expect("Missing ';' separator");
+        c_constants.push((name.to_owned(), value.to_owned()));
     }
 
     let mut results = Results::default();
@@ -458,17 +453,11 @@ fn cross_validate_layout_with_c() {
     let mut c_layouts = Vec::new();
 
     for l in get_c_output("layout").unwrap().lines() {
-        let mut words = l.trim().split(';');
-        let name = words.next().expect("Failed to parse name").to_owned();
-        let size = words
-            .next()
-            .and_then(|s| s.parse().ok())
-            .expect("Failed to parse size");
-        let alignment = words
-            .next()
-            .and_then(|s| s.parse().ok())
-            .expect("Failed to parse alignment");
-        c_layouts.push((name, Layout { size, alignment }));
+        let (name, value) = l.split_once(';').expect("Missing first ';' separator");
+        let (size, alignment) = value.split_once(';').expect("Missing second ';' separator");
+        let size = size.parse().expect("Failed to parse size");
+        let alignment = alignment.parse().expect("Failed to parse alignment");
+        c_layouts.push((name.to_owned(), Layout { size, alignment }));
     }
 
     let mut results = Results::default();


### PR DESCRIPTION
In GStreamer's Vulkan bindings (`GstVulkan-1.0.gir`) we have a string constant that starts and ends with a space.  When the C program emits the value of this constant through `printf()`, an erroneous `.trim()` call here in Rust strips the trailing whitespace and causes the test for this particular constant to fail:

    ---- cross_validate_constants_with_c stdout ----
    Constant value mismatch for GST_VULKAN_SWAPPER_VIDEO_FORMATS
    Rust: " { RGBA, BGRA, RGB, BGR } "
    C:    " { RGBA, BGRA, RGB, BGR }"

Address this by removing the `.trim()`, and simplifying some of the iterator code away with a `.split_once()`.

All tests on at least GStreamer succeed, leading to believe that this `.trim()` serves no purpose as the argument is already split on newlines; any additional whitespace is hence part of the constant that is being tested.
