### PR TITLE
analysis: Call extra to_glib functions in array len transformation

### DIFF
--- a/src/analysis/bounds.rs
+++ b/src/analysis/bounds.rs
@@ -210,7 +210,7 @@ impl Bounds {
         }
     }
 
-    fn get_to_glib_extra(
+    pub fn get_to_glib_extra(
         bound_type: &BoundType,
         nullable: bool,
         instance_parameter: bool,


### PR DESCRIPTION
Insert the `as_ref()` calls before `len()` when the array parameter has trait bounds. Needed for https://github.com/gtk-rs/gtk-rs-core/pull/708, fixes this error:

```
error[E0599]: no method named `len` found for type parameter `impl AsRef<std::path::Path>` in the current scope
   --> glib/src/auto/functions.rs:348:27
    |
348 |     let len = opsysstring.len() as isize;
    |                           ^^^ method not found in `impl AsRef<std::path::Path>`
```

Error source: https://github.com/gtk-rs/gtk-rs-core/runs/6910586265?check_suite_focus=true#step:15:81