### PR TITLE
Do not overwrite the dox field in Cargo.toml

### DIFF
--- a/book/src/config_ffi.md
+++ b/book/src/config_ffi.md
@@ -50,10 +50,6 @@ version = "3.16"
 dependencies = [
   "glib-sys/v3_16"
 ]
-# Add features to the "dox" feature declaration in `Cargo.toml`. So with the following
-# config, it'll generate:
-# dox = ["whatever"]
-dox_feature_dependencies = ["whatever"]
 ```
 
 You can mark some functions that has suffix `_utf8` on Windows:

--- a/src/codegen/sys/cargo_toml.rs
+++ b/src/codegen/sys/cargo_toml.rs
@@ -186,7 +186,12 @@ fn fill_in(root: &mut Table, env: &Env) {
         let features = upsert_table(root, "features");
         let mut dox_features = Vec::new();
         for ext_lib in &env.config.external_libraries {
-            dox_features.push(Value::String(format!("{}/dox", ext_lib.crate_name)));
+            let crate_name = if ext_lib.crate_name == "gdk_pixbuf" {
+                "gdk-pixbuf"
+            } else {
+                &ext_lib.crate_name
+            };
+            dox_features.push(Value::String(format!("{}/dox", crate_name)));
         }
         features.insert("dox".to_string(), Value::Array(dox_features));
     }

--- a/src/codegen/sys/cargo_toml.rs
+++ b/src/codegen/sys/cargo_toml.rs
@@ -93,15 +93,6 @@ fn fill_empty(root: &mut Table, env: &Env, crate_name: &str) {
         set_string(dep, "package", ext_package);
         set_string(dep, "git", repo_url);
     }
-
-    {
-        let features = upsert_table(root, "features");
-        let mut dox_features = Vec::new();
-        for ext_lib in &env.config.external_libraries {
-            dox_features.push(Value::String(format!("{}/dox", ext_lib.crate_name)));
-        }
-        features.insert("dox".to_string(), Value::Array(dox_features));
-    }
 }
 
 fn fill_in(root: &mut Table, env: &Env) {
@@ -189,6 +180,15 @@ fn fill_in(root: &mut Table, env: &Env) {
                     .collect::<Vec<_>>(),
             ),
         );
+    }
+
+    {
+        let features = upsert_table(root, "features");
+        let mut dox_features = Vec::new();
+        for ext_lib in &env.config.external_libraries {
+            dox_features.push(Value::String(format!("{}/dox", ext_lib.crate_name)));
+        }
+        features.insert("dox".to_string(), Value::Array(dox_features));
     }
 }
 

--- a/src/codegen/sys/cargo_toml.rs
+++ b/src/codegen/sys/cargo_toml.rs
@@ -96,16 +96,11 @@ fn fill_empty(root: &mut Table, env: &Env, crate_name: &str) {
 
     {
         let features = upsert_table(root, "features");
-        features.insert(
-            "dox".to_string(),
-            Value::Array(
-                env.config
-                    .dox_feature_dependencies
-                    .iter()
-                    .map(|s| Value::String(s.clone()))
-                    .collect(),
-            ),
-        );
+        let mut dox_features = Vec::new();
+        for ext_lib in &env.config.external_libraries {
+            dox_features.push(Value::String(format!("{}/dox", ext_lib.crate_name)));
+        }
+        features.insert("dox".to_string(), Value::Array(dox_features));
     }
 }
 

--- a/src/codegen/sys/cargo_toml.rs
+++ b/src/codegen/sys/cargo_toml.rs
@@ -93,6 +93,20 @@ fn fill_empty(root: &mut Table, env: &Env, crate_name: &str) {
         set_string(dep, "package", ext_package);
         set_string(dep, "git", repo_url);
     }
+
+    {
+        let features = upsert_table(root, "features");
+        features.insert(
+            "dox".to_string(),
+            Value::Array(
+                env.config
+                    .dox_feature_dependencies
+                    .iter()
+                    .map(|s| Value::String(s.clone()))
+                    .collect(),
+            ),
+        );
+    }
 }
 
 fn fill_in(root: &mut Table, env: &Env) {
@@ -131,16 +145,6 @@ fn fill_in(root: &mut Table, env: &Env) {
             features.insert(version.to_feature(), Value::Array(prev_array));
             Some(version)
         });
-        features.insert(
-            "dox".to_string(),
-            Value::Array(
-                env.config
-                    .dox_feature_dependencies
-                    .iter()
-                    .map(|s| Value::String(s.clone()))
-                    .collect(),
-            ),
-        );
     }
 
     {

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -118,7 +118,6 @@ pub struct Config {
     pub extra_versions: Vec<Version>,
     pub lib_version_overrides: HashMap<Version, Version>,
     pub feature_dependencies: HashMap<Version, Vec<String>>,
-    pub dox_feature_dependencies: Vec<String>,
 }
 
 impl Config {
@@ -345,7 +344,6 @@ impl Config {
         let extra_versions = read_extra_versions(&toml)?;
         let lib_version_overrides = read_lib_version_overrides(&toml)?;
         let feature_dependencies = read_feature_dependencies(&toml)?;
-        let dox_feature_dependencies = read_dox_feature_dependencies(&toml)?;
 
         Ok(Config {
             work_mode,
@@ -374,7 +372,6 @@ impl Config {
             extra_versions,
             lib_version_overrides,
             feature_dependencies,
-            dox_feature_dependencies,
         })
     }
 
@@ -476,24 +473,6 @@ fn read_extra_versions(toml: &toml::Value) -> Result<Vec<Version>, String> {
                 })
             })
             .map(|s| s.and_then(str::parse))
-            .collect(),
-        None => Ok(Vec::new()),
-    }
-}
-
-fn read_dox_feature_dependencies(toml: &toml::Value) -> Result<Vec<String>, String> {
-    match toml.lookup("options.dox_feature_dependencies") {
-        Some(a) => a
-            .as_result_vec("options.dox_feature_dependencies")?
-            .iter()
-            .map(|v| {
-                v.as_str()
-                    .ok_or_else(|| {
-                        "options.dox_feature_dependencies expected to be array of string"
-                            .to_string()
-                    })
-                    .map(str::to_owned)
-            })
             .collect(),
         None => Ok(Vec::new()),
     }


### PR DESCRIPTION
I don't know how gir would know if a dependency has a dox feature without connecting to the internet or maintaining a list. This is why I opted for this simple solution:

Now gir just doesn't overwrite the dox field if it is present in the Cargo.toml. All other features will still be overwritten so new ones can be automatically added. This will fix https://github.com/gtk-rs/gir/issues/1381 and allows the merging of the PRs mentioned in the issue.