### PR TITLE
analysis: Handle move configuration in Ext trait

### DIFF
--- a/src/analysis/function_parameters.rs
+++ b/src/analysis/function_parameters.rs
@@ -225,7 +225,7 @@ pub fn analyze(
         if async_func && async_param_to_remove(&par.name) {
             add_rust_parameter = false;
         }
-
+        let move_ = configured_parameters.iter().any(|p| p.move_);
         let mut array_par = configured_parameters.iter().find_map(|cp| {
             cp.length_of
                 .as_ref()
@@ -245,6 +245,7 @@ pub fn analyze(
                         &bound_type,
                         *array_par.nullable,
                         array_par.instance_parameter,
+                        move_,
                     ))
                     .into();
             }
@@ -296,7 +297,7 @@ pub fn analyze(
             user_data_index: par.closure,
             destroy_index: par.destroy,
             try_from_glib: try_from_glib.clone(),
-            move_: configured_parameters.iter().any(|p| p.move_),
+            move_,
         };
         parameters.c_parameters.push(c_par);
 


### PR DESCRIPTION
By calling to_owned() on the result of as_ref() as the into_glib_ptr requires Self and AsRef returns &Self