### PR TITLE
Add external docs url config option

### DIFF
--- a/src/codegen/general.rs
+++ b/src/codegen/general.rs
@@ -129,6 +129,13 @@ pub fn define_fundamental_type(
     let sys_crate_name = env.main_sys_crate_name();
     writeln!(w, "{} {{", use_glib_type(env, "wrapper!"))?;
     doc_alias(w, glib_name, "", 1)?;
+    external_doc_link(
+        w,
+        env.config.external_docs_url.as_deref(),
+        type_name,
+        &visibility,
+        1,
+    )?;
     writeln!(
         w,
         "\t{} struct {}(Shared<{}::{}>);",
@@ -235,6 +242,13 @@ pub fn define_object_type(
 
     writeln!(w, "{} {{", use_glib_type(env, "wrapper!"))?;
     doc_alias(w, glib_name, "", 1)?;
+    external_doc_link(
+        w,
+        env.config.external_docs_url.as_deref(),
+        type_name,
+        &visibility,
+        1,
+    )?;
     if parents.is_empty() {
         writeln!(
             w,
@@ -907,6 +921,29 @@ pub fn doc_alias(w: &mut dyn Write, name: &str, comment_prefix: &str, indent: us
         comment_prefix,
         name,
     )
+}
+
+pub fn external_doc_link(
+    w: &mut dyn Write,
+    external_url: Option<&str>,
+    name: &str,
+    visibility: &Visibility,
+    indent: usize,
+) -> Result<()> {
+    // Don't generate the external doc link on non-public types.
+    if !visibility.is_public() {
+        Ok(())
+    } else if let Some(external_url) = external_url {
+        writeln!(
+            w,
+            "{}/// This documentation is incomplete due to license restrictions and limitations on docs.rs. Please have a look at [our official docs]({}/index.html?search={}) for more information.",
+            tabs(indent),
+            external_url.trim_end_matches('/'),
+            name
+        )
+    } else {
+        Ok(())
+    }
 }
 
 pub fn doc_hidden(

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -119,6 +119,10 @@ pub struct Config {
     pub lib_version_overrides: HashMap<Version, Version>,
     pub feature_dependencies: HashMap<Version, Vec<String>>,
     pub dox_feature_dependencies: Vec<String>,
+    /// An url that will be inserted into the docs as link that links
+    /// to another doc source, for example when builds on docs.rs
+    /// are limited due to license issues.
+    pub external_docs_url: Option<String>,
 }
 
 impl Config {
@@ -346,6 +350,7 @@ impl Config {
         let lib_version_overrides = read_lib_version_overrides(&toml)?;
         let feature_dependencies = read_feature_dependencies(&toml)?;
         let dox_feature_dependencies = read_dox_feature_dependencies(&toml)?;
+        let external_docs_url = read_external_docs_url(&toml)?;
 
         Ok(Config {
             work_mode,
@@ -375,6 +380,7 @@ impl Config {
             lib_version_overrides,
             feature_dependencies,
             dox_feature_dependencies,
+            external_docs_url,
         })
     }
 
@@ -546,6 +552,17 @@ fn read_feature_dependencies(toml: &toml::Value) -> Result<HashMap<Version, Vec<
     }
 
     Ok(map)
+}
+
+fn read_external_docs_url(toml: &toml::Value) -> Result<Option<String>, String> {
+    Ok(
+        if let Some(value) = toml.lookup("options.external_docs_url") {
+            let value = value.as_result_str("options.external_docs_url")?;
+            Some(value.to_string())
+        } else {
+            None
+        },
+    )
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Many gtk-rs crates have license issues with their docs, so they exclude most docs from their source and build their documentation separately. However, doc.rs will always build the documentation, even if Cargo.toml specifies a different doc url.Sites like [lib.rs](https://lib.rs/crates/gtk4) even list the doc.rs docs as "API reference" and list it before the actual documentation. So overall, it's not unlikely for new users to end up on docs.rs and wonder why the docs are so bad. 

Further, SEO is a real problem with the docs. Searching for [libadwaita docs](https://duckduckgo.com/?q=libadwaita+docs) gives you the link to the Flutter rip-off, then an Arch package and then the docs built for Relm4 (which are just as bad the docs.rs docs). You can't even find the actual docs through DDG it seems. One way to improve this is to generate a lot of links because that's what search engines like to see.

With this merged, gtk-rs crates could configure their gir codegen to link every type to their actual docs.
Of course, this shouldn't interfere with the creation of the actual docs, so I hope that rustdoc-stripper or some other mechanism will be able to remove this.

### Example

For gtk4, the config could look like this:

```toml
[options]
# ...
external_docs_url = "https://gtk-rs.org/gtk4-rs/stable/latest/docs/gtk4"
```

This would then generate a doc comment for all auto-generated types. This is how it would look for `Box`:

```rust
glib::wrapper! {
    #[doc(alias = "GtkBox")]
    /// This doc is limited due to license limitations. Please look at [our official docs](https://gtk-rs.org/gtk4-rs/stable/latest/docs/gtk4/index.html?search=Box) for more information.
    pub struct Box(Object<ffi::GtkBox, ffi::GtkBoxClass>) @extends Widget, @implements Accessible, Buildable, ConstraintTarget, Orientable;
    // ...
}
```

This is the generated link in this case: https://gtk-rs.org/gtk4-rs/stable/latest/docs/gtk4/index.html?search=Box

For now, the link is just a search query, but we could make it a direct link to the types as well. The only concern would be modules (when a type isn't in the crate's root, the generated doc link would need to include the module path as well) and  API breakages leading to broken links.