### PR TITLE
Remove parsing and storage of unused and deprecated allow-none attribute

### DIFF
--- a/src/analysis/function_parameters.rs
+++ b/src/analysis/function_parameters.rs
@@ -49,7 +49,6 @@ pub struct RustParameter {
     pub ind_c: usize, //index in `Vec<CParameter>`
     pub name: String,
     pub typ: TypeId,
-    pub allow_none: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -309,7 +308,6 @@ pub fn analyze(
                 name: name.clone(),
                 typ,
                 ind_c,
-                allow_none: par.allow_none,
             };
             parameters.rust_parameters.push(rust_par);
         } else {

--- a/src/analysis/properties.rs
+++ b/src/analysis/properties.rs
@@ -313,7 +313,6 @@ fn analyze_property(
                     transfer: library::Transfer::None,
                     caller_allocates: false,
                     nullable: library::Nullable(false),
-                    allow_none: false,
                     array_length: None,
                     is_error: false,
                     doc: None,

--- a/src/library.rs
+++ b/src/library.rs
@@ -516,7 +516,6 @@ pub struct Parameter {
     pub transfer: Transfer,
     pub caller_allocates: bool,
     pub nullable: Nullable,
-    pub allow_none: bool,
     pub array_length: Option<u32>,
     pub is_error: bool,
     pub doc: Option<String>,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -954,7 +954,6 @@ impl Library {
                 caller_allocates: false,
                 nullable: Nullable(true),
                 array_length: None,
-                allow_none: true,
                 is_error: true,
                 doc: None,
                 scope: ParameterScope::None,
@@ -1106,7 +1105,6 @@ impl Library {
             .attr_from_str("transfer-ownership")?
             .unwrap_or(Transfer::None);
         let nullable = elem.attr_bool("nullable", false);
-        let allow_none = elem.attr_bool("allow-none", false);
         let scope = elem.attr_from_str("scope")?.unwrap_or(ParameterScope::None);
         let closure = elem.attr_from_str("closure")?;
         let destroy = elem.attr_from_str("destroy")?;
@@ -1165,7 +1163,6 @@ impl Library {
                 transfer,
                 caller_allocates,
                 nullable: Nullable(nullable),
-                allow_none,
                 array_length,
                 is_error: false,
                 doc,
@@ -1183,7 +1180,6 @@ impl Library {
                 transfer: Transfer::None,
                 caller_allocates: false,
                 nullable: Nullable(false),
-                allow_none,
                 array_length: None,
                 is_error: false,
                 doc,


### PR DESCRIPTION
It's replaced by optional and nullable, which we already handle.