### PR TITLE
Fix new clippy lints

### DIFF
--- a/src/codegen/flags.rs
+++ b/src/codegen/flags.rs
@@ -122,7 +122,7 @@ fn generate_flags(
         }
         writeln!(
             w,
-            "\t\tconst {} = {}::{} as u32;",
+            "\t\tconst {} = {}::{} as _;",
             name, sys_crate_name, member.c_identifier,
         )?;
     }

--- a/src/codegen/function_body_chunk.rs
+++ b/src/codegen/function_body_chunk.rs
@@ -976,12 +976,11 @@ impl Builder {
             if let TransformationType::Length {
                 ref array_name,
                 ref array_length_name,
-                ref array_length_type,
+                ..
             } = trans.transformation_type
             {
                 if let In = self.parameters[trans.ind_c] {
-                    let value =
-                        Chunk::Custom(format!("{}.len() as {}", array_name, array_length_type));
+                    let value = Chunk::Custom(format!("{array_name}.len() as _"));
                     chunks.push(Chunk::Let {
                         name: array_length_name.clone(),
                         is_mut: false,

--- a/src/codegen/sys/build.rs
+++ b/src/codegen/sys/build.rs
@@ -56,7 +56,7 @@ fn main() {} // prevent linking libraries to avoid documentation failure
 #[cfg(not(feature = "dox"))]
 fn main() {
     if let Err(s) = system_deps::Config::new().probe() {
-        println!("cargo:warning={}", s);
+        println!("cargo:warning={s}");
         process::exit(1);
     }
 }

--- a/src/codegen/sys/lib_.rs
+++ b/src/codegen/sys/lib_.rs
@@ -388,7 +388,7 @@ fn generate_interfaces_structs(
             w,
             &interface.c_type,
             &format!(
-                "write!(f, \"{name} @ {{:p}}\", self)",
+                "write!(f, \"{name} @ {{self:p}}\")",
                 name = interface.c_type
             ),
         )?;
@@ -449,7 +449,7 @@ pub struct GHookList {
 
 impl ::std::fmt::Debug for GHookList {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        write!(f, "GHookList @ {:p}", self)
+        write!(f, "GHookList @ {self:p}")
     }
 }
 
@@ -516,7 +516,7 @@ fn generate_from_fields(
     )?;
     writeln!(
         w,
-        "\t\tf.debug_struct(&format!(\"{name} @ {{:p}}\", self))",
+        "\t\tf.debug_struct(&format!(\"{name} @ {{self:p}}\"))",
         name = &fields.name
     )?;
     for field in fields.fields.iter().filter(|f| f.debug) {

--- a/src/codegen/translate_from_glib.rs
+++ b/src/codegen/translate_from_glib.rs
@@ -149,7 +149,7 @@ impl TranslateFromGlib for analysis::return_value::Info {
 
 fn from_glib_xxx(transfer: library::Transfer, array_length: Option<&String>) -> (String, String) {
     use crate::library::Transfer;
-    let good_print = |name: &str| format!(", {}.assume_init() as usize)", name);
+    let good_print = |name: &str| format!(", {}.assume_init() as _)", name);
     match (transfer, array_length) {
         (Transfer::None, None) => ("from_glib_none(".into(), ")".into()),
         (Transfer::Full, None) => ("from_glib_full(".into(), ")".into()),

--- a/src/writer/to_code.rs
+++ b/src/writer/to_code.rs
@@ -147,7 +147,7 @@ impl ToCode for Chunk {
                 let mut v: Vec<String> = Vec::with_capacity(6);
                 if is_detailed {
                     v.push(format!(
-                        r#"let detailed_signal_name = detail.map(|name| {{ format!("{0}::{{}}\0", name) }});"#,
+                        r#"let detailed_signal_name = detail.map(|name| {{ format!("{0}::{{name}}\0") }});"#,
                         signal
                     ));
                     v.push(format!(


### PR DESCRIPTION
It fixes two warnings:

``warning: variables can be used directly in the `format!` string`` and `unneeded cast`.