### PR TITLE
codegen: silence deprecation warnings in impls for deprecated types/functions

### DIFF
--- a/src/codegen/constants.rs
+++ b/src/codegen/constants.rs
@@ -44,7 +44,14 @@ pub fn generate(env: &Env, root_path: &Path, mod_rs: &mut Vec<String>) {
                 if let Some(cfg) = version_condition_string(env, None, constant.version, false, 0) {
                     mod_rs.push(cfg);
                 }
-                mod_rs.push(format!("pub use self::constants::{};", constant.name));
+                mod_rs.push(format!(
+                    "{}pub use self::constants::{};",
+                    constant
+                        .deprecated_version
+                        .map(|_| "#[allow(deprecated)]\n")
+                        .unwrap_or(""),
+                    constant.name
+                ));
             }
         }
 

--- a/src/codegen/flags.rs
+++ b/src/codegen/flags.rs
@@ -1,4 +1,4 @@
-use super::{function, trait_impls};
+use super::{function, general::allow_deprecated, trait_impls};
 use crate::{
     analysis::flags::Info,
     analysis::special_functions::Type,
@@ -51,7 +51,11 @@ pub fn generate(env: &Env, root_path: &Path, mod_rs: &mut Vec<String>) {
                 mod_rs.push(cfg);
             }
             mod_rs.push(format!(
-                "{} use self::flags::{};",
+                "{}{} use self::flags::{};",
+                flags
+                    .deprecated_version
+                    .map(|_| "#[allow(deprecated)]\n")
+                    .unwrap_or(""),
                 flags_analysis.visibility.export_visibility(),
                 flags.name
             ));
@@ -143,6 +147,7 @@ fn generate_flags(
         writeln!(w)?;
         version_condition(w, env, None, flags.version, false, 0)?;
         cfg_condition_no_doc(w, config.cfg_condition.as_ref(), false, 0)?;
+        allow_deprecated(w, flags.deprecated_version, false, 0)?;
         write!(w, "impl {} {{", analysis.name)?;
         for func_analysis in functions {
             function::generate(
@@ -177,6 +182,7 @@ fn generate_flags(
         // Generate Display trait implementation.
         version_condition(w, env, None, flags.version, false, 0)?;
         cfg_condition_no_doc(w, config.cfg_condition.as_ref(), false, 0)?;
+        allow_deprecated(w, flags.deprecated_version, false, 0)?;
         writeln!(
             w,
             "impl fmt::Display for {0} {{\n\
@@ -210,6 +216,7 @@ fn generate_flags(
 
     version_condition(w, env, None, flags.version, false, 0)?;
     cfg_condition_no_doc(w, config.cfg_condition.as_ref(), false, 0)?;
+    allow_deprecated(w, flags.deprecated_version, false, 0)?;
     writeln!(
         w,
         "#[doc(hidden)]
@@ -234,6 +241,7 @@ impl IntoGlib for {name} {{
 
     version_condition(w, env, None, flags.version, false, 0)?;
     cfg_condition_no_doc(w, config.cfg_condition.as_ref(), false, 0)?;
+    allow_deprecated(w, flags.deprecated_version, false, 0)?;
     writeln!(
         w,
         "#[doc(hidden)]
@@ -258,6 +266,7 @@ impl FromGlib<{sys_crate_name}::{ffi_name}> for {name} {{
 
         version_condition(w, env, None, version, false, 0)?;
         cfg_condition_no_doc(w, config.cfg_condition.as_ref(), false, 0)?;
+        allow_deprecated(w, flags.deprecated_version, false, 0)?;
         writeln!(
             w,
             "impl StaticType for {name} {{
@@ -273,6 +282,7 @@ impl FromGlib<{sys_crate_name}::{ffi_name}> for {name} {{
 
         version_condition(w, env, None, version, false, 0)?;
         cfg_condition_no_doc(w, config.cfg_condition.as_ref(), false, 0)?;
+        allow_deprecated(w, flags.deprecated_version, false, 0)?;
         writeln!(
             w,
             "impl {valuetype} for {name} {{
@@ -285,6 +295,7 @@ impl FromGlib<{sys_crate_name}::{ffi_name}> for {name} {{
 
         version_condition(w, env, None, version, false, 0)?;
         cfg_condition_no_doc(w, config.cfg_condition.as_ref(), false, 0)?;
+        allow_deprecated(w, flags.deprecated_version, false, 0)?;
         writeln!(
             w,
             "unsafe impl<'a> FromValue<'a> for {name} {{
@@ -304,6 +315,7 @@ impl FromGlib<{sys_crate_name}::{ffi_name}> for {name} {{
 
         version_condition(w, env, None, version, false, 0)?;
         cfg_condition_no_doc(w, config.cfg_condition.as_ref(), false, 0)?;
+        allow_deprecated(w, flags.deprecated_version, false, 0)?;
         writeln!(
             w,
             "impl ToValue for {name} {{
@@ -328,6 +340,7 @@ impl FromGlib<{sys_crate_name}::{ffi_name}> for {name} {{
 
         version_condition(w, env, None, version, false, 0)?;
         cfg_condition_no_doc(w, config.cfg_condition.as_ref(), false, 0)?;
+        allow_deprecated(w, flags.deprecated_version, false, 0)?;
         writeln!(
             w,
             "impl From<{name}> for {gvalue} {{

--- a/src/codegen/function.rs
+++ b/src/codegen/function.rs
@@ -1,8 +1,8 @@
 use super::{
     function_body_chunk,
     general::{
-        cfg_condition, cfg_deprecated, doc_alias, doc_hidden, not_version_condition,
-        version_condition,
+        allow_deprecated, cfg_condition, cfg_deprecated, doc_alias, doc_hidden,
+        not_version_condition, version_condition,
     },
     parameter::ToParameter,
     return_value::{out_parameter_types, out_parameters_as_return, ToReturnValue},
@@ -105,6 +105,7 @@ pub fn generate(
     version_condition(w, env, None, version, commented, indent)?;
     not_version_condition(w, analysis.not_version, commented, indent)?;
     doc_hidden(w, analysis.doc_hidden, comment_prefix, indent)?;
+    allow_deprecated(w, analysis.deprecated_version, commented, indent)?;
     if !in_trait || only_declaration {
         doc_alias(w, &analysis.glib_name, comment_prefix, indent)?;
         if analysis.codegen_name() != analysis.func_name {

--- a/src/codegen/general.rs
+++ b/src/codegen/general.rs
@@ -922,6 +922,24 @@ pub fn doc_hidden(
     }
 }
 
+pub fn allow_deprecated(
+    w: &mut dyn Write,
+    allow_deprecated: Option<Version>,
+    commented: bool,
+    indent: usize,
+) -> Result<()> {
+    if allow_deprecated.is_some() {
+        writeln!(
+            w,
+            "{}{}#[allow(deprecated)]",
+            tabs(indent),
+            if commented { "//" } else { "" }
+        )
+    } else {
+        Ok(())
+    }
+}
+
 pub fn write_vec<T: Display>(w: &mut dyn Write, v: &[T]) -> Result<()> {
     for s in v {
         writeln!(w, "{}", s)?;

--- a/src/codegen/object.rs
+++ b/src/codegen/object.rs
@@ -26,6 +26,13 @@ pub fn generate(
     generate_display_trait: bool,
 ) -> Result<()> {
     general::start_comments(w, &env.config)?;
+    if analysis
+        .functions
+        .iter()
+        .any(|f| f.deprecated_version.is_some())
+    {
+        writeln!(w, "#![allow(deprecated)]")?;
+    }
     general::uses(w, env, &analysis.imports, analysis.version)?;
 
     let config = &env.config.objects[&analysis.full_name];


### PR DESCRIPTION
Gets rid of all the annoying warnings for `gio::TlsRehandshakeMode`, `pango::BidiType`, etc