### PR TITLE
Fix generation without any shared libraries

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -102,7 +102,16 @@ impl Library {
             ns.package_names = packages;
             ns.c_includes = c_includes;
             if let Some(s) = elem.attr("shared-library") {
-                ns.shared_library = s.split(',').map(String::from).collect();
+                ns.shared_library = s
+                    .split(',')
+                    .filter_map(|x| {
+                        if !x.is_empty() {
+                            Some(String::from(x))
+                        } else {
+                            None
+                        }
+                    })
+                    .collect();
             }
             if let Some(s) = elem.attr("identifier-prefixes") {
                 ns.identifier_prefixes = s.split(',').map(String::from).collect();


### PR DESCRIPTION
For example with [gsettings-desktop-schemas-rs](https://gitlab.gnome.org/vlinkz/gsettings-desktop-schemas-rs), there is no library bound. At the moment `sys/lib.rs` generates with the following at the end:
```rust
#[link(name = "")]
extern "C" {

}
```
which leads to the error:
```
error[E0454]: link name must not be empty
   --> gsettings-desktop-schemas/sys/src/lib.rs:199:15
    |
199 | #[link(name = "")]
    |               ^^ empty link name
```