### PR TITLE
analysis: Don't use IntoGlibPtr for Vec<T> parameters

### DIFF
--- a/src/analysis/function_parameters.rs
+++ b/src/analysis/function_parameters.rs
@@ -241,7 +241,16 @@ pub fn analyze(
         let move_ = configured_parameters
             .iter()
             .find_map(|p| p.move_)
-            .unwrap_or(transfer == Transfer::Full && par.direction.is_in());
+            .unwrap_or_else(|| {
+                // FIXME: drop the condition here once we have figured out how to handle
+                // the Vec<T> use case, e.g with something like
+
+                if matches!(env.library.type_(typ), library::Type::CArray(_)) {
+                    false
+                } else {
+                    transfer == Transfer::Full && par.direction.is_in()
+                }
+            });
         let mut array_par = configured_parameters.iter().find_map(|cp| {
             cp.length_of
                 .as_ref()

--- a/src/analysis/function_parameters.rs
+++ b/src/analysis/function_parameters.rs
@@ -243,7 +243,7 @@ pub fn analyze(
             .find_map(|p| p.move_)
             .unwrap_or_else(|| {
                 // FIXME: drop the condition here once we have figured out how to handle
-                // the Vec<T> use case, e.g with something like
+                // the Vec<T> use case, e.g with something like PtrSlice
 
                 if matches!(env.library.type_(typ), library::Type::CArray(_)) {
                     false


### PR DESCRIPTION
We don't have a clear path forward implement yet for handling those cases.