### PR TITLE
Fixes an overflow bug that may occasionally panic if gir is built in debug

### DIFF
--- a/src/analysis/function_parameters.rs
+++ b/src/analysis/function_parameters.rs
@@ -442,7 +442,7 @@ fn detect_length<'a>(
     par: &library::Parameter,
     parameters: &'a [library::Parameter],
 ) -> Option<&'a library::Parameter> {
-    if !is_length(par) {
+    if !is_length(par) || pos == 0 {
         return None;
     }
 


### PR DESCRIPTION
When generating bindings for a specific type using a debug build of the gir tool, I got

```
thread 'main' panicked at 'attempt to subtract with overflow', src/analysis/function_parameters.rs:449:20
stack backtrace:
   0: rust_begin_unwind
             at /rustc/897e37553bba8b42751c67658967889d11ecd120/library/std/src/panicking.rs:584:5
   1: core::panicking::panic_fmt
             at /rustc/897e37553bba8b42751c67658967889d11ecd120/library/core/src/panicking.rs:142:14
   2: core::panicking::panic
             at /rustc/897e37553bba8b42751c67658967889d11ecd120/library/core/src/panicking.rs:48:5
   3: libgir::analysis::function_parameters::detect_length
             at /Users/marcomp/git/oss/gir/src/analysis/function_parameters.rs:449:20
   4: libgir::analysis::function_parameters::analyze
             at /Users/marcomp/git/oss/gir/src/analysis/function_parameters.rs:263:25
   5: libgir::analysis::functions::analyze_function
             at /Users/marcomp/git/oss/gir/src/analysis/functions.rs:685:26
   6: libgir::analysis::functions::analyze
             at /Users/marcomp/git/oss/gir/src/analysis/functions.rs:214:24
   7: libgir::analysis::object::class
             at /Users/marcomp/git/oss/gir/src/analysis/object.rs:189:25
   8: libgir::analysis::analyze
             at /Users/marcomp/git/oss/gir/src/analysis/mod.rs:316:33
   9: libgir::analysis::run
             at /Users/marcomp/git/oss/gir/src/analysis/mod.rs:177:13
  10: gir::main
             at /Users/marcomp/git/oss/gir/src/main.rs:194:9
  11: core::ops::function::FnOnce::call_once
             at /rustc/897e37553bba8b42751c67658967889d11ecd120/library/core/src/ops/function.rs:248:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```
The reason this happens is that `detect_length` does a 

```rust
parameters.get(pos - 1)...
```

and the function is entered with `pos` equal to zero. Being `pos` a `usize` this causes an overflow. In release mode the whole thing works, because overflow checks are disabled, `pos - 1` gets insanely big and the slice.get method returns `None`.

Now, I'm not sure if this is a simple overflow bug or is really a symptom of something being very wrong (i.e. is `pos` ever supposed to be zero?), but the difference in behavior between release and debug feels very wrong anyway. If this is considered an impossible condition, I can change the check to make it fail also in release mode.
