### PR TITLE
Add configuration for exhaustive enums

### DIFF
--- a/book/src/config_api.md
+++ b/book/src/config_api.md
@@ -101,7 +101,11 @@ final_type = true
 # note that fundamental types don't make use of IsA/Cast traits and you should
 # implement something similar manually
 # gir is only capable for generating the type definitions along with their functions
-fundamental_type = false 
+fundamental_type = false
+# mark the enum as exhaustive. This must only be done if it is impossible for
+# the C library to add new variants to the enum at a later time but allows
+# for more optimal code to be generated.
+exhaustive = false
 # allow rename result file
 module_name = "soome_class"
 # override starting version

--- a/src/config/gobjects.rs
+++ b/src/config/gobjects.rs
@@ -77,6 +77,7 @@ pub struct GObject {
     pub type_id: Option<TypeId>,
     pub final_type: Option<bool>,
     pub fundamental_type: Option<bool>,
+    pub exhaustive: bool,
     pub trait_name: Option<String>,
     pub child_properties: Option<ChildProperties>,
     pub concurrency: library::Concurrency,
@@ -115,6 +116,7 @@ impl Default for GObject {
             type_id: None,
             final_type: None,
             fundamental_type: None,
+            exhaustive: false,
             trait_name: None,
             child_properties: None,
             concurrency: Default::default(),
@@ -258,6 +260,7 @@ fn parse_object(
             "child_type",
             "final_type",
             "fundamental_type",
+            "exhaustive",
             "trait",
             "trait_name",
             "cfg_condition",
@@ -332,6 +335,10 @@ fn parse_object(
     let fundamental_type = toml_object
         .lookup("fundamental_type")
         .and_then(Value::as_bool);
+    let exhaustive = toml_object
+        .lookup("exhaustive")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
     let trait_name = toml_object
         .lookup("trait_name")
         .and_then(Value::as_str)
@@ -484,6 +491,7 @@ fn parse_object(
         type_id: None,
         final_type,
         fundamental_type,
+        exhaustive,
         trait_name,
         child_properties,
         concurrency,


### PR DESCRIPTION
This allows them to be represented as a plain `i32` instead of a 5-byte big enum, which in turn allows direct casting between the C and Rust type and fitting the value into a register on 32 bit systems, or even a `Result` on 64 bit systems.

----

Example generated code for an example in GStreamer

```rust
#[must_use]
#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone, Copy)]
#[repr(i32)]
#[doc(alias = "GstFlowReturn")]
pub enum FlowReturn {
    #[doc(alias = "GST_FLOW_CUSTOM_SUCCESS_2")]
    CustomSuccess2 = ffi::GST_FLOW_CUSTOM_SUCCESS_2,
    #[doc(alias = "GST_FLOW_CUSTOM_SUCCESS_1")]
    CustomSuccess1 = ffi::GST_FLOW_CUSTOM_SUCCESS_1,
    #[doc(alias = "GST_FLOW_CUSTOM_SUCCESS")]
    CustomSuccess = ffi::GST_FLOW_CUSTOM_SUCCESS,
    #[doc(alias = "GST_FLOW_OK")]
    Ok = ffi::GST_FLOW_OK,
    #[doc(alias = "GST_FLOW_NOT_LINKED")]
    NotLinked = ffi::GST_FLOW_NOT_LINKED,
    #[doc(alias = "GST_FLOW_FLUSHING")]
    Flushing = ffi::GST_FLOW_FLUSHING,
    #[doc(alias = "GST_FLOW_EOS")]
    Eos = ffi::GST_FLOW_EOS,
    #[doc(alias = "GST_FLOW_NOT_NEGOTIATED")]
    NotNegotiated = ffi::GST_FLOW_NOT_NEGOTIATED,
    #[doc(alias = "GST_FLOW_ERROR")]
    Error = ffi::GST_FLOW_ERROR,
    #[doc(alias = "GST_FLOW_NOT_SUPPORTED")]
    NotSupported = ffi::GST_FLOW_NOT_SUPPORTED,
    #[doc(alias = "GST_FLOW_CUSTOM_ERROR")]
    CustomError = ffi::GST_FLOW_CUSTOM_ERROR,
    #[doc(alias = "GST_FLOW_CUSTOM_ERROR_1")]
    CustomError1 = ffi::GST_FLOW_CUSTOM_ERROR_1,
    #[doc(alias = "GST_FLOW_CUSTOM_ERROR_2")]
    CustomError2 = ffi::GST_FLOW_CUSTOM_ERROR_2,
}

#[doc(hidden)]
impl IntoGlib for FlowReturn {
    type GlibType = ffi::GstFlowReturn;

    #[inline]
    fn into_glib(self) -> ffi::GstFlowReturn {
        self as ffi::GstFlowReturn
    }
}

#[doc(hidden)]
impl FromGlib<ffi::GstFlowReturn> for FlowReturn {
    #[inline]
    unsafe fn from_glib(value: ffi::GstFlowReturn) -> Self {
        skip_assert_initialized!();

        debug_assert!([
            ffi::GST_FLOW_CUSTOM_SUCCESS_2,
            ffi::GST_FLOW_CUSTOM_SUCCESS_1,
            ffi::GST_FLOW_CUSTOM_SUCCESS,
            ffi::GST_FLOW_OK,
            ffi::GST_FLOW_NOT_LINKED,
            ffi::GST_FLOW_FLUSHING,
            ffi::GST_FLOW_EOS,
            ffi::GST_FLOW_NOT_NEGOTIATED,
            ffi::GST_FLOW_ERROR,
            ffi::GST_FLOW_NOT_SUPPORTED,
            ffi::GST_FLOW_CUSTOM_ERROR,
            ffi::GST_FLOW_CUSTOM_ERROR_1,
            ffi::GST_FLOW_CUSTOM_ERROR_2
        ]
        .contains(&value));
        std::mem::transmute(value)
    }
}

[...]
```