### PR TITLE
Use `Object::new()` instead of `Object::new_default()`

### DIFF
--- a/src/codegen/general.rs
+++ b/src/codegen/general.rs
@@ -999,7 +999,7 @@ pub fn declare_default_from_new(
                 w,
                 "impl Default for {name} {{
                      fn default() -> Self {{
-                         glib::object::Object::new_default::<Self>()
+                         glib::object::Object::new::<Self>()
                      }}
                  }}"
             )?;


### PR DESCRIPTION
The latter is about to be renamed to the former.

See https://github.com/gtk-rs/gtk-rs-core/issues/913