### PR TITLE
Generate less clippy warnings code

### DIFF
--- a/src/analysis/functions.rs
+++ b/src/analysis/functions.rs
@@ -903,11 +903,13 @@ fn analyze_function(
         }
 
         imports.add_used_types(&used_types);
-        if ret.base_tid.is_some() || parameters.c_parameters.iter().any(|p| p.move_) {
+        if ret.base_tid.is_some() {
             imports.add("glib::prelude::*");
         }
 
-        if func.name.parse::<special_functions::Type>().is_err() {
+        if func.name.parse::<special_functions::Type>().is_err()
+            || parameters.c_parameters.iter().any(|p| p.move_)
+        {
             imports.add("glib::translate::*");
         }
         bounds.update_imports(imports);
@@ -1186,7 +1188,9 @@ fn analyze_callback(
             .direction(ParameterDirection::Return)
             .try_build()
         {
-            if !rust_type.as_str().ends_with("GString") {
+            if !rust_type.as_str().ends_with("GString")
+                && !rust_type.as_str().ends_with("GAsyncResult")
+            {
                 imports_to_add.extend(rust_type.into_used_types());
             }
         }

--- a/src/analysis/object.rs
+++ b/src/analysis/object.rs
@@ -165,7 +165,8 @@ pub fn class(env: &Env, obj: &GObject, deps: &[library::TypeId]) -> Option<Info>
         imports.add("std::fmt");
     }
 
-    let supertypes = supertypes::analyze(env, class_tid, version, &mut imports);
+    let is_fundamental = obj.fundamental_type.unwrap_or(klass.is_fundamental);
+    let supertypes = supertypes::analyze(env, class_tid, version, &mut imports, is_fundamental);
     let supertypes_properties = supertypes
         .iter()
         .filter_map(|t| match env.type_(t.type_id) {
@@ -182,7 +183,6 @@ pub fn class(env: &Env, obj: &GObject, deps: &[library::TypeId]) -> Option<Info>
         .as_ref()
         .cloned()
         .unwrap_or_else(|| format!("{name}Ext"));
-    let is_fundamental = obj.fundamental_type.unwrap_or(klass.is_fundamental);
 
     let mut signatures = Signatures::with_capacity(klass.functions.len());
 
@@ -255,7 +255,6 @@ pub fn class(env: &Env, obj: &GObject, deps: &[library::TypeId]) -> Option<Info>
         && (has_signals || has_methods || !properties.is_empty() || !child_properties.is_empty());
 
     if is_fundamental {
-        imports.add("glib::prelude::*");
         imports.add("glib::translate::*");
     }
 
@@ -342,7 +341,7 @@ pub fn interface(env: &Env, obj: &GObject, deps: &[library::TypeId]) -> Option<I
         imports.add("std::fmt");
     }
 
-    let supertypes = supertypes::analyze(env, iface_tid, version, &mut imports);
+    let supertypes = supertypes::analyze(env, iface_tid, version, &mut imports, false);
     let supertypes_properties = supertypes
         .iter()
         .filter_map(|t| match env.type_(t.type_id) {

--- a/src/analysis/supertypes.rs
+++ b/src/analysis/supertypes.rs
@@ -11,6 +11,7 @@ pub fn analyze(
     type_id: TypeId,
     version: Option<Version>,
     imports: &mut Imports,
+    add_parent_types_import: bool,
 ) -> Vec<StatusedTypeId> {
     let mut parents = Vec::new();
     let gobject_id = env.library.find_type(0, "GObject.Object").unwrap();
@@ -29,7 +30,7 @@ pub fn analyze(
             status,
         });
 
-        if !status.ignored() && super_tid.ns_id == namespaces::MAIN {
+        if !status.ignored() && super_tid.ns_id == namespaces::MAIN && !add_parent_types_import {
             if let Ok(rust_type) = RustType::try_new(env, super_tid) {
                 let full_name = super_tid.full_name(&env.library);
                 if let Some(parent_version) = env


### PR DESCRIPTION
Allows to drop the following from `gtk4/auto`


```rust
#[allow(clippy::let_and_return)]
#[allow(clippy::clone_on_copy)]
```