### PR TITLE
Refactor `impl Default` generation

### DIFF
--- a/src/codegen/general.rs
+++ b/src/codegen/general.rs
@@ -966,47 +966,23 @@ pub fn write_vec<T: Display>(w: &mut dyn Write, v: &[T]) -> Result<()> {
     Ok(())
 }
 
-pub fn declare_default_from_new(
+pub fn declare_default(
     w: &mut dyn Write,
     env: &Env,
     name: &str,
-    functions: &[analysis::functions::Info],
-    has_builder: bool,
+    func: &analysis::functions::Info,
 ) -> Result<()> {
-    if let Some(func) = functions.iter().find(|f| {
-        !f.hidden
-            && f.status.need_generate()
-            && f.name == "new"
-            // Cannot generate Default implementation for Option<>
-            && f.ret.parameter.as_ref().map_or(false, |x| !*x.lib_par.nullable)
-    }) {
-        if func.parameters.rust_parameters.is_empty() {
-            writeln!(w)?;
-            version_condition(w, env, None, func.version, false, 0)?;
-            writeln!(
-                w,
-                "impl Default for {name} {{
-                     fn default() -> Self {{
-                         Self::new()
-                     }}
-                 }}"
-            )?;
-        } else if has_builder {
-            // create an alternative default implementation the uses `glib::object::Object::new()`
-            writeln!(w)?;
-            version_condition(w, env, None, func.version, false, 0)?;
-            writeln!(
-                w,
-                "impl Default for {name} {{
-                     fn default() -> Self {{
-                         glib::object::Object::new::<Self>()
-                     }}
-                 }}"
-            )?;
-        }
-    }
-
-    Ok(())
+    writeln!(w)?;
+    version_condition(w, env, None, func.version, false, 0)?;
+    writeln!(
+        w,
+        "impl Default for {name} {{
+             fn default() -> Self {{
+                 Self::{}()
+             }}
+         }}",
+        &func.name
+    )
 }
 
 /// Escapes string in format suitable for placing inside double quotes.

--- a/src/codegen/record.rs
+++ b/src/codegen/record.rs
@@ -113,7 +113,9 @@ pub fn generate(w: &mut dyn Write, env: &Env, analysis: &analysis::record::Info)
         writeln!(w, "}}")?;
     }
 
-    general::declare_default_from_new(w, env, &analysis.name, &analysis.functions, false)?;
+    if let Some(func) = analysis.default_constructor() {
+        general::declare_default(w, env, &analysis.name, func)?;
+    }
 
     trait_impls::generate(
         w,


### PR DESCRIPTION
Move the detection of a default constructor function in the analysis. Move the logic about using Object::new into object.