### PR TITLE
codegen: Avoid useless borrows for properties setters

### DIFF
--- a/src/codegen/property_body.rs
+++ b/src/codegen/property_body.rs
@@ -126,7 +126,7 @@ impl<'a> Builder<'a> {
             };
 
             vec![Chunk::Custom(format!(
-                "{}::set_property({},\"{}\", &{})",
+                "{}::set_property({},\"{}\", {})",
                 use_glib_type(self.env, "ObjectExt"),
                 self_,
                 self.name,


### PR DESCRIPTION
Detected by nightly clippy