### PR TITLE
Make features independent from docsrs attribute

### DIFF
--- a/book/src/tutorial/generate_docs.md
+++ b/book/src/tutorial/generate_docs.md
@@ -45,7 +45,7 @@ This is mostly useful for clarifying feature requirements through the docs.
 To build the docs with the `docsrs` attribute, you can use the following command:
 
 ```sh
-RUSTDOCFLAGS='--cfg docsrs' cargo +nightly doc
+RUSTDOCFLAGS='--cfg docsrs' cargo +nightly doc --all-features
 ```
 
 Congratulations, we are done.

--- a/book/src/tutorial/high_level_rust_api.md
+++ b/book/src/tutorial/high_level_rust_api.md
@@ -11,6 +11,7 @@ Make sure everything under `[package]` is to your liking.
 Add the following lines to the file:
 ```toml
 [package.metadata.docs.rs]
+all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 ```
 This automatically activates the `docsrs` attribute if you chose to publish the bindings and docs.rs tries to build the documentation.

--- a/src/codegen/general.rs
+++ b/src/codegen/general.rs
@@ -124,7 +124,7 @@ pub fn uses(
         if !scope.is_none() {
             let scope = scope.as_ref().unwrap();
             if !scope.constraints.is_empty() {
-                writeln!(w, "#[cfg(any({}, docsrs))]", scope.constraints.join(", "))?;
+                writeln!(w, "#[cfg(any({}))]", scope.constraints.join(", "))?;
                 writeln!(
                     w,
                     "#[cfg_attr(docsrs, doc(cfg({})))]",
@@ -862,7 +862,7 @@ pub fn cfg_condition_string_no_doc(
 ) -> Option<String> {
     cfg_condition.map(|cfg| {
         let comment = if commented { "//" } else { "" };
-        format!("{0}{1}#[cfg(any({2}, docsrs))]", tabs(indent), comment, cfg,)
+        format!("{0}{1}#[cfg(any({2}))]", tabs(indent), comment, cfg)
     })
 }
 

--- a/tests/sys/atk-sys/Cargo.toml
+++ b/tests/sys/atk-sys/Cargo.toml
@@ -71,7 +71,9 @@ version = "2.32"
 
 [package.metadata.system-deps.atk.v2_34]
 version = "2.34"
+
 [package.metadata.docs.rs]
+all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dev-dependencies]

--- a/tests/sys/gdk-pixbuf-sys/Cargo.toml
+++ b/tests/sys/gdk-pixbuf-sys/Cargo.toml
@@ -55,7 +55,9 @@ version = "2.36.8"
 
 [package.metadata.system-deps.gdk_pixbuf_2_0.v2_40]
 version = "2.40"
+
 [package.metadata.docs.rs]
+all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dev-dependencies]

--- a/tests/sys/gdk-sys/Cargo.toml
+++ b/tests/sys/gdk-sys/Cargo.toml
@@ -83,7 +83,9 @@ version = "3.22"
 
 [package.metadata.system-deps.gdk_3_0.v3_24]
 version = "3.24"
+
 [package.metadata.docs.rs]
+all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dev-dependencies]

--- a/tests/sys/gio-sys/Cargo.toml
+++ b/tests/sys/gio-sys/Cargo.toml
@@ -95,7 +95,9 @@ version = "2.64"
 
 [package.metadata.system-deps.gio_2_0.v2_66]
 version = "2.66"
+
 [package.metadata.docs.rs]
+all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dev-dependencies]

--- a/tests/sys/glib-sys/Cargo.toml
+++ b/tests/sys/glib-sys/Cargo.toml
@@ -83,7 +83,9 @@ version = "2.64"
 
 [package.metadata.system-deps.glib_2_0.v2_66]
 version = "2.66"
+
 [package.metadata.docs.rs]
+all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dev-dependencies]

--- a/tests/sys/gobject-sys/Cargo.toml
+++ b/tests/sys/gobject-sys/Cargo.toml
@@ -63,7 +63,9 @@ version = "2.62"
 
 [package.metadata.system-deps.gobject_2_0.v2_66]
 version = "2.66"
+
 [package.metadata.docs.rs]
+all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dev-dependencies]

--- a/tests/sys/gtk-sys/Cargo.toml
+++ b/tests/sys/gtk-sys/Cargo.toml
@@ -119,7 +119,9 @@ version = "3.24.8"
 
 [package.metadata.system-deps."gtk+_3_0".v3_24_9]
 version = "3.24.9"
+
 [package.metadata.docs.rs]
+all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dev-dependencies]

--- a/tests/sys/pango-sys/Cargo.toml
+++ b/tests/sys/pango-sys/Cargo.toml
@@ -63,7 +63,9 @@ version = "1.44"
 
 [package.metadata.system-deps.pango.v1_46]
 version = "1.46"
+
 [package.metadata.docs.rs]
+all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dev-dependencies]


### PR DESCRIPTION
Removing the "dox" feature caused some unexpected complications because some crates, cairo in particular, used the "dox" feature as replacement for `--all-features`. In other words, "dox" did not only enable the typical documentation configuration, but also pulled in additional dependencies and effectively overwrote some feature flags (with `#[cfg(any(feature = "...", feature = "dox"))]`). This behavior was matched with the `docsrs` attribute so far, but of course the attribute can't activate dependencies in Cargo.toml.

My proposed solution would be to never use the `docsrs` attribute to interact with feature flags and conditional compilation. If someone wants to document everything `--all-features` would be the way to go. This makes sure that conditional compilation is the same in regular builds and doc builds.