### PR TITLE
Remove docsrs attr for conditional compilation

### DIFF
--- a/src/codegen/general.rs
+++ b/src/codegen/general.rs
@@ -821,7 +821,7 @@ pub fn not_version_condition_no_docsrs(
             }
         });
         let s = format!(
-            "{}{}#[cfg(not(any({}, docsrs)))]",
+            "{}{}#[cfg(not(any({})))]",
             tabs(indent),
             comment,
             v.to_cfg(namespace_name.as_deref())


### PR DESCRIPTION
@sdroege in the previous PR, I've accidentally missed one occurrence of docsrs used for conditional compilation. Once merged, all blockers for the gtk-rs-core PR should be resolved.