### PR TITLE
parser: ignore `boxed` elements

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -140,7 +140,7 @@ impl Library {
                 "function" => self.read_global_function(parser, ns_id, elem),
                 "constant" => self.read_constant(parser, ns_id, elem),
                 "alias" => self.read_alias(parser, ns_id, elem),
-                "function-macro" | "docsection" => parser.ignore_element(),
+                "boxed" | "function-macro" | "docsection" => parser.ignore_element(),
                 _ => {
                     warn!("<{} name={:?}>", elem.name(), elem.attr("name"));
                     parser.ignore_element()


### PR DESCRIPTION
This tag is somewhat obscure and only occurs when there is a boxed GType without a public struct definition. In gtk4-rs this is only used once with `GtkTreeRowData`:

```
[WARN  libgir::parser] <boxed name=Some("TreeRowData")>
```

Which is buggy and deprecated and there was never a binding for it anyway, so let's just silence these warnings. Fixes #1456