### PR TITLE
Implement basic virtual methods support

### DIFF
--- a/book/src/config/api.md
+++ b/book/src/config/api.md
@@ -204,6 +204,31 @@ generate_doc = false
             [[object.function.parameter.callback_parameter]]
             name = "name_of_the_callback_parameter"
             nullable = true
+    # virtual methods support the same configuration for parameters and return types as functions
+    # note that they are not used for code generation yet.
+    [[object.virtual_method]]
+    # filter virtual method from object
+    name = "set_website_label"
+    # alternative way to apply override for many functions. Will be used with '^' and '$' on both sides
+    # can be used instead of `name` almost anywhere
+    # pattern = "[gs]et_value"
+    # don't generate function
+    ignore = true
+    # override starting version
+    version = "3.12"
+    # prefixed function with #[cfg(mycond)]
+    cfg_condition = "mycond"
+    # prefixed function with #[doc(hidden)]
+    doc_hidden = true
+    # define a list of function parameters to be ignored when the documentation is generated
+    doc_ignore_parameters = ["some_user_data_param"]
+    # write function docs to trait other than default "xxxExt",
+    # also works in [object.signal] and [object.property]
+    doc_trait_name = "SocketListenerExtManual"
+    # to rename the generated function
+    rename = "something_else"
+    # In case you don't want to generate the documentation for this method.
+    generate_doc = false
     [[object.signal]]
     name = "activate-link"
     # replace trampoline bool return type with `Inhibit`

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -96,6 +96,24 @@ impl Analysis {
             })
     }
 
+    pub fn find_object_by_virtual_method<
+        F: Fn(&functions::Info) -> bool + Copy,
+        G: Fn(&object::Info) -> bool + Copy,
+    >(
+        &self,
+        env: &Env,
+        search_obj: G,
+        search_fn: F,
+    ) -> Option<(&object::Info, &functions::Info)> {
+        self.objects
+            .values()
+            .filter(|o| search_obj(o))
+            .find_map(|obj_info| {
+                find_function(env, obj_info.virtual_methods.iter(), search_fn)
+                    .map(|fn_info| (obj_info, fn_info))
+            })
+    }
+
     pub fn find_object_by_function<
         F: Fn(&functions::Info) -> bool + Copy,
         G: Fn(&object::Info) -> bool + Copy,

--- a/src/analysis/object.rs
+++ b/src/analysis/object.rs
@@ -20,6 +20,7 @@ pub enum LocationInObject {
     Impl,
     VirtualExt,
     ClassExt,
+    ClassExtManual,
     Ext,
     ExtManual,
     Builder,
@@ -94,6 +95,7 @@ impl Info {
     /// Returns the location of the function within this object
     pub fn function_location(&self, fn_info: &functions::Info) -> LocationInObject {
         if fn_info.kind == FunctionKind::ClassMethod {
+            // TODO: Fix location here once we can auto generate virtual methods
             LocationInObject::ClassExt
         } else if fn_info.kind == FunctionKind::VirtualMethod {
             // TODO: Fix location here once we can auto generate virtual methods
@@ -138,10 +140,13 @@ impl Info {
                     trait_name.into(),
                 )
             }
-            LocationInObject::ClassExt => (
-                format!("subclass::prelude::{}", self.trait_name).into(),
-                self.trait_name.as_str().into(),
-            ),
+            LocationInObject::ClassExt | LocationInObject::ClassExtManual => {
+                let trait_name = format!("{}Ext", self.trait_name);
+                (
+                    format!("subclass::prelude::{}", trait_name).into(),
+                    trait_name.into(),
+                )
+            }
             LocationInObject::Builder => {
                 panic!("C documentation is not expected to link to builders (a Rust concept)!")
             }

--- a/src/analysis/object.rs
+++ b/src/analysis/object.rs
@@ -37,6 +37,7 @@ pub struct Info {
     pub trait_name: String,
     pub has_constructors: bool,
     pub has_functions: bool,
+    pub virtual_methods: Vec<functions::Info>,
     pub signals: Vec<signals::Info>,
     pub notify_signals: Vec<signals::Info>,
     pub properties: Vec<properties::Property>,
@@ -186,6 +187,18 @@ pub fn class(env: &Env, obj: &GObject, deps: &[library::TypeId]) -> Option<Info>
 
     let mut signatures = Signatures::with_capacity(klass.functions.len());
 
+    let virtual_methods = functions::analyze(
+        env,
+        &klass.virtual_methods,
+        Some(class_tid),
+        true,
+        false,
+        obj,
+        &mut imports,
+        None,
+        Some(deps),
+    );
+
     let mut functions = functions::analyze(
         env,
         &klass.functions,
@@ -306,6 +319,7 @@ pub fn class(env: &Env, obj: &GObject, deps: &[library::TypeId]) -> Option<Info>
         trait_name,
         has_constructors,
         has_functions,
+        virtual_methods,
         signals,
         notify_signals,
         properties,

--- a/src/analysis/object.rs
+++ b/src/analysis/object.rs
@@ -19,6 +19,7 @@ use crate::{
 pub enum LocationInObject {
     Impl,
     VirtualExt,
+    ClassExt,
     Ext,
     ExtManual,
     Builder,
@@ -92,7 +93,9 @@ impl Info {
 
     /// Returns the location of the function within this object
     pub fn function_location(&self, fn_info: &functions::Info) -> LocationInObject {
-        if fn_info.kind == FunctionKind::VirtualMethod {
+        if fn_info.kind == FunctionKind::ClassMethod {
+            LocationInObject::ClassExt
+        } else if fn_info.kind == FunctionKind::VirtualMethod {
             // TODO: Fix location here once we can auto generate virtual methods
             LocationInObject::VirtualExt
         } else if self.final_type
@@ -135,6 +138,10 @@ impl Info {
                     trait_name.into(),
                 )
             }
+            LocationInObject::ClassExt => (
+                format!("subclass::prelude::{}", self.trait_name).into(),
+                self.trait_name.as_str().into(),
+            ),
             LocationInObject::Builder => {
                 panic!("C documentation is not expected to link to builders (a Rust concept)!")
             }

--- a/src/codegen/doc/gi_docgen.rs
+++ b/src/codegen/doc/gi_docgen.rs
@@ -220,6 +220,7 @@ fn find_virtual_method_by_name(
         |_| false,
         |_| false,
         |_| false,
+        false,
         true,
     )
 }
@@ -262,6 +263,7 @@ fn find_method_or_function_by_name(
             })
         },
         is_class_method,
+        false,
     )
 }
 

--- a/src/codegen/doc/mod.rs
+++ b/src/codegen/doc/mod.rs
@@ -655,7 +655,7 @@ fn create_record_doc(w: &mut dyn Write, env: &Env, info: &analysis::record::Info
     let object = env.config.objects.get(&info.full_name);
     let trait_name = object
         .and_then(|o| o.trait_name.clone())
-        .unwrap_or_else(|| format!("{}SubclassExt", info.name));
+        .unwrap_or_else(|| format!("{}Ext", info.name));
     let generate_doc = object.map_or(true, |r| r.generate_doc);
     if generate_doc {
         write_item_doc(w, &ty, |w| {

--- a/src/config/functions.rs
+++ b/src/config/functions.rs
@@ -255,7 +255,7 @@ impl Return {
     }
 }
 
-fn check_rename(rename: &Option<String>, object_name: &str, function_name: &Ident) -> bool {
+pub fn check_rename(rename: &Option<String>, object_name: &str, function_name: &Ident) -> bool {
     if let Some(rename) = rename {
         for c in &["\t", "\n", " "] {
             if rename.contains(c) {

--- a/src/config/gobjects.rs
+++ b/src/config/gobjects.rs
@@ -16,6 +16,7 @@ use super::{
     members::Members,
     properties::Properties,
     signals::{Signal, Signals},
+    virtual_methods::VirtualMethods,
 };
 use crate::{
     analysis::{conversion_type::ConversionType, ref_mode},
@@ -65,6 +66,7 @@ impl FromStr for GStatus {
 pub struct GObject {
     pub name: String,
     pub functions: Functions,
+    pub virtual_methods: VirtualMethods,
     pub constants: Constants,
     pub signals: Signals,
     pub members: Members,
@@ -104,6 +106,7 @@ impl Default for GObject {
         GObject {
             name: "Default".into(),
             functions: Functions::new(),
+            virtual_methods: VirtualMethods::new(),
             constants: Constants::new(),
             signals: Signals::new(),
             members: Members::new(),
@@ -297,6 +300,16 @@ fn parse_object(
             assert!(function_names.insert(name), "{name} already defined!");
         }
     }
+    let virtual_methods = VirtualMethods::parse(toml_object.lookup("virtual_method"), &name);
+    let mut virtual_methods_names = HashSet::new();
+    for f in &virtual_methods {
+        if let Ident::Name(name) = &f.ident {
+            assert!(
+                virtual_methods_names.insert(name),
+                "{name} already defined!"
+            );
+        }
+    }
 
     let signals = {
         let mut v = Vec::new();
@@ -479,6 +492,7 @@ fn parse_object(
     GObject {
         name,
         functions,
+        virtual_methods,
         constants,
         signals,
         members,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -16,6 +16,7 @@ pub mod properties;
 pub mod property_generate_flags;
 pub mod signals;
 pub mod string_type;
+pub mod virtual_methods;
 pub mod work_mode;
 
 pub use self::{

--- a/src/config/virtual_methods.rs
+++ b/src/config/virtual_methods.rs
@@ -1,0 +1,189 @@
+use std::collections::HashSet;
+
+use log::error;
+use toml::Value;
+
+use super::{
+    error::TomlHelper,
+    functions::{check_rename, Parameters, Return},
+    gobjects::GStatus,
+    ident::Ident,
+    parsable::{Parsable, Parse},
+};
+use crate::version::Version;
+
+#[derive(Clone, Debug)]
+pub struct VirtualMethod {
+    pub ident: Ident,
+    pub status: GStatus,
+    pub version: Option<Version>,
+    pub cfg_condition: Option<String>,
+    pub parameters: Parameters,
+    pub ret: Return,
+    pub doc_hidden: bool,
+    pub doc_ignore_parameters: HashSet<String>,
+    pub doc_trait_name: Option<String>,
+    pub unsafe_: bool,
+    pub rename: Option<String>,
+    pub bypass_auto_rename: bool,
+    pub generate_doc: bool,
+}
+
+impl Parse for VirtualMethod {
+    fn parse(toml: &Value, object_name: &str) -> Option<Self> {
+        let ident = match Ident::parse(toml, object_name, "virtual_method") {
+            Some(ident) => ident,
+            None => {
+                error!(
+                    "No 'name' or 'pattern' given for virtual_method for object {}",
+                    object_name
+                );
+                return None;
+            }
+        };
+        toml.check_unwanted(
+            &[
+                "ignore",
+                "manual",
+                "version",
+                "cfg_condition",
+                "parameter",
+                "return",
+                "name",
+                "doc_hidden",
+                "doc_ignore_parameters",
+                "pattern",
+                "doc_trait_name",
+                "unsafe",
+                "rename",
+                "bypass_auto_rename",
+                "generate_doc",
+            ],
+            &format!("virtual_method {object_name}"),
+        );
+
+        let status = {
+            if toml
+                .lookup("ignore")
+                .and_then(Value::as_bool)
+                .unwrap_or(false)
+            {
+                GStatus::Ignore
+            } else if toml
+                .lookup("manual")
+                .and_then(Value::as_bool)
+                .unwrap_or(false)
+            {
+                GStatus::Manual
+            } else {
+                GStatus::Generate
+            }
+        };
+        let version = toml
+            .lookup("version")
+            .and_then(Value::as_str)
+            .and_then(|s| s.parse().ok());
+        let cfg_condition = toml
+            .lookup("cfg_condition")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned);
+        let parameters = Parameters::parse(toml.lookup("parameter"), object_name);
+        let ret = Return::parse(toml.lookup("return"), object_name);
+        let doc_hidden = toml
+            .lookup("doc_hidden")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        let doc_ignore_parameters = toml
+            .lookup_vec("doc_ignore_parameters", "Invalid doc_ignore_parameters")
+            .map(|v| {
+                v.iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default();
+        let doc_trait_name = toml
+            .lookup("doc_trait_name")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned);
+        let unsafe_ = toml
+            .lookup("unsafe")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        let rename = toml
+            .lookup("rename")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned);
+        if !check_rename(&rename, object_name, &ident) {
+            return None;
+        }
+        let bypass_auto_rename = toml
+            .lookup("bypass_auto_rename")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+
+        let generate_doc = toml
+            .lookup("generate_doc")
+            .and_then(Value::as_bool)
+            .unwrap_or(true);
+        Some(Self {
+            ident,
+            status,
+            version,
+            cfg_condition,
+            parameters,
+            ret,
+            doc_hidden,
+            doc_ignore_parameters,
+            doc_trait_name,
+            unsafe_,
+            rename,
+            bypass_auto_rename,
+            generate_doc,
+        })
+    }
+}
+
+impl AsRef<Ident> for VirtualMethod {
+    fn as_ref(&self) -> &Ident {
+        &self.ident
+    }
+}
+
+pub type VirtualMethods = Vec<VirtualMethod>;
+
+#[cfg(test)]
+mod tests {
+    use super::{super::ident::Ident, *};
+
+    fn toml(input: &str) -> ::toml::Value {
+        let value = ::toml::from_str(input);
+        assert!(value.is_ok());
+        value.unwrap()
+    }
+
+    #[test]
+    fn function_parse_ignore() {
+        let toml = toml(
+            r#"
+name = "func1"
+ignore = true
+"#,
+        );
+        let f = VirtualMethod::parse(&toml, "a").unwrap();
+        assert_eq!(f.ident, Ident::Name("func1".into()));
+        assert!(f.status.ignored());
+    }
+
+    #[test]
+    fn function_parse_manual() {
+        let toml = toml(
+            r#"
+name = "func1"
+manual = true
+"#,
+        );
+        let f = VirtualMethod::parse(&toml, "a").unwrap();
+        assert_eq!(f.ident, Ident::Name("func1".into()));
+        assert!(f.status.manual());
+    }
+}

--- a/src/library.rs
+++ b/src/library.rs
@@ -153,6 +153,7 @@ pub enum FunctionKind {
     Function,
     Method,
     Global,
+    VirtualMethod,
 }
 
 impl FromStr for FunctionKind {
@@ -549,6 +550,7 @@ pub struct Interface {
     pub c_class_type: Option<String>,
     pub glib_get_type: String,
     pub functions: Vec<Function>,
+    pub virtual_methods: Vec<Function>,
     pub signals: Vec<Signal>,
     pub properties: Vec<Property>,
     pub prerequisites: Vec<TypeId>,
@@ -568,6 +570,7 @@ pub struct Class {
     pub glib_get_type: String,
     pub fields: Vec<Field>,
     pub functions: Vec<Function>,
+    pub virtual_methods: Vec<Function>,
     pub signals: Vec<Signal>,
     pub properties: Vec<Property>,
     pub parent: Option<TypeId>,

--- a/src/library.rs
+++ b/src/library.rs
@@ -153,6 +153,7 @@ pub enum FunctionKind {
     Function,
     Method,
     Global,
+    ClassMethod,
     VirtualMethod,
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -298,6 +298,8 @@ impl Library {
             parser.ignore_element()?;
             return Ok(None);
         }
+        let is_class_record = record_name.ends_with("Class");
+
         let c_type = elem.attr_required("type")?;
         let symbol_prefix = elem.attr("symbol-prefix").map(ToOwned::to_owned);
         let get_type = elem.attr("get-type").map(ToOwned::to_owned);
@@ -388,9 +390,18 @@ impl Library {
             name: record_name.into(),
             c_type: c_type.into(),
             glib_get_type: get_type,
+            functions: if is_class_record && gtype_struct_for.is_some() {
+                fns.into_iter()
+                    .map(|mut f| {
+                        f.kind = FunctionKind::ClassMethod;
+                        f
+                    })
+                    .collect::<Vec<_>>()
+            } else {
+                fns
+            },
             gtype_struct_for: gtype_struct_for.map(|s| s.into()),
             fields,
-            functions: fns,
             version,
             deprecated_version,
             doc,


### PR DESCRIPTION
The intention behind this PR is not to add code generation for subclassing code but it does a good step forward. 

What the PR does currently:
- Parse virtual-methods from the gir file 
- Add configuration options for `[object.virtual_method]`
- Embed the docs for virtual methods
- Working docs links witth gi-docgen

Before

![image](https://user-images.githubusercontent.com/7660997/235325141-e4edbe50-9ee5-41e9-937e-6ee3bcb8dab8.png)

![image](https://user-images.githubusercontent.com/7660997/235325166-fc7b1cca-d4f9-4ce7-bc84-c70e1feff599.png)


After

![image](https://user-images.githubusercontent.com/7660997/235325267-43dfd2ac-387d-4e9a-af4f-1cbc49d82a00.png)

![image](https://user-images.githubusercontent.com/7660997/235325274-1ddecd16-b6b4-45e4-a1ed-6687728526fe.png)

TODO: 
- [x] Add more tests for parsing config options
- [x] Document the new config options
- [x] Test it with gtk-rs-core/gstreamer-rs


Parts of #1319