### PR TITLE
docs/gi-docgen: quote arg identifiers with backticks

### DIFF
--- a/src/codegen/doc/format.rs
+++ b/src/codegen/doc/format.rs
@@ -151,16 +151,20 @@ fn replace_symbols(
                 s => panic!("Unknown symbol prefix `{s}`"),
             },
         });
+        let out = ARG_SIGIL.replace_all(&out, |caps: &Captures<'_>| {
+            format!("{}`{}`", &caps[1], &caps[2])
+        });
         let out = GDK_GTK.replace_all(&out, |caps: &Captures<'_>| {
             find_type(&caps[2], env).unwrap_or_else(|| format!("`{}`", &caps[2]))
         });
 
-        out.to_string()
+        out.into_owned()
     } else {
         replace_c_types(input, env, in_type)
     }
 }
 
+static ARG_SIGIL: Lazy<Regex> = Lazy::new(|| Regex::new(r"(^|\W)@([A-Za-z0-9_]+)\b").unwrap());
 static SYMBOL: Lazy<Regex> = Lazy::new(|| Regex::new(r"([@#%])(\w+\b)([:.]+[\w-]+\b)?").unwrap());
 static GI_DOCGEN_SYMBOL: Lazy<Regex> =
     Lazy::new(|| Regex::new(r"([%])(\w+\b)([:.]+[\w-]+\b)?").unwrap());

--- a/src/codegen/doc/gi_docgen.rs
+++ b/src/codegen/doc/gi_docgen.rs
@@ -110,7 +110,7 @@ pub(crate) fn replace_c_types(
                 caps[0].to_string()
             }
         })
-        .to_string()
+        .into_owned()
 }
 
 /// A representation of the various ways to link items using GI-docgen


### PR DESCRIPTION
Looks like this was missed on the transition from gtk-doc. This is for things like `@self` and `@name` in https://gtk-rs.org/gtk4-rs/git/docs/gtk4/prelude/trait.WidgetExt.html#method.activate_action

And also avoid a copy when converting from `Cow<str>`