### PR TITLE
parser: ignore source-position in virtual methods

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -554,6 +554,7 @@ impl Library {
                 self.read_parameter(parser, ns_id, elem, true, false)
                     .map(|p| ret = Some(p))
             }
+            "source-position" => parser.ignore_element(),
             "doc" => parser.text().map(|t| doc = Some(t)),
             "doc-deprecated" => parser.text().map(|t| doc_deprecated = Some(t)),
             "attribute" => parser.ignore_element(),


### PR DESCRIPTION
Regenerating libadwaita-rs errors out otherwise