### PR TITLE
analysis: Avoid overflow when determining whether to emit a parameter

### DIFF
--- a/src/analysis/function_parameters.rs
+++ b/src/analysis/function_parameters.rs
@@ -240,7 +240,10 @@ pub fn analyze(
             }
         };
 
-        if async_func && to_remove.contains(&(pos - correction_instance)) {
+        if async_func
+            && pos >= correction_instance
+            && to_remove.contains(&(pos - correction_instance))
+        {
             add_rust_parameter = false;
         }
         let mut transfer = par.transfer;

--- a/src/analysis/functions.rs
+++ b/src/analysis/functions.rs
@@ -735,7 +735,10 @@ fn analyze_function(
                     correction_instance = 1;
                 }
 
-                if r#async && to_remove.contains(&(pos - correction_instance)) {
+                if r#async
+                    && pos >= correction_instance
+                    && to_remove.contains(&(pos - correction_instance))
+                {
                     continue;
                 }
                 assert!(


### PR DESCRIPTION
Fixes a debug build of GIR panicking when processing non-static async methods.

```
  thread 'main' panicked at 'attempt to subtract with overflow', ...\gtk-rs-gir\src\analysis\function_parameters.rs:243:46
  stack backtrace:
     0: rust_begin_unwind
               at /rustc/4087deaccd8bceb458c9610d29744d5f3504c5c0/library\std\src/panicking.rs:577:5
     1: core::panicking::panic_fmt
               at /rustc/4087deaccd8bceb458c9610d29744d5f3504c5c0/library\core\src/panicking.rs:67:14
     2: core::panicking::panic
               at /rustc/4087deaccd8bceb458c9610d29744d5f3504c5c0/library\core\src/panicking.rs:117:5
     3: libgir::analysis::function_parameters::analyze
     4: libgir::analysis::functions::analyze_function
     5: libgir::analysis::functions::analyze
     6: libgir::analysis::object::interface
     7: libgir::analysis::analyze
     8: libgir::analysis::run
     9: gir::main
               at ...\gtk-rs-gir\src\main.rs:192:9
```