### PR TITLE
Revert "Specify link attribute for Windows to be happy"

### DIFF
--- a/src/codegen/sys/lib_.rs
+++ b/src/codegen/sys/lib_.rs
@@ -25,18 +25,6 @@ pub fn generate(env: &Env) {
     save_to_file(&path, env.config.make_backup, |w| generate_lib(w, env));
 }
 
-fn write_link_attr(w: &mut dyn Write, shared_libs: &[String]) -> Result<()> {
-    for it in shared_libs {
-        writeln!(
-            w,
-            "#[link(name = \"{}\")]",
-            shared_lib_name_to_link_name(it)
-        )?;
-    }
-
-    Ok(())
-}
-
 fn generate_lib(w: &mut dyn Write, env: &Env) -> Result<()> {
     general::start_comments(w, &env.config)?;
     statics::begin(w)?;
@@ -88,7 +76,6 @@ fn generate_lib(w: &mut dyn Write, env: &Env) -> Result<()> {
     }
 
     if !env.namespaces.main().shared_libs.is_empty() {
-        write_link_attr(w, &env.namespaces.main().shared_libs)?;
         writeln!(w, "extern \"C\" {{")?;
         functions::generate_enums_funcs(w, env, &enums)?;
         functions::generate_bitfields_funcs(w, env, &bitfields)?;

--- a/src/nameutil.rs
+++ b/src/nameutil.rs
@@ -128,25 +128,6 @@ pub fn lib_name_to_toml(name: &str) -> String {
     name.to_string().replace(['-', '.'], "_")
 }
 
-pub fn shared_lib_name_to_link_name(name: &str) -> &str {
-    let mut s = name;
-
-    if s.starts_with("lib") {
-        s = &s[3..];
-    }
-
-    if let Some(offset) = s.rfind(".so") {
-        s = &s[..offset];
-    } else if let Some(offset) = s.rfind(".dll") {
-        s = &s[..offset];
-        if let Some(offset) = s.rfind('-') {
-            s = &s[..offset];
-        }
-    }
-
-    s
-}
-
 pub fn use_glib_type(env: &crate::env::Env, import: &str) -> String {
     format!(
         "{}::{}",
@@ -251,15 +232,5 @@ mod tests {
     #[test]
     fn lib_name_to_toml_works() {
         assert_eq!(lib_name_to_toml("gstreamer-1.0"), "gstreamer_1_0");
-    }
-
-    #[test]
-    fn shared_lib_name_to_link_name_works() {
-        assert_eq!(shared_lib_name_to_link_name("libgtk-4-1.dll"), "gtk-4");
-        assert_eq!(shared_lib_name_to_link_name("libatk-1.0.so.0"), "atk-1.0");
-        assert_eq!(
-            shared_lib_name_to_link_name("libgdk_pixbuf-2.0.so.0"),
-            "gdk_pixbuf-2.0"
-        );
     }
 }


### PR DESCRIPTION
This reverts commit a8dc21319bf6edaba19b2046ffd60c80fd91a2d7.

Linking flags should be provided by the system-deps crate. Specifying linking with the attribute creates issue when statically linking system dependencies.