### PR TITLE
codegen: build tests on all unix platforms

### DIFF
--- a/src/codegen/sys/tests.rs
+++ b/src/codegen/sys/tests.rs
@@ -305,7 +305,7 @@ fn generate_abi_rs(
     info!("Generating file {:?}", path);
     general::start_comments(w, &env.config)?;
     writeln!(w)?;
-    writeln!(w, "#![cfg(target_os = \"linux\")]")?;
+    writeln!(w, "#![cfg(unix)]")?;
     writeln!(w)?;
 
     if !ctypes.is_empty() {


### PR DESCRIPTION
They work fine on FreeBSD, it was annoying to see tests just gone when updating from 0.15.x to 0.17.x..