### PR TITLE
Fix docsrs

### DIFF
--- a/src/codegen/sys/cargo_toml.rs
+++ b/src/codegen/sys/cargo_toml.rs
@@ -188,16 +188,10 @@ fn fill_in(root: &mut Table, env: &Env) {
             ])
         });
 
-        let docs_rs_features: Vec<String> = vec![];
-        docs_rs_metadata.insert(
-            "features".to_string(),
-            Value::Array(
-                docs_rs_features
-                    .into_iter()
-                    .map(Value::String)
-                    .collect::<Vec<_>>(),
-            ),
-        );
+        // Generate docs for all features unless a list of features to be activated on docs.rs was specified
+        if let toml::map::Entry::Vacant(_) = docs_rs_metadata.entry("features") {
+            set_string(docs_rs_metadata, "all-features", "true");
+        }
     }
 }
 

--- a/src/codegen/sys/cargo_toml.rs
+++ b/src/codegen/sys/cargo_toml.rs
@@ -173,6 +173,21 @@ fn fill_in(root: &mut Table, env: &Env) {
         let docs_rs_metadata = upsert_table(docs_rs_metadata, "docs");
         let docs_rs_metadata = upsert_table(docs_rs_metadata, "rs");
 
+        // Set the rustc and rustdoc args to be able to build the docs on docs.rs without the libraries
+        docs_rs_metadata.entry("rustc-args").or_insert_with(|| {
+            Value::Array(vec![
+                Value::String("--cfg".to_string()),
+                Value::String("docsrs".to_string()),
+            ])
+        });
+        docs_rs_metadata.entry("rustdoc-args").or_insert_with(|| {
+            Value::Array(vec![
+                Value::String("--cfg".to_string()),
+                Value::String("docsrs".to_string()),
+                Value::String("--generate-link-to-definition".to_string()),
+            ])
+        });
+
         let docs_rs_features: Vec<String> = vec![];
         docs_rs_metadata.insert(
             "features".to_string(),

--- a/src/codegen/sys/cargo_toml.rs
+++ b/src/codegen/sys/cargo_toml.rs
@@ -172,7 +172,8 @@ fn fill_in(root: &mut Table, env: &Env) {
         let docs_rs_metadata = upsert_table(docs_rs_metadata, "metadata");
         let docs_rs_metadata = upsert_table(docs_rs_metadata, "docs");
         let docs_rs_metadata = upsert_table(docs_rs_metadata, "rs");
-        let docs_rs_features = env.config.docs_rs_features.clone();
+
+        let docs_rs_features: Vec<String> = vec![];
         docs_rs_metadata.insert(
             "features".to_string(),
             Value::Array(

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -114,7 +114,6 @@ pub struct Config {
     pub single_version_file: Option<PathBuf>,
     pub generate_display_trait: bool,
     pub trust_return_value_nullability: bool,
-    pub docs_rs_features: Vec<String>,
     pub disable_format: bool,
     pub split_build_rs: bool,
     pub extra_versions: Vec<Version>,
@@ -265,17 +264,6 @@ impl Config {
                 None => false,
             };
 
-        let mut docs_rs_features = Vec::new();
-        for v in match toml.lookup("options.docs_rs_features") {
-            Some(v) => v.as_result_vec("options.docs_rs_features")?.as_slice(),
-            None => &[],
-        } {
-            docs_rs_features.push(v.as_str().map(|s| s.to_owned()).ok_or(format!(
-                "Invalid `docs_rs_features` value element, expected a string, found {}",
-                v.type_str()
-            ))?);
-        }
-
         // options.concurrency is the default of all objects if nothing
         // else is configured
         let mut objects = toml
@@ -373,7 +361,6 @@ impl Config {
             single_version_file,
             generate_display_trait,
             trust_return_value_nullability,
-            docs_rs_features,
             disable_format,
             split_build_rs,
             extra_versions,


### PR DESCRIPTION
This PR includes a few improvements/cleanups regarding building docs on docs.rs:

- The `docs_rs_features` option in the `Gir.toml` was removed. I searched on Github if anybody was using it and I couldn't find anyone. It was also not documented so I don't think anyone used it. It would have complicated with the last point.
- Since the removal of the dox feature, a few rustc args need to get set in order to build the docs without linking the libraries. They are always the same so we can set them by default in the `Cargo.toml` of the sys crate.
- Automatically activate all features of the sys crate so that they all get documented.