### PR TITLE
Add trait_name to API docs

### DIFF
--- a/book/src/config/api.md
+++ b/book/src/config/api.md
@@ -128,6 +128,8 @@ visibility = "pub" # or 'crate' / 'private' / 'super'
 # The default value to used for the `Default` implementation. It only
 # works for flags and enums. You have to pass the "GIR" member name.
 default_value = "fill"
+# Change the name of the generated trait to e.g avoid naming conflicts
+trait_name = "TraitnameExt" 
 # In case you don't want to generate the documentation for this type.
 generate_doc = false
     # define overrides for function


### PR DESCRIPTION
I had a naming conflict with a generated trait and could not find a solution in the docs. Better to add it to the book to avoid the same [question](https://github.com/gtk-rs/gir/issues/1488) in the future