### PR TITLE
Fix inserting all-features in Cargo.toml for docs.rs

### DIFF
--- a/src/codegen/sys/cargo_toml.rs
+++ b/src/codegen/sys/cargo_toml.rs
@@ -190,7 +190,7 @@ fn fill_in(root: &mut Table, env: &Env) {
 
         // Generate docs for all features unless a list of features to be activated on docs.rs was specified
         if let toml::map::Entry::Vacant(_) = docs_rs_metadata.entry("features") {
-            set_string(docs_rs_metadata, "all-features", "true");
+            docs_rs_metadata.insert("all-features".to_string(), Value::Boolean(true));
         }
     }
 }


### PR DESCRIPTION
Without this PR, this is what is added to the `Cargo.toml` of the sys crate:

```
[package.metadata.docs.rs]
all-features = "true"
```

With the fix the type is correct:

```
[package.metadata.docs.rs]
all-features = true
```

Sorry about that