### PR TITLE
Exclude tests folder and Gir.toml, versions.txt files

### DIFF
--- a/src/codegen/sys/cargo_toml.rs
+++ b/src/codegen/sys/cargo_toml.rs
@@ -102,6 +102,16 @@ fn fill_in(root: &mut Table, env: &Env) {
         let package = upsert_table(root, "package");
         set_string(package, "build", "build.rs");
         // set_string(package, "version", "0.2.0");
+
+        if let toml::map::Entry::Vacant(_) = package.entry("include") {
+            package.entry("exclude").or_insert_with(|| {
+                Value::Array(vec![
+                    Value::String("tests".to_string()),
+                    Value::String("Gir.toml".to_string()),
+                    Value::String("versions.txt".to_string()),
+                ])
+            });
+        }
     }
 
     {


### PR DESCRIPTION
Similar to https://github.com/gtk-rs/gtk-rs-core/pull/1158

The size of the crates can be reduced by excluding the `tests` folder and the `Gir.toml` + `versions.txt` files from being published to crates.io. All crates that are generated by gir have the two files and most will have a `tests` folder. They never have to get published to crates.io so gir can automatically generate that line for us. If for whatever reason they do need to be published, the entries can be removed from the list. The entry is never overwritten if it exists. There can also be an `include` list. If that is the case, no `exclude` is added.

While this in most cases will only save a few KB, the gtk, gstreamer and related crates do get a lot of downloads so I believe it is beneficial.

You can see which files will be included without publishing the crates by running cargo package --list.
