### PR TITLE
config/codegen: Stop generating useless Display impls

### DIFF
--- a/book/src/config/api.md
+++ b/book/src/config/api.md
@@ -21,10 +21,6 @@ deprecate_by_min_version = true
 # can also take path to the directory for saving "versions.txt" or filename with extension.
 # Relative to target_path
 single_version_file = true
-# Generation of Display trait enabled for all enums, classes, etc.,
-# which do not have an override for `generate_display_trait`
-# (defaults to "true")
-generate_display_trait = true
 # Trust the nullability information about return values. If this is disabled
 # then any pointer return type is assumed to be nullable unless there is an
 # explicit override for it.
@@ -116,8 +112,6 @@ module_name = "soome_class"
 version = "3.12"
 # prefixed object in mod.rs with #[cfg(mycond)]
 cfg_condition = "mycond"
-# if you want to override default option Ex. for write your own Display implementation
-generate_display_trait = false
 # if you want to generate builder with name SomeClassBuilder
 generate_builder = true
 # trust return value nullability annotations for this specific type.

--- a/src/analysis/enums.rs
+++ b/src/analysis/enums.rs
@@ -52,10 +52,6 @@ pub fn new(env: &Env, obj: &GObject, imports: &mut Imports) -> Option<Info> {
         if has_get_type {
             imports.add("glib::prelude::*");
         }
-
-        if obj.generate_display_trait {
-            imports.add("std::fmt");
-        }
     }
 
     let mut functions = functions::analyze(

--- a/src/analysis/flags.rs
+++ b/src/analysis/flags.rs
@@ -48,10 +48,6 @@ pub fn new(env: &Env, obj: &GObject, imports: &mut Imports) -> Option<Info> {
         if has_get_type {
             imports.add("glib::prelude::*");
         }
-
-        if obj.generate_display_trait {
-            imports.add("std::fmt");
-        }
     }
 
     let mut functions = functions::analyze(

--- a/src/analysis/functions.rs
+++ b/src/analysis/functions.rs
@@ -849,24 +849,9 @@ fn analyze_function(
             func.c_identifier.as_ref().unwrap_or(&func.name)
         );
         commented = true;
-    } else if status.need_generate() && !commented {
-        if !outs.is_empty() {
-            out_parameters::analyze_imports(env, &func.parameters, imports);
-        }
-        if let Some(AsyncTrampoline {
-            ref output_params, ..
-        }) = trampoline
-        {
-            out_parameters::analyze_imports(
-                env,
-                output_params.iter().map(|out| &out.lib_par),
-                imports,
-            );
-        }
     }
 
     if r#async && status.need_generate() && !commented {
-        imports.add("std::ptr");
         imports.add("std::boxed::Box as Box_");
         imports.add("std::pin::Pin");
 

--- a/src/analysis/object.rs
+++ b/src/analysis/object.rs
@@ -186,9 +186,6 @@ pub fn class(env: &Env, obj: &GObject, deps: &[library::TypeId]) -> Option<Info>
     let deprecated_version = klass.deprecated_version;
 
     let mut imports = Imports::with_defined(&env.library, &name);
-    if obj.generate_display_trait {
-        imports.add("std::fmt");
-    }
 
     let is_fundamental = obj.fundamental_type.unwrap_or(klass.is_fundamental);
     let supertypes = supertypes::analyze(env, class_tid, version, &mut imports, is_fundamental);
@@ -377,9 +374,6 @@ pub fn interface(env: &Env, obj: &GObject, deps: &[library::TypeId]) -> Option<I
 
     let mut imports = Imports::with_defined(&env.library, &name);
     imports.add("glib::prelude::*");
-    if obj.generate_display_trait {
-        imports.add("std::fmt");
-    }
 
     let supertypes = supertypes::analyze(env, iface_tid, version, &mut imports, false);
     let supertypes_properties = supertypes

--- a/src/analysis/properties.rs
+++ b/src/analysis/properties.rs
@@ -343,7 +343,6 @@ fn analyze_property(
                 imports.add("glib::prelude::*");
             }
             imports.add("glib::signal::{connect_raw, SignalHandlerId}");
-            imports.add("std::mem::transmute");
             imports.add("std::boxed::Box as Box_");
 
             Some(signals::Info {

--- a/src/analysis/signals.rs
+++ b/src/analysis/signals.rs
@@ -103,7 +103,6 @@ fn analyze_signal(
         imports.add_used_types(&used_types);
         imports.add("glib::prelude::*");
         imports.add("glib::signal::{connect_raw, SignalHandlerId}");
-        imports.add("std::mem::transmute");
         imports.add("std::boxed::Box as Box_");
     }
     let generate_doc = configured_signals.iter().all(|f| f.generate_doc);

--- a/src/analysis/special_functions.rs
+++ b/src/analysis/special_functions.rs
@@ -251,11 +251,8 @@ pub fn analyze_imports(specials: &Infos, imports: &mut Imports) {
                 imports.add_with_version("glib::translate::*", info.version);
             }
             Compare => {
-                imports.add_with_version("std::cmp", info.version);
                 imports.add_with_version("glib::translate::*", info.version);
             }
-            Display => imports.add_with_version("std::fmt", info.version),
-            Hash => imports.add_with_version("std::hash", info.version),
             Equal => imports.add_with_version("glib::translate::*", info.version),
             _ => {}
         }

--- a/src/codegen/enums.rs
+++ b/src/codegen/enums.rs
@@ -6,7 +6,7 @@ use std::{
 
 use super::{function, trait_impls};
 use crate::{
-    analysis::{enums::Info, special_functions::Type},
+    analysis::enums::Info,
     codegen::{
         general::{
             self, allow_deprecated, cfg_condition, cfg_condition_no_doc, cfg_condition_string,
@@ -225,35 +225,6 @@ fn generate_enum(
     )?;
 
     writeln!(w)?;
-
-    if config.generate_display_trait && !analysis.specials.has_trait(Type::Display) {
-        // Generate Display trait implementation.
-        version_condition(w, env, None, enum_.version, false, 0)?;
-        cfg_condition_no_doc(w, config.cfg_condition.as_ref(), false, 0)?;
-        allow_deprecated(w, any_deprecated_version, false, 0)?;
-        writeln!(
-            w,
-            "impl fmt::Display for {0} {{\n\
-             \tfn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {{\n\
-             \t\twrite!(f, \"{0}::{{}}\", match *self {{",
-            enum_.name
-        )?;
-        for member in &members {
-            version_condition_no_doc(w, env, None, member.version, false, 3)?;
-            cfg_condition_no_doc(w, member.cfg_condition.as_ref(), false, 3)?;
-            writeln!(w, "\t\t\tSelf::{0} => \"{0}\",", member.name)?;
-        }
-
-        if !config.exhaustive {
-            writeln!(
-                w,
-                "\t\t\t_ => \"Unknown\",\n\
-                 \t\t}})\n\
-                 \t}}\n\
-                 }}\n"
-            )?;
-        }
-    }
 
     // Only inline from_glib / into_glib implementations if there are not many enums members
     let maybe_inline = if members.len() <= 12 || config.exhaustive {

--- a/src/codegen/flags.rs
+++ b/src/codegen/flags.rs
@@ -5,7 +5,7 @@ use std::{
 
 use super::{function, general::allow_deprecated, trait_impls};
 use crate::{
-    analysis::{flags::Info, special_functions::Type},
+    analysis::flags::Info,
     codegen::{
         general::{
             self, cfg_condition, cfg_condition_doc, cfg_condition_no_doc, cfg_condition_string,
@@ -180,21 +180,6 @@ fn generate_flags(
 
     writeln!(w)?;
 
-    if config.generate_display_trait && !analysis.specials.has_trait(Type::Display) {
-        // Generate Display trait implementation.
-        version_condition(w, env, None, flags.version, false, 0)?;
-        cfg_condition_no_doc(w, config.cfg_condition.as_ref(), false, 0)?;
-        allow_deprecated(w, flags.deprecated_version, false, 0)?;
-        writeln!(
-            w,
-            "impl fmt::Display for {0} {{\n\
-            \tfn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {{\n\
-            \t\t<Self as fmt::Debug>::fmt(self, f)\n\
-            \t}}\n\
-            }}\n",
-            flags.name
-        )?;
-    }
     generate_default_impl(
         w,
         env,

--- a/src/codegen/object.rs
+++ b/src/codegen/object.rs
@@ -14,7 +14,7 @@ use super::{
 use crate::{
     analysis::{
         self, bounds::BoundType, object::has_builder_properties, record_type::RecordType,
-        ref_mode::RefMode, rust_type::RustType, special_functions::Type,
+        ref_mode::RefMode, rust_type::RustType,
     },
     env::Env,
     library::{self, Nullable},
@@ -22,12 +22,7 @@ use crate::{
     traits::IntoString,
 };
 
-pub fn generate(
-    w: &mut dyn Write,
-    env: &Env,
-    analysis: &analysis::object::Info,
-    generate_display_trait: bool,
-) -> Result<()> {
+pub fn generate(w: &mut dyn Write, env: &Env, analysis: &analysis::object::Info) -> Result<()> {
     general::start_comments(w, &env.config)?;
     if analysis
         .functions
@@ -330,20 +325,6 @@ pub fn generate(
         writeln!(w)?;
         generate_trait(w, env, analysis)?;
     }
-
-    if generate_display_trait && !analysis.specials.has_trait(Type::Display) {
-        writeln!(w, "\nimpl fmt::Display for {} {{", analysis.name,)?;
-        // Generate Display trait implementation.
-        writeln!(
-            w,
-            "\tfn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {{\n\
-             \t\tf.write_str(\"{}\")\n\
-             \t}}\n\
-             }}",
-            analysis.name
-        )?;
-    }
-
     Ok(())
 }
 

--- a/src/codegen/objects.rs
+++ b/src/codegen/objects.rs
@@ -23,13 +23,12 @@ pub fn generate(
             .clone()
             .unwrap_or_else(|| module_name(split_namespace_name(&class_analysis.full_name).1));
 
-        let generate_display_trait = obj.generate_display_trait;
         let mut path = root_path.join(&mod_name);
         path.set_extension("rs");
         info!("Generating file {:?}", path);
 
         save_to_file(path, env.config.make_backup, |w| {
-            super::object::generate(w, env, class_analysis, generate_display_trait)
+            super::object::generate(w, env, class_analysis)
         });
 
         super::object::generate_reexports(env, class_analysis, &mod_name, mod_rs, traits, builders);

--- a/src/codegen/trait_impls.rs
+++ b/src/codegen/trait_impls.rs
@@ -140,9 +140,9 @@ fn generate_display(
     writeln!(
         w,
         "\
-impl fmt::Display for {type_name} {{
+impl std::fmt::Display for {type_name} {{
     #[inline]
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {{
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {{
         {body}
     }}
 }}"
@@ -168,10 +168,10 @@ fn generate_hash(
     writeln!(
         w,
         "\
-impl hash::Hash for {type_name} {{
+impl std::hash::Hash for {type_name} {{
     #[inline]
-    fn hash<H>(&self, state: &mut H) where H: hash::Hasher {{
-        hash::Hash::hash(&{call}, state)
+    fn hash<H>(&self, state: &mut H) where H: std::hash::Hasher {{
+        std::hash::Hash::hash(&{call}, state)
     }}
 }}"
     )
@@ -258,14 +258,14 @@ fn generate_ord(
         "\
 impl PartialOrd for {type_name} {{
     #[inline]
-    fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {{
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {{
         {call}.partial_cmp(&0)
     }}
 }}
 
 impl Ord for {type_name} {{
     #[inline]
-    fn cmp(&self, other: &Self) -> cmp::Ordering {{
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {{
         {call}.cmp(&0)
     }}
 }}"

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -112,7 +112,6 @@ pub struct Config {
     pub show_statistics: bool,
     pub concurrency: library::Concurrency,
     pub single_version_file: Option<PathBuf>,
-    pub generate_display_trait: bool,
     pub trust_return_value_nullability: bool,
     pub disable_format: bool,
     pub split_build_rs: bool,
@@ -253,11 +252,6 @@ impl Config {
             None => Default::default(),
         };
 
-        let generate_display_trait = match toml.lookup("options.generate_display_trait") {
-            Some(v) => v.as_result_bool("options.generate_display_trait")?,
-            None => true,
-        };
-
         let trust_return_value_nullability =
             match toml.lookup("options.trust_return_value_nullability") {
                 Some(v) => v.as_result_bool("options.trust_return_value_nullability")?,
@@ -272,7 +266,6 @@ impl Config {
                 gobjects::parse_toml(
                     t,
                     concurrency,
-                    generate_display_trait,
                     generate_builder,
                     trust_return_value_nullability,
                 )
@@ -282,7 +275,6 @@ impl Config {
             &mut objects,
             &toml,
             concurrency,
-            generate_display_trait,
             generate_builder,
             trust_return_value_nullability,
         );
@@ -359,7 +351,6 @@ impl Config {
             show_statistics,
             concurrency,
             single_version_file,
-            generate_display_trait,
             trust_return_value_nullability,
             disable_format,
             split_build_rs,

--- a/src/config/gobjects.rs
+++ b/src/config/gobjects.rs
@@ -86,7 +86,6 @@ pub struct GObject {
     pub ref_mode: Option<ref_mode::RefMode>,
     pub must_use: bool,
     pub conversion_type: Option<ConversionType>,
-    pub generate_display_trait: bool,
     pub trust_return_value_nullability: bool,
     pub manual_traits: Vec<String>,
     pub align: Option<u32>,
@@ -126,7 +125,6 @@ impl Default for GObject {
             ref_mode: None,
             must_use: false,
             conversion_type: None,
-            generate_display_trait: true,
             trust_return_value_nullability: false,
             manual_traits: Vec::default(),
             align: None,
@@ -149,7 +147,6 @@ pub type GObjects = BTreeMap<String, GObject>;
 pub fn parse_toml(
     toml_objects: &Value,
     concurrency: library::Concurrency,
-    generate_display_trait: bool,
     generate_builder: bool,
     trust_return_value_nullability: bool,
 ) -> GObjects {
@@ -158,7 +155,6 @@ pub fn parse_toml(
         let gobject = parse_object(
             toml_object,
             concurrency,
-            generate_display_trait,
             generate_builder,
             trust_return_value_nullability,
         );
@@ -232,7 +228,6 @@ pub fn parse_conversion_type(toml: Option<&Value>, object_name: &str) -> Option<
 fn parse_object(
     toml_object: &Value,
     concurrency: library::Concurrency,
-    default_generate_display_trait: bool,
     generate_builder: bool,
     trust_return_value_nullability: bool,
 ) -> GObject {
@@ -268,7 +263,6 @@ fn parse_object(
             "trait_name",
             "cfg_condition",
             "must_use",
-            "generate_display_trait",
             "trust_return_value_nullability",
             "manual_traits",
             "align",
@@ -371,10 +365,6 @@ fn parse_object(
         .lookup("must_use")
         .and_then(Value::as_bool)
         .unwrap_or(false);
-    let generate_display_trait = toml_object
-        .lookup("generate_display_trait")
-        .and_then(Value::as_bool)
-        .unwrap_or(default_generate_display_trait);
     let trust_return_value_nullability = toml_object
         .lookup("trust_return_value_nullability")
         .and_then(Value::as_bool)
@@ -512,7 +502,6 @@ fn parse_object(
         ref_mode,
         must_use,
         conversion_type,
-        generate_display_trait,
         trust_return_value_nullability,
         manual_traits,
         align,
@@ -532,7 +521,6 @@ pub fn parse_status_shorthands(
     objects: &mut GObjects,
     toml: &Value,
     concurrency: library::Concurrency,
-    generate_display_trait: bool,
     generate_builder: bool,
     trust_return_value_nullability: bool,
 ) {
@@ -543,7 +531,6 @@ pub fn parse_status_shorthands(
             status,
             toml,
             concurrency,
-            generate_display_trait,
             generate_builder,
             trust_return_value_nullability,
         );
@@ -555,7 +542,6 @@ fn parse_status_shorthand(
     status: GStatus,
     toml: &Value,
     concurrency: library::Concurrency,
-    generate_display_trait: bool,
     generate_builder: bool,
     trust_return_value_nullability: bool,
 ) {
@@ -570,7 +556,6 @@ fn parse_status_shorthand(
                             name: name.into(),
                             status,
                             concurrency,
-                            generate_display_trait,
                             trust_return_value_nullability,
                             generate_builder,
                             ..Default::default()
@@ -628,7 +613,7 @@ status = "generate"
 "#,
         );
 
-        let object = parse_object(toml, Concurrency::default(), false, false, false);
+        let object = parse_object(toml, Concurrency::default(), false, false);
         assert_eq!(object.conversion_type, None);
     }
 
@@ -642,7 +627,7 @@ conversion_type = "Option"
 "#,
         );
 
-        let object = parse_object(&toml, Concurrency::default(), false, false, false);
+        let object = parse_object(&toml, Concurrency::default(), false, false);
         assert_eq!(object.conversion_type, Some(ConversionType::Option));
     }
 
@@ -657,7 +642,7 @@ status = "generate"
 "#,
         );
 
-        let object = parse_object(toml, Concurrency::default(), false, false, false);
+        let object = parse_object(toml, Concurrency::default(), false, false);
         assert_eq!(object.conversion_type, Some(ConversionType::Option));
     }
 
@@ -672,7 +657,7 @@ status = "generate"
 "#,
         );
 
-        let object = parse_object(toml, Concurrency::default(), false, false, false);
+        let object = parse_object(toml, Concurrency::default(), false, false);
         assert_eq!(
             object.conversion_type,
             Some(ConversionType::Result {
@@ -694,7 +679,7 @@ status = "generate"
 "#,
         );
 
-        let object = parse_object(toml, Concurrency::default(), false, false, false);
+        let object = parse_object(toml, Concurrency::default(), false, false);
         assert_eq!(
             object.conversion_type,
             Some(ConversionType::Result {
@@ -717,7 +702,7 @@ status = "generate"
 "#,
         );
 
-        let object = parse_object(toml, Concurrency::default(), false, false, false);
+        let object = parse_object(toml, Concurrency::default(), false, false);
         assert_eq!(
             object.conversion_type,
             Some(ConversionType::Result {
@@ -745,7 +730,7 @@ status = "generate"
 
         let object = toml
             .lookup("object")
-            .map(|t| parse_toml(t, Concurrency::default(), false, false, false))
+            .map(|t| parse_toml(t, Concurrency::default(), false, false))
             .expect("parsing failed");
         assert_eq!(
             object["Test"].constants,
@@ -774,7 +759,7 @@ generate_doc = false
 "#,
         );
 
-        let object = parse_object(r, Concurrency::default(), false, false, false);
+        let object = parse_object(r, Concurrency::default(), false, false);
         assert!(!object.generate_doc);
 
         // Ensure that the default value is "true".
@@ -784,7 +769,7 @@ name = "Test"
 status = "generate"
 "#,
         );
-        let object = parse_object(r, Concurrency::default(), false, false, false);
+        let object = parse_object(r, Concurrency::default(), false, false);
         assert!(object.generate_doc);
     }
 }

--- a/src/writer/to_code.rs
+++ b/src/writer/to_code.rs
@@ -78,13 +78,13 @@ impl ToCode for Chunk {
                 let s = format_block_one_line(&prefix, ";", &value_strings, "", "");
                 vec![s]
             }
-            Uninitialized => vec!["mem::MaybeUninit::uninit()".into()],
+            Uninitialized => vec!["std::mem::MaybeUninit::uninit()".into()],
             UninitializedNamed { ref name } => {
                 let s = format!("{name}::uninitialized()");
                 vec![s]
             }
-            NullPtr => vec!["ptr::null()".into()],
-            NullMutPtr => vec!["ptr::null_mut()".into()],
+            NullPtr => vec!["std::ptr::null()".into()],
+            NullMutPtr => vec!["std::ptr::null_mut()".into()],
             Custom(ref string) => vec![string.clone()],
             Tuple(ref chs, ref mode) => {
                 #[allow(deprecated)]

--- a/src/writer/to_code.rs
+++ b/src/writer/to_code.rs
@@ -163,7 +163,7 @@ impl ToCode for Chunk {
                 }
                 let self_str = if in_trait { "Self, " } else { "" };
                 v.push(format!(
-                    "\tSome(transmute::<_, unsafe extern \"C\" fn()>({trampoline}::<{self_str}F> as *const ())), Box_::into_raw(f))"
+                    "\tSome(std::mem::transmute::<_, unsafe extern \"C\" fn()>({trampoline}::<{self_str}F> as *const ())), Box_::into_raw(f))"
                 ));
                 v
             }


### PR DESCRIPTION
- objects: It uses to print the type name: not useful at all
- enums: It does print what a debug impl would print
- flags: It does print what a debug impl would print

So just get rid of that generated code and let the bindings generate a display impl manually when it makes sense