### PR TITLE
Make auto builders/traits/functions `pub(crate)`

### DIFF
--- a/book/src/tutorial/handling_errors.md
+++ b/book/src/tutorial/handling_errors.md
@@ -128,7 +128,7 @@ A little tip about reexporting manual traits: in `gtk3-rs`, we create a `src/pre
 The `src/prelude.rs` file looks like this:
 
 ```rust
-pub use auto::traits::*;
+pub use crate::auto::traits::*;
 pub use region::RegionExtManual;
 ```
 

--- a/book/src/tutorial/high_level_rust_api.md
+++ b/book/src/tutorial/high_level_rust_api.md
@@ -317,7 +317,9 @@ These are the objects we will add to the `manual` array in the following steps.
 These are global functions that were not generated.
 To fix it, we just add `"NameOfYourLibrary.*"` to the `generate` array in the Git.toml and add the following line to your src/lib.rs file:
 ```rust
-pub use auto::functions::*;
+pub mod functions {
+  pub use super::auto::functions::*;
+}
 ```
 
 ## Generating the code

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -175,9 +175,8 @@ pub fn run(env: &mut Env) {
         if obj.status.ignored() {
             continue;
         }
-        let tid = match env.library.find_type(0, &obj.name) {
-            Some(x) => x,
-            None => continue,
+        let Some(tid) = env.library.find_type(0, &obj.name) else {
+            continue;
         };
         let deps = supertypes::dependencies(env, tid);
         to_analyze.push((tid, deps));
@@ -224,9 +223,8 @@ fn analyze_enums(env: &mut Env) {
         if obj.status.ignored() {
             continue;
         }
-        let tid = match env.library.find_type(0, &obj.name) {
-            Some(x) => x,
-            None => continue,
+        let Some(tid) = env.library.find_type(0, &obj.name) else {
+            continue;
         };
 
         if let Type::Enumeration(_) = env.library.type_(tid) {
@@ -246,9 +244,8 @@ fn analyze_flags(env: &mut Env) {
         if obj.status.ignored() {
             continue;
         }
-        let tid = match env.library.find_type(0, &obj.name) {
-            Some(x) => x,
-            None => continue,
+        let Some(tid) = env.library.find_type(0, &obj.name) else {
+            continue;
         };
 
         if let Type::Bitfield(_) = env.library.type_(tid) {
@@ -325,9 +322,8 @@ fn analyze_constants(env: &mut Env) {
 
 fn analyze(env: &mut Env, tid: TypeId, deps: &[TypeId]) {
     let full_name = tid.full_name(&env.library);
-    let obj = match env.config.objects.get(&*full_name) {
-        Some(obj) => obj,
-        None => return,
+    let Some(obj) = env.config.objects.get(&*full_name) else {
+        return;
     };
     match env.library.type_(tid) {
         Type::Class(_) => {

--- a/src/codegen/functions.rs
+++ b/src/codegen/functions.rs
@@ -26,7 +26,7 @@ pub fn generate(env: &Env, root_path: &Path, mod_rs: &mut Vec<String>) {
 
         writeln!(w)?;
 
-        mod_rs.push("\npub mod functions;".into());
+        mod_rs.push("\npub(crate) mod functions;".into());
 
         for func_analysis in &functions.functions {
             function::generate(w, env, None, func_analysis, None, None, false, false, 0)?;

--- a/src/codegen/functions.rs
+++ b/src/codegen/functions.rs
@@ -11,9 +11,8 @@ use crate::{
 pub fn generate(env: &Env, root_path: &Path, mod_rs: &mut Vec<String>) {
     info!("Generate global functions");
 
-    let functions = match env.analysis.global_functions {
-        Some(ref functions) => functions,
-        None => return,
+    let Some(ref functions) = env.analysis.global_functions else {
+        return;
     };
     // Don't generate anything if we have no functions
     if functions.functions.is_empty() {

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -87,15 +87,13 @@ pub fn generate_mod_rs(
         general::write_vec(w, mod_rs)?;
         writeln!(w)?;
         if !traits.is_empty() {
-            writeln!(w, "#[doc(hidden)]")?;
-            writeln!(w, "pub mod traits {{")?;
+            writeln!(w, "pub(crate) mod traits {{")?;
             general::write_vec(w, traits)?;
             writeln!(w, "}}")?;
         }
 
         if !builders.is_empty() {
-            writeln!(w, "#[doc(hidden)]")?;
-            writeln!(w, "pub mod builders {{")?;
+            writeln!(w, "pub(crate) mod builders {{")?;
             general::write_vec(w, builders)?;
             writeln!(w, "}}")?;
         }

--- a/src/codegen/sys/functions.rs
+++ b/src/codegen/sys/functions.rs
@@ -121,9 +121,8 @@ pub fn generate_unions_funcs(
 ) -> Result<()> {
     let intern_str = INTERN.to_string();
     for union in unions {
-        let c_type = match union.c_type {
-            Some(ref x) => x,
-            None => return Ok(()),
+        let Some(ref c_type) = union.c_type else {
+            return Ok(());
         };
         let name = format!("{}.{}", env.config.library_name, union.name);
         let obj = env.config.objects.get(&name).unwrap_or(&DEFAULT_OBJ);

--- a/src/codegen/sys/lib_.rs
+++ b/src/codegen/sys/lib_.rs
@@ -124,9 +124,8 @@ fn find_modules(env: &Env) -> Result<Vec<String>> {
     let mut vec = Vec::<String>::new();
     for entry in fs::read_dir(&env.config.auto_path)? {
         let path = entry?.path();
-        let ext = match path.extension() {
-            Some(ext) => ext,
-            None => continue,
+        let Some(ext) = path.extension() else {
+            continue;
         };
         if ext != "rs" {
             continue;

--- a/src/config/constants.rs
+++ b/src/config/constants.rs
@@ -15,15 +15,12 @@ pub struct Constant {
 
 impl Parse for Constant {
     fn parse(toml: &Value, object_name: &str) -> Option<Self> {
-        let ident = match Ident::parse(toml, object_name, "constant") {
-            Some(ident) => ident,
-            None => {
-                error!(
-                    "No 'name' or 'pattern' given for constant for object {}",
-                    object_name
-                );
-                return None;
-            }
+        let Some(ident) = Ident::parse(toml, object_name, "constant") else {
+            error!(
+                "No 'name' or 'pattern' given for constant for object {}",
+                object_name
+            );
+            return None;
         };
         toml.check_unwanted(
             &[

--- a/src/config/error.rs
+++ b/src/config/error.rs
@@ -16,10 +16,7 @@ where
 impl TomlHelper for toml::Value {
     fn check_unwanted(&self, options: &[&str], err_msg: &str) {
         let mut ret = Vec::new();
-        let table = match self.as_table() {
-            Some(table) => table,
-            None => return,
-        };
+        let Some(table) = self.as_table() else { return };
         for (key, _) in table.iter() {
             if !options.contains(&key.as_str()) {
                 ret.push(key.clone());

--- a/src/config/functions.rs
+++ b/src/config/functions.rs
@@ -28,15 +28,12 @@ pub type CallbackParameters = Vec<CallbackParameter>;
 
 impl Parse for CallbackParameter {
     fn parse(toml: &Value, object_name: &str) -> Option<Self> {
-        let ident = match Ident::parse(toml, object_name, "callback parameter") {
-            Some(ident) => ident,
-            None => {
-                error!(
-                    "No 'name' or 'pattern' given for parameter for object {}",
-                    object_name
-                );
-                return None;
-            }
+        let Some(ident) = Ident::parse(toml, object_name, "callback parameter") else {
+            error!(
+                "No 'name' or 'pattern' given for parameter for object {}",
+                object_name
+            );
+            return None;
         };
         toml.check_unwanted(&["nullable"], &format!("callback parameter {object_name}"));
 
@@ -72,15 +69,12 @@ pub struct Parameter {
 
 impl Parse for Parameter {
     fn parse(toml: &Value, object_name: &str) -> Option<Self> {
-        let ident = match Ident::parse(toml, object_name, "function parameter") {
-            Some(ident) => ident,
-            None => {
-                error!(
-                    "No 'name' or 'pattern' given for parameter for object {}",
-                    object_name
-                );
-                return None;
-            }
+        let Some(ident) = Ident::parse(toml, object_name, "function parameter") else {
+            error!(
+                "No 'name' or 'pattern' given for parameter for object {}",
+                object_name
+            );
+            return None;
         };
         toml.check_unwanted(
             &[
@@ -295,15 +289,12 @@ pub struct Function {
 
 impl Parse for Function {
     fn parse(toml: &Value, object_name: &str) -> Option<Self> {
-        let ident = match Ident::parse(toml, object_name, "function") {
-            Some(ident) => ident,
-            None => {
-                error!(
-                    "No 'name' or 'pattern' given for function for object {}",
-                    object_name
-                );
-                return None;
-            }
+        let Some(ident) = Ident::parse(toml, object_name, "function") else {
+            error!(
+                "No 'name' or 'pattern' given for function for object {}",
+                object_name
+            );
+            return None;
         };
         toml.check_unwanted(
             &[

--- a/src/config/members.rs
+++ b/src/config/members.rs
@@ -18,15 +18,12 @@ pub struct Member {
 
 impl Parse for Member {
     fn parse(toml: &Value, object_name: &str) -> Option<Self> {
-        let ident = match Ident::parse(toml, object_name, "member") {
-            Some(ident) => ident,
-            None => {
-                error!(
-                    "No 'name' or 'pattern' given for member for object {}",
-                    object_name
-                );
-                return None;
-            }
+        let Some(ident) = Ident::parse(toml, object_name, "member") else {
+            error!(
+                "No 'name' or 'pattern' given for member for object {}",
+                object_name
+            );
+            return None;
         };
 
         toml.check_unwanted(

--- a/src/config/properties.rs
+++ b/src/config/properties.rs
@@ -20,15 +20,12 @@ pub struct Property {
 
 impl Parse for Property {
     fn parse(toml: &Value, object_name: &str) -> Option<Self> {
-        let ident = match Ident::parse(toml, object_name, "property") {
-            Some(ident) => ident,
-            None => {
-                error!(
-                    "No 'name' or 'pattern' given for property for object {}",
-                    object_name
-                );
-                return None;
-            }
+        let Some(ident) = Ident::parse(toml, object_name, "property") else {
+            error!(
+                "No 'name' or 'pattern' given for property for object {}",
+                object_name
+            );
+            return None;
         };
 
         toml.check_unwanted(

--- a/src/config/signals.rs
+++ b/src/config/signals.rs
@@ -46,15 +46,12 @@ pub struct Parameter {
 
 impl Parse for Parameter {
     fn parse(toml: &Value, object_name: &str) -> Option<Self> {
-        let ident = match Ident::parse(toml, object_name, "signal parameter") {
-            Some(ident) => ident,
-            None => {
-                error!(
-                    "No 'name' or 'pattern' given for parameter for object {}",
-                    object_name
-                );
-                return None;
-            }
+        let Some(ident) = Ident::parse(toml, object_name, "signal parameter") else {
+            error!(
+                "No 'name' or 'pattern' given for parameter for object {}",
+                object_name
+            );
+            return None;
         };
         toml.check_unwanted(
             &["nullable", "transformation", "new_name", "name", "pattern"],
@@ -118,15 +115,12 @@ impl Signal {
         object_name: &str,
         concurrency: library::Concurrency,
     ) -> Option<Self> {
-        let ident = match Ident::parse(toml, object_name, "signal") {
-            Some(ident) => ident,
-            None => {
-                error!(
-                    "No 'name' or 'pattern' given for signal for object {}",
-                    object_name
-                );
-                return None;
-            }
+        let Some(ident) = Ident::parse(toml, object_name, "signal") else {
+            error!(
+                "No 'name' or 'pattern' given for signal for object {}",
+                object_name
+            );
+            return None;
         };
         toml.check_unwanted(
             &[

--- a/src/config/virtual_methods.rs
+++ b/src/config/virtual_methods.rs
@@ -31,15 +31,12 @@ pub struct VirtualMethod {
 
 impl Parse for VirtualMethod {
     fn parse(toml: &Value, object_name: &str) -> Option<Self> {
-        let ident = match Ident::parse(toml, object_name, "virtual_method") {
-            Some(ident) => ident,
-            None => {
-                error!(
-                    "No 'name' or 'pattern' given for virtual_method for object {}",
-                    object_name
-                );
-                return None;
-            }
+        let Some(ident) = Ident::parse(toml, object_name, "virtual_method") else {
+            error!(
+                "No 'name' or 'pattern' given for virtual_method for object {}",
+                object_name
+            );
+            return None;
         };
         toml.check_unwanted(
             &[

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -26,9 +26,8 @@ impl Library {
         for dir in dirs {
             let dir: &Path = dir.as_ref();
             let file_name = make_file_name(dir, &libs[libs.len() - 1]);
-            let mut parser = match XmlParser::from_path(&file_name) {
-                Ok(p) => p,
-                _ => continue,
+            let Ok(mut parser) = XmlParser::from_path(&file_name) else {
+                continue;
             };
             return parser.document(|p, _| {
                 p.element_with_name("repository", |sub_parser, _elem| {

--- a/src/update_version.rs
+++ b/src/update_version.rs
@@ -85,9 +85,8 @@ fn fix_versions_by_config(library: &mut Library, cfg: &Config) {
         }
         let version = obj.version;
 
-        let tid = match library.find_type(0, &obj.name) {
-            Some(x) => x,
-            None => continue,
+        let Some(tid) = library.find_type(0, &obj.name) else {
+            continue;
         };
         match library.type_mut(tid) {
             Class(class) => class.version = version,


### PR DESCRIPTION
Currently clippy would complain about a pub mod in auto having the same name as the outer mod. We should just make these mods `pub(crate)` and ask the user to explicitly re-export them.  This solves the clippy lint complaint without having to rename any  files.