### PR TITLE
parser: Don't require name/type for record types

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -291,7 +291,7 @@ impl Library {
         parent_name_prefix: Option<&str>,
         parent_ctype_prefix: Option<&str>,
     ) -> Result<Option<Type>, String> {
-        let record_name = elem.attr_required("name")?;
+        let record_name = elem.attr("name").unwrap_or_default();
         // Records starting with `_` are intended to be private and should not be bound
         if record_name.starts_with('_') {
             parser.ignore_element()?;
@@ -299,7 +299,7 @@ impl Library {
         }
         let is_class_record = record_name.ends_with("Class");
 
-        let c_type = elem.attr_required("type")?;
+        let c_type = elem.attr("type").unwrap_or_default();
         let symbol_prefix = elem.attr("symbol-prefix").map(ToOwned::to_owned);
         let get_type = elem.attr("get-type").map(ToOwned::to_owned);
         let gtype_struct_for = elem.attr("is-gtype-struct-for");


### PR DESCRIPTION
As gtk4 now has a record that contains a union without a name/c-type