### PR TITLE
Automatically assume that `win32_` and `unix_` should use the related cfg

### DIFF
--- a/src/config/functions.rs
+++ b/src/config/functions.rs
@@ -344,10 +344,7 @@ impl Parse for Function {
             .lookup("version")
             .and_then(Value::as_str)
             .and_then(|s| s.parse().ok());
-        let cfg_condition = toml
-            .lookup("cfg_condition")
-            .and_then(Value::as_str)
-            .map(ToOwned::to_owned);
+        let cfg_condition = super::get_cfg_condition(toml, object_name);
         let parameters = Parameters::parse(toml.lookup("parameter"), object_name);
         let ret = Return::parse(toml.lookup("return"), object_name);
         let doc_hidden = toml

--- a/src/config/gobjects.rs
+++ b/src/config/gobjects.rs
@@ -330,10 +330,7 @@ fn parse_object(
         .lookup("version")
         .and_then(Value::as_str)
         .and_then(|s| s.parse().ok());
-    let cfg_condition = toml_object
-        .lookup("cfg_condition")
-        .and_then(Value::as_str)
-        .map(ToOwned::to_owned);
+    let cfg_condition = super::get_object_cfg_condition(toml_object, &name);
     let generate_trait = toml_object.lookup("trait").and_then(Value::as_bool);
     let final_type = toml_object
         .lookup("final_type")

--- a/src/config/members.rs
+++ b/src/config/members.rs
@@ -52,10 +52,7 @@ impl Parse for Member {
             .lookup("deprecated_version")
             .and_then(Value::as_str)
             .and_then(|s| s.parse().ok());
-        let cfg_condition = toml
-            .lookup("cfg_condition")
-            .and_then(Value::as_str)
-            .map(ToOwned::to_owned);
+        let cfg_condition = super::get_cfg_condition(toml, object_name);
 
         let status = {
             if toml

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -27,3 +27,62 @@ pub use self::{
     string_type::StringType,
     work_mode::WorkMode,
 };
+
+use self::error::TomlHelper;
+use log::warn;
+
+fn get_cfg_condition(toml: &toml::Value, object_name: &str) -> Option<String> {
+    let cfg_condition = toml.lookup("cfg_condition").and_then(toml::Value::as_str);
+    let Some(sub_object_name) = object_name.split('.').nth(1) else {
+        return cfg_condition.map(ToString::to_string);
+    };
+    if sub_object_name.starts_with("win32_") {
+        match cfg_condition {
+            Some("windows") => {
+                warn!("\"object {object_name}\": No need to set `cfg_condition` to `windows` if name starts with `win32_`");
+                Some("window".to_string())
+            }
+            None => Some("window".to_string()),
+            Some(cfg) => Some(format!("{cfg},windows")),
+        }
+    } else if sub_object_name.starts_with("unix_") {
+        match cfg_condition {
+            Some("unix") => {
+                warn!("\"object {object_name}\": No need to set `cfg_condition` to `unix` if name starts with `unix_`");
+                Some("unix".to_string())
+            }
+            None => Some("unix".to_string()),
+            Some(cfg) => Some(format!("{cfg},unix")),
+        }
+    } else {
+        cfg_condition.map(ToString::to_string)
+    }
+}
+
+fn get_object_cfg_condition(toml: &toml::Value, object_name: &str) -> Option<String> {
+    let cfg_condition = toml.lookup("cfg_condition").and_then(toml::Value::as_str);
+    let Some(sub_object_name) = object_name.split('.').nth(1) else {
+        return cfg_condition.map(ToString::to_string);
+    };
+    if sub_object_name.starts_with("Win32") || sub_object_name.starts_with("GWin32") {
+        match cfg_condition {
+            Some("windows") => {
+                warn!("\"object {object_name}\": No need to set `cfg_condition` to `windows` if object name starts with `Win32`");
+                Some("windows".to_string())
+            }
+            None => Some("windows".to_string()),
+            Some(cfg) => Some(format!("{cfg},windows")),
+        }
+    } else if sub_object_name.starts_with("Unix") || sub_object_name.starts_with("GUnix") {
+        match cfg_condition {
+            Some("unix") => {
+                warn!("\"object {object_name}\": No need to set `cfg_condition` to `unix` if object name starts with `Unix`");
+                Some("unix".to_string())
+            }
+            None => Some("unix".to_string()),
+            Some(cfg) => Some(format!("{cfg},unix")),
+        }
+    } else {
+        cfg_condition.map(ToString::to_string)
+    }
+}

--- a/src/config/virtual_methods.rs
+++ b/src/config/virtual_methods.rs
@@ -80,10 +80,7 @@ impl Parse for VirtualMethod {
             .lookup("version")
             .and_then(Value::as_str)
             .and_then(|s| s.parse().ok());
-        let cfg_condition = toml
-            .lookup("cfg_condition")
-            .and_then(Value::as_str)
-            .map(ToOwned::to_owned);
+        let cfg_condition = super::get_cfg_condition(toml, object_name);
         let parameters = Parameters::parse(toml.lookup("parameter"), object_name);
         let ret = Return::parse(toml.lookup("return"), object_name);
         let doc_hidden = toml


### PR DESCRIPTION
I'm waiting for https://github.com/gtk-rs/gtk-rs-core/pull/1285 to be merged to confirm that it's working as expected. Reviews can wait until then.