### PR TITLE
Automatically assume that `win32_` and `unix_` should use the related cfg

### DIFF
--- a/src/analysis/constants.rs
+++ b/src/analysis/constants.rs
@@ -1,6 +1,6 @@
 use std::borrow::Borrow;
 
-use crate::{config, env::Env, library, nameutil, traits::*, version::Version};
+use crate::{config, env::Env, library, nameutil, traits::*, update_cfgs, version::Version};
 
 #[derive(Debug)]
 pub struct Info {
@@ -49,6 +49,7 @@ pub fn analyze<F: Borrow<library::Constant>>(
         let cfg_condition = configured_constants
             .iter()
             .find_map(|c| c.cfg_condition.clone());
+        let cfg_condition = update_cfgs::get_constant_cfg_condition(&constant.name, &cfg_condition);
 
         let name = nameutil::mangle_keywords(&*constant.name).into_owned();
 

--- a/src/analysis/functions.rs
+++ b/src/analysis/functions.rs
@@ -35,6 +35,7 @@ use crate::{
     },
     nameutil,
     traits::*,
+    update_cfgs,
     version::Version,
 };
 
@@ -651,6 +652,9 @@ fn analyze_function(
     let cfg_condition = configured_functions
         .iter()
         .find_map(|f| f.cfg_condition.clone());
+    let ns = env.library.namespace(ns_id);
+    let cfg_condition =
+        update_cfgs::get_cfg_condition(&func.name, &cfg_condition, &ns.symbol_prefixes);
     let doc_hidden = configured_functions.iter().any(|f| f.doc_hidden);
     let doc_trait_name = configured_functions
         .iter()

--- a/src/analysis/namespaces.rs
+++ b/src/analysis/namespaces.rs
@@ -14,6 +14,7 @@ pub struct Namespace {
     pub higher_crate_name: String,
     pub package_names: Vec<String>,
     pub symbol_prefixes: Vec<String>,
+    pub identifier_prefixes: Vec<String>,
     pub shared_libs: Vec<String>,
     pub versions: Vec<Version>,
 }
@@ -58,6 +59,7 @@ pub fn run(gir: &library::Library) -> Info {
             higher_crate_name,
             package_names: ns.package_names.clone(),
             symbol_prefixes: ns.symbol_prefixes.clone(),
+            identifier_prefixes: ns.identifier_prefixes.clone(),
             shared_libs: ns.shared_library.clone(),
             versions: ns.versions.iter().copied().collect(),
         });

--- a/src/analysis/object.rs
+++ b/src/analysis/object.rs
@@ -12,6 +12,7 @@ use crate::{
     library::{self, FunctionKind},
     nameutil::*,
     traits::*,
+    update_cfgs,
 };
 
 /// The location of an item within the object
@@ -302,6 +303,9 @@ pub fn class(env: &Env, obj: &GObject, deps: &[library::TypeId]) -> Option<Info>
         imports.add("glib::prelude::*");
     }
 
+    let ns = env.library.namespace(class_tid.ns_id);
+    let cfg_condition =
+        update_cfgs::get_object_cfg_condition(&name, &obj.cfg_condition, &ns.identifier_prefixes);
     let base = InfoBase {
         full_name,
         type_id: class_tid,
@@ -311,7 +315,7 @@ pub fn class(env: &Env, obj: &GObject, deps: &[library::TypeId]) -> Option<Info>
         imports,
         version,
         deprecated_version,
-        cfg_condition: obj.cfg_condition.clone(),
+        cfg_condition,
         concurrency: obj.concurrency,
         visibility: obj.visibility,
     };
@@ -428,6 +432,9 @@ pub fn interface(env: &Env, obj: &GObject, deps: &[library::TypeId]) -> Option<I
         deps,
     );
 
+    let ns = env.library.namespace(iface_tid.ns_id);
+    let cfg_condition =
+        update_cfgs::get_object_cfg_condition(&name, &obj.cfg_condition, &ns.identifier_prefixes);
     let base = InfoBase {
         full_name,
         type_id: iface_tid,
@@ -437,7 +444,7 @@ pub fn interface(env: &Env, obj: &GObject, deps: &[library::TypeId]) -> Option<I
         imports,
         version,
         deprecated_version,
-        cfg_condition: obj.cfg_condition.clone(),
+        cfg_condition,
         concurrency: obj.concurrency,
         visibility: obj.visibility,
     };

--- a/src/analysis/record.rs
+++ b/src/analysis/record.rs
@@ -12,6 +12,7 @@ use crate::{
     library,
     nameutil::*,
     traits::*,
+    update_cfgs,
     version::Version,
 };
 
@@ -195,6 +196,10 @@ pub fn new(env: &Env, obj: &GObject) -> Option<Info> {
         }
     }
 
+    let ns = env.library.namespace(record_tid.ns_id);
+    let cfg_condition =
+        update_cfgs::get_object_cfg_condition(&name, &obj.cfg_condition, &ns.identifier_prefixes);
+
     let base = InfoBase {
         full_name,
         type_id: record_tid,
@@ -204,7 +209,7 @@ pub fn new(env: &Env, obj: &GObject) -> Option<Info> {
         imports,
         version,
         deprecated_version,
-        cfg_condition: obj.cfg_condition.clone(),
+        cfg_condition,
         concurrency: obj.concurrency,
         visibility: obj.visibility,
     };

--- a/src/codegen/sys/fields.rs
+++ b/src/codegen/sys/fields.rs
@@ -4,6 +4,7 @@ use crate::{
     env::Env,
     library::*,
     traits::{IntoString, MaybeRefAs},
+    update_cfgs,
 };
 
 pub struct Fields {
@@ -164,10 +165,13 @@ fn field_ffi_type(env: &Env, field: &Field) -> Result {
 }
 
 fn get_gobject_cfg_condition(env: &Env, name: &str) -> Option<String> {
-    let full_name = format!("{}.{}", env.namespaces.main().name, name);
-    if let Some(obj) = env.config.objects.get(&full_name) {
-        obj.cfg_condition.clone()
-    } else {
-        None
-    }
+    let ns = env.namespaces.main();
+    let full_name = format!("{}.{}", ns.name, name);
+    env.config
+        .objects
+        .get(&full_name)
+        .and_then(|obj| {
+            update_cfgs::get_object_cfg_condition(name, &obj.cfg_condition, &ns.identifier_prefixes)
+        })
+        .or_else(|| update_cfgs::get_object_cfg_condition(name, &None, &ns.identifier_prefixes))
 }

--- a/src/codegen/sys/lib_.rs
+++ b/src/codegen/sys/lib_.rs
@@ -14,6 +14,7 @@ use crate::{
     library::*,
     nameutil::*,
     traits::*,
+    update_cfgs,
 };
 
 pub fn generate(env: &Env) {
@@ -164,7 +165,8 @@ fn generate_aliases(w: &mut dyn Write, env: &Env, items: &[&Alias]) -> Result<()
         writeln!(w, "// Aliases")?;
     }
     for item in items {
-        let full_name = format!("{}.{}", env.namespaces.main().name, item.name);
+        let ns = env.namespaces.main();
+        let full_name = format!("{}.{}", ns.name, item.name);
         if !env.type_status_sys(&full_name).need_generate() {
             continue;
         }
@@ -176,8 +178,17 @@ fn generate_aliases(w: &mut dyn Write, env: &Env, items: &[&Alias]) -> Result<()
             .config
             .objects
             .get(&full_name)
-            .and_then(|obj| obj.cfg_condition.as_ref());
-        cfg_condition(w, cfg_condition_, false, 0)?;
+            .and_then(|obj| {
+                update_cfgs::get_object_cfg_condition(
+                    &item.name,
+                    &obj.cfg_condition,
+                    &ns.identifier_prefixes,
+                )
+            })
+            .or_else(|| {
+                update_cfgs::get_object_cfg_condition(&item.name, &None, &ns.identifier_prefixes)
+            });
+        cfg_condition(w, cfg_condition_.as_ref(), false, 0)?;
         writeln!(w, "{}pub type {} = {};", comment, item.c_identifier, c_type)?;
     }
     if !items.is_empty() {
@@ -224,13 +235,15 @@ fn generate_bitfields(w: &mut dyn Write, env: &Env, items: &[&Bitfield]) -> Resu
 
 fn generate_constant_cfg_configure(
     w: &mut dyn Write,
+    constant: &Constant,
     configured_constants: &[&constants::Constant],
     commented: bool,
 ) -> Result<()> {
     let cfg_condition_ = configured_constants
         .iter()
-        .find_map(|f| f.cfg_condition.as_ref());
-    cfg_condition(w, cfg_condition_, commented, 1)?;
+        .find_map(|f| update_cfgs::get_constant_cfg_condition(&constant.name, &f.cfg_condition))
+        .or_else(|| update_cfgs::get_constant_cfg_condition(&constant.name, &None));
+    cfg_condition(w, cfg_condition_.as_ref(), commented, 1)?;
     Ok(())
 }
 
@@ -270,7 +283,12 @@ fn generate_constants(w: &mut dyn Write, env: &Env, constants: &[Constant]) -> R
 
         if let Some(obj) = config {
             let configured_constants = obj.constants.matched(&full_name);
-            generate_constant_cfg_configure(w, &configured_constants, !comment.is_empty())?;
+            generate_constant_cfg_configure(
+                w,
+                constant,
+                &configured_constants,
+                !comment.is_empty(),
+            )?;
         }
 
         writeln!(
@@ -291,7 +309,8 @@ fn generate_enums(w: &mut dyn Write, env: &Env, items: &[&Enumeration]) -> Resul
         writeln!(w, "// Enums")?;
     }
     for item in items {
-        let full_name = format!("{}.{}", env.namespaces.main().name, item.name);
+        let ns = env.namespaces.main();
+        let full_name = format!("{}.{}", ns.name, item.name);
         let config = env.config.objects.get(&full_name);
         if let Some(false) = config.map(|c| c.status.need_generate()) {
             continue;
@@ -300,8 +319,17 @@ fn generate_enums(w: &mut dyn Write, env: &Env, items: &[&Enumeration]) -> Resul
             .config
             .objects
             .get(&full_name)
-            .and_then(|obj| obj.cfg_condition.as_ref());
-        cfg_condition(w, cfg_condition_, false, 0)?;
+            .and_then(|obj| {
+                update_cfgs::get_object_cfg_condition(
+                    &item.name,
+                    &obj.cfg_condition,
+                    &ns.identifier_prefixes,
+                )
+            })
+            .or_else(|| {
+                update_cfgs::get_object_cfg_condition(&item.name, &None, &ns.identifier_prefixes)
+            });
+        cfg_condition(w, cfg_condition_.as_ref(), false, 0)?;
         writeln!(w, "pub type {} = c_int;", item.c_type)?;
         for member in &item.members {
             let member_config = config
@@ -317,7 +345,7 @@ fn generate_enums(w: &mut dyn Write, env: &Env, items: &[&Enumeration]) -> Resul
                 continue;
             }
 
-            cfg_condition(w, cfg_condition_, false, 0)?;
+            cfg_condition(w, cfg_condition_.as_ref(), false, 0)?;
             version_condition(w, env, None, version, false, 0)?;
             writeln!(
                 w,
@@ -404,7 +432,8 @@ fn generate_interfaces_structs(
         writeln!(w, "// Interfaces")?;
     }
     for interface in interfaces {
-        let full_name = format!("{}.{}", env.namespaces.main().name, interface.name);
+        let ns = env.namespaces.main();
+        let full_name = format!("{}.{}", ns.name, interface.name);
         if !env.type_status_sys(&full_name).need_generate() {
             continue;
         }
@@ -412,10 +441,23 @@ fn generate_interfaces_structs(
             .config
             .objects
             .get(&full_name)
-            .and_then(|obj| obj.cfg_condition.as_ref());
-        cfg_condition(w, cfg_condition_, false, 0)?;
+            .and_then(|obj| {
+                update_cfgs::get_object_cfg_condition(
+                    &interface.name,
+                    &obj.cfg_condition,
+                    &ns.identifier_prefixes,
+                )
+            })
+            .or_else(|| {
+                update_cfgs::get_object_cfg_condition(
+                    &interface.name,
+                    &None,
+                    &ns.identifier_prefixes,
+                )
+            });
+        cfg_condition(w, cfg_condition_.as_ref(), false, 0)?;
         generate_opaque_type(w, &interface.c_type)?;
-        cfg_condition(w, cfg_condition_, false, 0)?;
+        cfg_condition(w, cfg_condition_.as_ref(), false, 0)?;
         generate_debug_impl(
             w,
             &interface.c_type,
@@ -490,15 +532,25 @@ impl ::std::fmt::Debug for GHookList {
 }
 
 fn generate_disguised(w: &mut dyn Write, env: &Env, record: &Record) -> Result<()> {
-    let full_name = format!("{}.{}", env.namespaces.main().name, record.name);
+    let ns = env.namespaces.main();
+    let full_name = format!("{}.{}", ns.name, record.name);
     let cfg_condition_ = env
         .config
         .objects
         .get(&full_name)
-        .and_then(|obj| obj.cfg_condition.as_ref());
-    cfg_condition(w, cfg_condition_, false, 0)?;
+        .and_then(|obj| {
+            update_cfgs::get_object_cfg_condition(
+                &record.name,
+                &obj.cfg_condition,
+                &ns.identifier_prefixes,
+            )
+        })
+        .or_else(|| {
+            update_cfgs::get_object_cfg_condition(&record.name, &None, &ns.identifier_prefixes)
+        });
+    cfg_condition(w, cfg_condition_.as_ref(), false, 0)?;
     generate_opaque_type(w, &format!("_{}", record.c_type))?;
-    cfg_condition(w, cfg_condition_, false, 0)?;
+    cfg_condition(w, cfg_condition_.as_ref(), false, 0)?;
     if record.pointer {
         writeln!(w, "pub type {name} = *mut _{name};", name = record.c_type)?;
     } else {

--- a/src/config/functions.rs
+++ b/src/config/functions.rs
@@ -344,10 +344,7 @@ impl Parse for Function {
             .lookup("version")
             .and_then(Value::as_str)
             .and_then(|s| s.parse().ok());
-        let cfg_condition = toml
-            .lookup("cfg_condition")
-            .and_then(Value::as_str)
-            .map(ToOwned::to_owned);
+        let cfg_condition = super::get_cfg_condition(toml, object_name);
         let parameters = Parameters::parse(toml.lookup("parameter"), object_name);
         let ret = Return::parse(toml.lookup("return"), object_name);
         let doc_hidden = toml

--- a/src/config/gobjects.rs
+++ b/src/config/gobjects.rs
@@ -330,10 +330,7 @@ fn parse_object(
         .lookup("version")
         .and_then(Value::as_str)
         .and_then(|s| s.parse().ok());
-    let cfg_condition = toml_object
-        .lookup("cfg_condition")
-        .and_then(Value::as_str)
-        .map(ToOwned::to_owned);
+    let cfg_condition = super::get_object_cfg_condition(toml_object, &name);
     let generate_trait = toml_object.lookup("trait").and_then(Value::as_bool);
     let final_type = toml_object
         .lookup("final_type")

--- a/src/config/members.rs
+++ b/src/config/members.rs
@@ -52,10 +52,7 @@ impl Parse for Member {
             .lookup("deprecated_version")
             .and_then(Value::as_str)
             .and_then(|s| s.parse().ok());
-        let cfg_condition = toml
-            .lookup("cfg_condition")
-            .and_then(Value::as_str)
-            .map(ToOwned::to_owned);
+        let cfg_condition = super::get_cfg_condition(toml, object_name);
 
         let status = {
             if toml

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -27,3 +27,62 @@ pub use self::{
     string_type::StringType,
     work_mode::WorkMode,
 };
+
+use self::error::TomlHelper;
+use log::warn;
+
+fn get_cfg_condition(toml: &toml::Value, object_name: &str) -> Option<String> {
+    let cfg_condition = toml.lookup("cfg_condition").and_then(toml::Value::as_str);
+    let Some(sub_object_name) = object_name.split('.').nth(1) else {
+        return cfg_condition.map(ToString::to_string);
+    };
+    if sub_object_name.starts_with("win32_") {
+        match cfg_condition {
+            Some("windows") => {
+                warn!("\"object {object_name}\": No need to set `cfg_condition` to `windows` if name starts with `win32_`");
+                Some("window".to_string())
+            }
+            None => Some("window".to_string()),
+            Some(cfg) => Some(format!("{cfg},windows")),
+        }
+    } else if sub_object_name.starts_with("unix_") {
+        match cfg_condition {
+            Some("unix") => {
+                warn!("\"object {object_name}\": No need to set `cfg_condition` to `unix` if name starts with `unix_`");
+                Some("unix".to_string())
+            }
+            None => Some("unix".to_string()),
+            Some(cfg) => Some(format!("{cfg},unix")),
+        }
+    } else {
+        cfg_condition.map(ToString::to_string)
+    }
+}
+
+fn get_object_cfg_condition(toml: &toml::Value, object_name: &str) -> Option<String> {
+    let cfg_condition = toml.lookup("cfg_condition").and_then(toml::Value::as_str);
+    let Some(sub_object_name) = object_name.split('.').nth(1) else {
+        return cfg_condition.map(ToString::to_string);
+    };
+    if sub_object_name.starts_with("Win32") || sub_object_name.starts_with("GWin32") {
+        match cfg_condition {
+            Some("windows") => {
+                warn!("\"object {object_name}\": No need to set `cfg_condition` to `windows` if object name starts with `Win32`");
+                Some("windows".to_string())
+            }
+            None => Some("windows".to_string()),
+            Some(cfg) => Some(format!("{cfg},windows")),
+        }
+    } else if sub_object_name.starts_with("Unix") || sub_object_name.starts_with("GUnix") {
+        match cfg_condition {
+            Some("unix") => {
+                warn!("\"object {object_name}\": No need to set `cfg_condition` to `unix` if object name starts with `Unix`");
+                Some("unix".to_string())
+            }
+            None => Some("unix".to_string()),
+            Some(cfg) => Some(format!("{cfg},unix")),
+        }
+    } else {
+        cfg_condition.map(ToString::to_string)
+    }
+}

--- a/src/config/virtual_methods.rs
+++ b/src/config/virtual_methods.rs
@@ -80,10 +80,7 @@ impl Parse for VirtualMethod {
             .lookup("version")
             .and_then(Value::as_str)
             .and_then(|s| s.parse().ok());
-        let cfg_condition = toml
-            .lookup("cfg_condition")
-            .and_then(Value::as_str)
-            .map(ToOwned::to_owned);
+        let cfg_condition = super::get_cfg_condition(toml, object_name);
         let parameters = Parameters::parse(toml.lookup("parameter"), object_name);
         let ret = Return::parse(toml.lookup("return"), object_name);
         let doc_hidden = toml

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@ mod library_preprocessing;
 mod nameutil;
 mod parser;
 mod traits;
+pub(crate) mod update_cfgs;
 pub mod update_version;
 mod version;
 mod visitors;

--- a/src/update_cfgs.rs
+++ b/src/update_cfgs.rs
@@ -1,0 +1,101 @@
+use log::warn;
+
+pub fn get_cfg_condition(
+    object_name: &str,
+    cfg_condition: &Option<String>,
+    identifier_prefixes: &[String],
+) -> Option<String> {
+    let sub_object_name = identifier_prefixes
+        .iter()
+        .filter_map(|prefix| object_name.strip_prefix(prefix))
+        .find_map(|name| name.strip_prefix('_'))
+        .unwrap_or(object_name);
+
+    if sub_object_name.starts_with("win32_") {
+        match cfg_condition.as_deref() {
+            Some("windows") => {
+                warn!("\"object {object_name}\": No need to set `cfg_condition` to `windows` if name starts with `win32_`");
+                Some("windows".to_string())
+            }
+            None => Some("windows".to_string()),
+            Some(cfg) => Some(format!("{cfg},windows")),
+        }
+    } else if sub_object_name.starts_with("unix_") {
+        match cfg_condition.as_deref() {
+            Some("unix") => {
+                warn!("\"object {object_name}\": No need to set `cfg_condition` to `unix` if name starts with `unix_`");
+                Some("unix".to_string())
+            }
+            None => Some("unix".to_string()),
+            Some(cfg) => Some(format!("{cfg},unix")),
+        }
+    } else {
+        cfg_condition.clone()
+    }
+}
+
+pub fn get_object_cfg_condition(
+    object_name: &str,
+    cfg_condition: &Option<String>,
+    identifier_prefixes: &[String],
+) -> Option<String> {
+    let sub_object_name = identifier_prefixes
+        .iter()
+        .filter_map(|prefix| object_name.strip_prefix(prefix))
+        .find(|name| {
+            name.chars()
+                .next()
+                .map(|c| c.is_uppercase())
+                .unwrap_or(false)
+        })
+        .unwrap_or(object_name);
+
+    if sub_object_name.starts_with("Win32") {
+        match cfg_condition.as_deref() {
+            Some("windows") => {
+                warn!("\"object {object_name}\": No need to set `cfg_condition` to `windows` if object name starts with `Win32`");
+                Some("windows".to_string())
+            }
+            None => Some("windows".to_string()),
+            Some(cfg) => Some(format!("{cfg},windows")),
+        }
+    } else if sub_object_name.starts_with("Unix") || sub_object_name.starts_with("UNIX") {
+        match cfg_condition.as_deref() {
+            Some("unix") => {
+                warn!("\"object {object_name}\": No need to set `cfg_condition` to `unix` if object name starts with `Unix`");
+                Some("unix".to_string())
+            }
+            None => Some("unix".to_string()),
+            Some(cfg) => Some(format!("{cfg},unix")),
+        }
+    } else {
+        cfg_condition.clone()
+    }
+}
+
+pub fn get_constant_cfg_condition(
+    const_name: &str,
+    cfg_condition: &Option<String>,
+) -> Option<String> {
+    if const_name.starts_with("WIN32_") {
+        match cfg_condition.as_deref() {
+            Some("windows") => {
+                warn!("\"object {const_name}\": No need to set `cfg_condition` to `windows` if name starts with `WIN32_`");
+                Some("windows".to_string())
+            }
+            None => Some("windows".to_string()),
+            Some(cfg) => Some(format!("{cfg},windows")),
+        }
+    } else if const_name.starts_with("UNIX_") {
+        match cfg_condition.as_deref() {
+            Some("unix") => {
+                warn!("\"object {const_name}\": No need to set `cfg_condition` to `unix` if name starts with `UNIX_`");
+                Some("unix".to_string())
+            }
+            None => Some("unix".to_string()),
+            Some(cfg) => Some(format!("{cfg},unix")),
+        }
+    } else {
+        cfg_condition.clone()
+    }
+}


### PR DESCRIPTION
You can take a look at the result [here](https://github.com/gtk-rs/gtk-rs-core/compare/master...GuillaumeGomez:gtk-rs-core:regen-with-cfg?expand=1) (I didn't remove all unneeded `cfg_condition` yet).