### PR TITLE
codegen/sys: Don't expect the crates are renamed

### DIFF
--- a/src/codegen/sys/cargo_toml.rs
+++ b/src/codegen/sys/cargo_toml.rs
@@ -48,7 +48,6 @@ fn fill_empty(root: &mut Table, env: &Env, crate_name: &str) {
 
     let deps = upsert_table(root, "dependencies");
     for ext_lib in &env.config.external_libraries {
-        let dep = upsert_table(deps, &ext_lib.crate_name);
         let ext_package = if ext_lib.crate_name == "cairo" {
             format!("{}-sys-rs", ext_lib.crate_name)
         } else if ext_lib.crate_name == "gdk_pixbuf" {
@@ -92,7 +91,7 @@ fn fill_empty(root: &mut Table, env: &Env, crate_name: &str) {
             | "gstreamer-allocators-sys" => "https://gitlab.freedesktop.org/gstreamer/gstreamer-rs",
             &_ => "ADD GIT REPOSITORY URL HERE",
         };
-        set_string(dep, "package", ext_package);
+        let dep = upsert_table(deps, ext_package);
         set_string(dep, "git", repo_url);
     }
 }

--- a/src/codegen/sys/lib_.rs
+++ b/src/codegen/sys/lib_.rs
@@ -41,6 +41,7 @@ fn generate_lib(w: &mut dyn Write, env: &Env) -> Result<()> {
     general::start_comments(w, &env.config)?;
     statics::begin(w)?;
 
+    generate_extern_crates(w, env)?;
     include_custom_modules(w, env)?;
     statics::after_extern_crates(w)?;
 
@@ -99,6 +100,21 @@ fn generate_lib(w: &mut dyn Write, env: &Env) -> Result<()> {
         functions::generate_other_funcs(w, env, &ns.functions)?;
 
         writeln!(w, "\n}}")?;
+    }
+
+    Ok(())
+}
+
+fn generate_extern_crates(w: &mut dyn Write, env: &Env) -> Result<()> {
+    for library in &env.config.external_libraries {
+        w.write_all(
+            format!(
+                "use {}_sys as {};\n",
+                library.crate_name.replace('-', "_"),
+                crate_name(&library.namespace)
+            )
+            .as_bytes(),
+        )?;
     }
 
     Ok(())


### PR DESCRIPTION
In the past, this seemed like a decent idea but the switch to using cargo workspace proves it wasn't as we now have conflicting crates with the same names