### PR TITLE
codegen: Fix nullable array in function params

### DIFF
--- a/src/analysis/function_parameters.rs
+++ b/src/analysis/function_parameters.rs
@@ -107,6 +107,7 @@ pub enum TransformationType {
         array_name: String,
         array_length_name: String,
         array_length_type: String,
+        nullable: library::Nullable,
     },
     IntoRaw(String),
     ToSome(String),
@@ -176,7 +177,13 @@ impl Parameters {
         let transformation = Transformation {
             ind_c,
             ind_rust: None,
-            transformation_type: get_length_type(env, "", &c_par.name, c_par.typ),
+            transformation_type: get_length_type(
+                env,
+                "",
+                &c_par.name,
+                c_par.typ,
+                library::Nullable(false),
+            ),
         };
         self.transformations.push(transformation);
     }
@@ -301,7 +308,13 @@ pub fn analyze(
             let transformation = Transformation {
                 ind_c,
                 ind_rust: None,
-                transformation_type: get_length_type(env, &array_name, &par.name, typ),
+                transformation_type: get_length_type(
+                    env,
+                    &array_name,
+                    &par.name,
+                    typ,
+                    array_par.nullable,
+                ),
             };
             parameters.transformations.push(transformation);
         }
@@ -448,12 +461,14 @@ fn get_length_type(
     array_name: &str,
     length_name: &str,
     length_typ: TypeId,
+    nullable: library::Nullable,
 ) -> TransformationType {
     let array_length_type = RustType::try_new(env, length_typ).into_string();
     TransformationType::Length {
         array_name: array_name.to_string(),
         array_length_name: length_name.to_string(),
         array_length_type,
+        nullable,
     }
 }
 

--- a/src/analysis/rust_type.rs
+++ b/src/analysis/rust_type.rs
@@ -401,7 +401,7 @@ impl<'env> RustTypeBuilder<'env> {
                     };
 
                     if let Some(s) = array_type {
-                        skip_option = true;
+                        skip_option = self.direction == ParameterDirection::Return;
                         if self.ref_mode.is_ref() {
                             Ok(format!("[{s}]").into())
                         } else {

--- a/src/codegen/function_body_chunk.rs
+++ b/src/codegen/function_body_chunk.rs
@@ -944,11 +944,19 @@ impl Builder {
             if let TransformationType::Length {
                 ref array_name,
                 ref array_length_name,
+                nullable,
                 ..
             } = trans.transformation_type
             {
                 if let In = self.parameters[trans.ind_c] {
-                    let value = Chunk::Custom(format!("{array_name}.len() as _"));
+                    let value = if !*nullable {
+                        Chunk::Custom(format!("{}.len() as _", array_name))
+                    } else {
+                        Chunk::Custom(format!(
+                            "{}.map(|arr| arr.len()).unwrap_or(0) as _",
+                            array_name
+                        ))
+                    };
                     chunks.push(Chunk::Let {
                         name: array_length_name.clone(),
                         is_mut: false,


### PR DESCRIPTION
Co-authored-by: Andy Russell <arussell123@gmail.com>
Fixes #1133

Take over of https://github.com/gtk-rs/gir/pull/1136 except it only generates Option<T> if it is not a return type. To avoid generating `Option<Vec<T>>`