### PR TITLE
codegen: Stop renaming ffi crate

### DIFF
--- a/src/analysis/enums.rs
+++ b/src/analysis/enums.rs
@@ -39,6 +39,7 @@ pub fn new(env: &Env, obj: &GObject, imports: &mut Imports) -> Option<Info> {
     if obj.status.need_generate() {
         // Mark the type as available within the enum namespace:
         imports.add_defined(&format!("crate::{name}"));
+        imports.add("crate::ffi");
 
         let imports = &mut imports.with_defaults(enumeration.version, &None);
         imports.add("glib::translate::*");

--- a/src/analysis/flags.rs
+++ b/src/analysis/flags.rs
@@ -39,6 +39,7 @@ pub fn new(env: &Env, obj: &GObject, imports: &mut Imports) -> Option<Info> {
     if obj.status.need_generate() {
         // Mark the type as available within the bitfield namespace:
         imports.add_defined(&format!("crate::{name}"));
+        imports.add("crate::ffi");
 
         let imports = &mut imports.with_defaults(flags.version, &None);
         imports.add("glib::translate::*");

--- a/src/analysis/functions.rs
+++ b/src/analysis/functions.rs
@@ -890,6 +890,8 @@ fn analyze_function(
             }
         }
 
+        imports.add("crate::ffi");
+
         imports.add_used_types(&used_types);
         if ret.base_tid.is_some() {
             imports.add("glib::prelude::*");

--- a/src/analysis/imports.rs
+++ b/src/analysis/imports.rs
@@ -125,9 +125,6 @@ impl Imports {
     /// It also extends the checks in case you are implementing "X". For
     /// example, you don't want to import "X" or "crate::X" in this case.
     fn common_checks(&self, name: &str) -> bool {
-        // The ffi namespace is used directly, including it is a programmer error.
-        assert_ne!(name, "crate::ffi");
-
         if (!name.contains("::") && name != "xlib") || self.defined.contains(name) {
             false
         } else if let Some(name) = name.strip_prefix("crate::") {

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -279,6 +279,7 @@ fn analyze_global_functions(env: &mut Env) {
 
     let mut imports = imports::Imports::new(&env.library);
     imports.add("glib::translate::*");
+    imports.add("crate:ffi");
 
     let functions = functions::analyze(
         env,

--- a/src/analysis/object.rs
+++ b/src/analysis/object.rs
@@ -290,6 +290,7 @@ pub fn class(env: &Env, obj: &GObject, deps: &[library::TypeId]) -> Option<Info>
         && !is_fundamental
         && (has_signals || has_methods || !properties.is_empty() || !child_properties.is_empty());
 
+    imports.add("crate::ffi");
     if is_fundamental {
         imports.add("glib::translate::*");
         imports.add("glib::prelude::*");
@@ -375,6 +376,7 @@ pub fn interface(env: &Env, obj: &GObject, deps: &[library::TypeId]) -> Option<I
 
     let mut imports = Imports::with_defined(&env.library, &name);
     imports.add("glib::prelude::*");
+    imports.add("crate::ffi");
 
     let supertypes = supertypes::analyze(env, iface_tid, version, &mut imports, false);
     let supertypes_properties = supertypes

--- a/src/analysis/record.rs
+++ b/src/analysis/record.rs
@@ -88,6 +88,7 @@ pub fn new(env: &Env, obj: &GObject) -> Option<Info> {
     let boxed_inline = obj.boxed_inline;
 
     let mut imports = Imports::with_defined(&env.library, &name);
+    imports.add("crate::ffi");
 
     let mut functions = functions::analyze(
         env,

--- a/src/codegen/constants.rs
+++ b/src/codegen/constants.rs
@@ -19,6 +19,7 @@ pub fn generate(env: &Env, root_path: &Path, mod_rs: &mut Vec<String>) {
 
     let sys_crate_name = env.main_sys_crate_name();
     imports.add("glib::GStr");
+    imports.add("crate::ffi");
 
     file_saver::save_to_file(path, env.config.make_backup, |w| {
         general::start_comments(w, &env.config)?;

--- a/src/codegen/enums.rs
+++ b/src/codegen/enums.rs
@@ -89,7 +89,7 @@ fn generate_enum(
 
     let mut members: Vec<Member<'_>> = Vec::new();
     let mut vals: HashSet<String> = HashSet::new();
-    let sys_crate_name = env.main_sys_crate_name();
+    let sys_crate_name = env.sys_crate_import(analysis.type_id);
 
     for member in &enum_.members {
         let member_config = config.members.matched(&member.name);

--- a/src/codegen/flags.rs
+++ b/src/codegen/flags.rs
@@ -75,7 +75,7 @@ fn generate_flags(
     config: &GObject,
     analysis: &Info,
 ) -> Result<()> {
-    let sys_crate_name = env.main_sys_crate_name();
+    let sys_crate_name = env.sys_crate_import(analysis.type_id);
     cfg_condition_no_doc(w, config.cfg_condition.as_ref(), false, 0)?;
     version_condition_no_doc(w, env, None, flags.version, false, 0)?;
     writeln!(w, "bitflags! {{")?;

--- a/src/codegen/general.rs
+++ b/src/codegen/general.rs
@@ -180,8 +180,9 @@ pub fn define_fundamental_type(
     unref_func: Option<&str>,
     parents: &[StatusedTypeId],
     visibility: Visibility,
+    type_id: TypeId,
 ) -> Result<()> {
-    let sys_crate_name = env.main_sys_crate_name();
+    let sys_crate_name = env.sys_crate_import(type_id);
     writeln!(w, "{} {{", use_glib_type(env, "wrapper!"))?;
     doc_alias(w, glib_name, "", 1)?;
     external_doc_link(
@@ -262,8 +263,9 @@ pub fn define_object_type(
     is_interface: bool,
     parents: &[StatusedTypeId],
     visibility: Visibility,
+    type_id: TypeId,
 ) -> Result<()> {
-    let sys_crate_name = env.main_sys_crate_name();
+    let sys_crate_name = env.sys_crate_import(type_id);
     let class_name = {
         if let Some(s) = glib_class_name {
             format!(", {sys_crate_name}::{s}")
@@ -375,8 +377,9 @@ fn define_boxed_type_internal(
     get_type_fn: Option<&str>,
     derive: &[Derive],
     visibility: Visibility,
+    type_id: TypeId,
 ) -> Result<()> {
-    let sys_crate_name = env.main_sys_crate_name();
+    let sys_crate_name = env.sys_crate_import(type_id);
     writeln!(w, "{} {{", use_glib_type(env, "wrapper!"))?;
 
     derives(w, derive, 1)?;
@@ -440,6 +443,7 @@ pub fn define_boxed_type(
     get_type_fn: Option<(String, Option<Version>)>,
     derive: &[Derive],
     visibility: Visibility,
+    type_id: TypeId,
 ) -> Result<()> {
     writeln!(w)?;
 
@@ -460,6 +464,7 @@ pub fn define_boxed_type(
                 Some(get_type_fn),
                 derive,
                 visibility,
+                type_id,
             )?;
 
             writeln!(w)?;
@@ -478,6 +483,7 @@ pub fn define_boxed_type(
                 None,
                 derive,
                 visibility,
+                type_id,
             )?;
         } else {
             define_boxed_type_internal(
@@ -494,6 +500,7 @@ pub fn define_boxed_type(
                 Some(get_type_fn),
                 derive,
                 visibility,
+                type_id,
             )?;
         }
     } else {
@@ -511,6 +518,7 @@ pub fn define_boxed_type(
             None,
             derive,
             visibility,
+            type_id,
         )?;
     }
 
@@ -529,8 +537,9 @@ pub fn define_auto_boxed_type(
     get_type_fn: &str,
     derive: &[Derive],
     visibility: Visibility,
+    type_id: TypeId,
 ) -> Result<()> {
-    let sys_crate_name = env.main_sys_crate_name();
+    let sys_crate_name = env.sys_crate_import(type_id);
     writeln!(w)?;
     writeln!(w, "{} {{", use_glib_type(env, "wrapper!"))?;
     derives(w, derive, 1)?;
@@ -593,8 +602,9 @@ fn define_shared_type_internal(
     get_type_fn: Option<&str>,
     derive: &[Derive],
     visibility: Visibility,
+    type_id: TypeId,
 ) -> Result<()> {
-    let sys_crate_name = env.main_sys_crate_name();
+    let sys_crate_name = env.sys_crate_import(type_id);
     writeln!(w, "{} {{", use_glib_type(env, "wrapper!"))?;
     derives(w, derive, 1)?;
     writeln!(
@@ -624,6 +634,7 @@ pub fn define_shared_type(
     get_type_fn: Option<(String, Option<Version>)>,
     derive: &[Derive],
     visibility: Visibility,
+    type_id: TypeId,
 ) -> Result<()> {
     writeln!(w)?;
 
@@ -640,12 +651,13 @@ pub fn define_shared_type(
                 Some(get_type_fn),
                 derive,
                 visibility,
+                type_id,
             )?;
 
             writeln!(w)?;
             not_version_condition_no_docsrs(w, env, None, get_type_version, false, 0)?;
             define_shared_type_internal(
-                w, env, type_name, glib_name, ref_fn, unref_fn, None, derive, visibility,
+                w, env, type_name, glib_name, ref_fn, unref_fn, None, derive, visibility, type_id,
             )?;
         } else {
             define_shared_type_internal(
@@ -658,11 +670,12 @@ pub fn define_shared_type(
                 Some(get_type_fn),
                 derive,
                 visibility,
+                type_id,
             )?;
         }
     } else {
         define_shared_type_internal(
-            w, env, type_name, glib_name, ref_fn, unref_fn, None, derive, visibility,
+            w, env, type_name, glib_name, ref_fn, unref_fn, None, derive, visibility, type_id,
         )?;
     }
 

--- a/src/codegen/object.rs
+++ b/src/codegen/object.rs
@@ -91,6 +91,7 @@ pub fn generate(w: &mut dyn Write, env: &Env, analysis: &analysis::object::Info)
                 analysis.unref_fn.as_deref(),
                 &analysis.supertypes,
                 analysis.visibility,
+                analysis.type_id,
             )?;
         } else {
             general::define_object_type(
@@ -103,6 +104,7 @@ pub fn generate(w: &mut dyn Write, env: &Env, analysis: &analysis::object::Info)
                 analysis.is_interface,
                 &analysis.supertypes,
                 analysis.visibility,
+                analysis.type_id,
             )?;
         }
     } else {
@@ -145,6 +147,7 @@ pub fn generate(w: &mut dyn Write, env: &Env, analysis: &analysis::object::Info)
                     analysis.is_interface,
                     &supertypes,
                     analysis.visibility,
+                    analysis.type_id,
                 )?;
 
                 for t in stypes {
@@ -175,6 +178,7 @@ pub fn generate(w: &mut dyn Write, env: &Env, analysis: &analysis::object::Info)
             analysis.is_interface,
             &supertypes,
             analysis.visibility,
+            analysis.type_id,
         )?;
     }
 

--- a/src/codegen/record.rs
+++ b/src/codegen/record.rs
@@ -28,6 +28,7 @@ pub fn generate(w: &mut dyn Write, env: &Env, analysis: &analysis::record::Info)
                 glib_get_type,
                 &analysis.derives,
                 analysis.visibility,
+                analysis.type_id,
             )?;
         } else {
             panic!(
@@ -55,6 +56,7 @@ pub fn generate(w: &mut dyn Write, env: &Env, analysis: &analysis::record::Info)
             }),
             &analysis.derives,
             analysis.visibility,
+            analysis.type_id,
         )?;
     } else if let (Some(copy_fn), Some(free_fn)) = (
         analysis.specials.traits().get(&Type::Copy),
@@ -80,6 +82,7 @@ pub fn generate(w: &mut dyn Write, env: &Env, analysis: &analysis::record::Info)
             }),
             &analysis.derives,
             analysis.visibility,
+            analysis.type_id,
         )?;
     } else {
         panic!(


### PR DESCRIPTION
As we would like to define those crates in the main workspace file to simplify the release process


Needs a gtk4-rs/gtk-rs-core regen first, to ensure everything is still working as expected.