### PR TITLE
codegen/function: body future handles ownership of slice argument

### DIFF
--- a/src/codegen/function.rs
+++ b/src/codegen/function.rs
@@ -438,9 +438,12 @@ pub fn body_chunk_futures(
         let c_par = &analysis.parameters.c_parameters[par.ind_c];
 
         let type_ = env.type_(par.typ);
-        let is_str = matches!(*type_, library::Type::Basic(library::Basic::Utf8));
+        let is_str = matches!(type_, library::Type::Basic(library::Basic::Utf8));
+        let is_slice = matches!(type_, library::Type::CArray(_));
 
-        if *c_par.nullable {
+        if is_slice {
+            writeln!(body, "let {} = {}.to_vec();", par.name, par.name)?;
+        } else if *c_par.nullable {
             writeln!(
                 body,
                 "let {} = {}.map(ToOwned::to_owned);",


### PR DESCRIPTION
Currently, the future body generated is something like:

```rust
pub fn probe_endpoints_future(
    my_slice: &[MyObject],
) -> Pin<
    Box_<dyn std::future::Future<Output = Result<_, glib::Error>> + 'static>,
> {
    skip_assert_initialized!();
   
   let my_slice = my_slice.map(ToOwned::to_owned);   // if my_slice is declared as nullable
             // or
   let my_slice = my_slice.clone();                  // if my_slice is not declared as nullable
   


    Box_::pin(gio::GioFuture::new(&(), move |_obj, cancellable, send| {
      // ...
}
```

both approaches fail to compile as:
* `.map` does not exist for `slice` type (it is not an `Option`)
* `.clone()` does not really give ownership of the data slice, as `clone` only copies the wide-pointer.
   - This is an issue as the future closure need to move something which needs '`static` lifetime (and that's the reason why the code in the generator performs a `clone` or `to_owned` in the first place).


This PR aims to handle the case of slice argument

