### PR TITLE
Allow `dead_code` lint for opaque structs

### DIFF
--- a/src/codegen/sys/lib_.rs
+++ b/src/codegen/sys/lib_.rs
@@ -406,6 +406,7 @@ fn generate_opaque_type(w: &mut dyn Write, name: &str) -> Result<()> {
     writeln!(
         w,
         r#"#[repr(C)]
+#[allow(dead_code)]
 pub struct {name} {{
     _data: [u8; 0],
     _marker: core::marker::PhantomData<(*mut u8, core::marker::PhantomPinned)>,


### PR DESCRIPTION
We're only using them by pointer and they're constructed from the C side, but clippy gives warnings:

```
warning: struct `GDoubleIEEE754` is never constructed
    --> glib/sys/src/lib.rs:1013:12
     |
1013 | pub struct GDoubleIEEE754 {
     |            ^^^^^^^^^^^^^^
     |
     = note: `#[warn(dead_code)]` on by default
```