### PR TITLE
Remove link attribute generation

### DIFF
--- a/src/codegen/sys/cargo_toml.rs
+++ b/src/codegen/sys/cargo_toml.rs
@@ -99,7 +99,9 @@ fn fill_empty(root: &mut Table, env: &Env, crate_name: &str) {
 fn fill_in(root: &mut Table, env: &Env) {
     {
         let package = upsert_table(root, "package");
-        set_string(package, "build", "build.rs");
+        package
+            .entry("build")
+            .or_insert_with(|| Value::String("build.rs".into()));
         // set_string(package, "version", "0.2.0");
     }
 

--- a/src/codegen/sys/lib_.rs
+++ b/src/codegen/sys/lib_.rs
@@ -25,18 +25,6 @@ pub fn generate(env: &Env) {
     save_to_file(&path, env.config.make_backup, |w| generate_lib(w, env));
 }
 
-fn write_link_attr(w: &mut dyn Write, shared_libs: &[String]) -> Result<()> {
-    for it in shared_libs {
-        writeln!(
-            w,
-            "#[link(name = \"{}\")]",
-            shared_lib_name_to_link_name(it)
-        )?;
-    }
-
-    Ok(())
-}
-
 fn generate_lib(w: &mut dyn Write, env: &Env) -> Result<()> {
     general::start_comments(w, &env.config)?;
     statics::begin(w)?;
@@ -89,7 +77,6 @@ fn generate_lib(w: &mut dyn Write, env: &Env) -> Result<()> {
     }
 
     if !env.namespaces.main().shared_libs.is_empty() {
-        write_link_attr(w, &env.namespaces.main().shared_libs)?;
         writeln!(w, "extern \"C\" {{")?;
         functions::generate_enums_funcs(w, env, &enums)?;
         functions::generate_bitfields_funcs(w, env, &bitfields)?;

--- a/src/nameutil.rs
+++ b/src/nameutil.rs
@@ -129,25 +129,6 @@ pub fn lib_name_to_toml(name: &str) -> String {
     name.to_string().replace(['-', '.'], "_")
 }
 
-pub fn shared_lib_name_to_link_name(name: &str) -> &str {
-    let mut s = name;
-
-    if s.starts_with("lib") {
-        s = &s[3..];
-    }
-
-    if let Some(offset) = s.rfind(".so") {
-        s = &s[..offset];
-    } else if let Some(offset) = s.rfind(".dll") {
-        s = &s[..offset];
-        if let Some(offset) = s.rfind('-') {
-            s = &s[..offset];
-        }
-    }
-
-    s
-}
-
 pub fn use_glib_type(env: &crate::env::Env, import: &str) -> String {
     format!(
         "{}::{}",
@@ -252,15 +233,5 @@ mod tests {
     #[test]
     fn lib_name_to_toml_works() {
         assert_eq!(lib_name_to_toml("gstreamer-1.0"), "gstreamer_1_0");
-    }
-
-    #[test]
-    fn shared_lib_name_to_link_name_works() {
-        assert_eq!(shared_lib_name_to_link_name("libgtk-4-1.dll"), "gtk-4");
-        assert_eq!(shared_lib_name_to_link_name("libatk-1.0.so.0"), "atk-1.0");
-        assert_eq!(
-            shared_lib_name_to_link_name("libgdk_pixbuf-2.0.so.0"),
-            "gdk_pixbuf-2.0"
-        );
     }
 }


### PR DESCRIPTION
Follow up to #1475. Motivated by work at `gtk-rs-core` and `gstreamer-rs` to override library linking.

At the moment a `#[link]` attribute is being generated for every `extern "C"` code block. This is not generally needed since `system-deps` already handles linking libraries, and it makes overriding dependencies difficult from higher up crates.

The only exception is one edge case when using Windows and static constants, but that is a limitation of the compiler. To handle this case, allow to use custom `build.rs` scripts by not overriding the package field.

All of the context for this change and all of the alternatives we considered are explained in gtk-rs/gtk-rs-core#1508.

## Changes

- Remove `#[link]` attribute generation.
- Allow custom build scripts. If the `package.build` key doesn't exist in `Cargo.toml`, generate it to be `build.rs`. Otherwise keep the existing value.

## Caveats

Something to consider is whether removing the `#[link]` generation could affect other crates. From an overview of other crates relying on `gir`, it seems that they are not linking static constants, just functions, which do not explicitly need dllimport. If this is expected to be a problem, maybe a command line flag like `--link` could be added to the generator script that allows customizing this behaviour.