### PR TITLE
[book] Add note to use ffi

### DIFF
--- a/book/src/tutorial/high_level_rust_api.md
+++ b/book/src/tutorial/high_level_rust_api.md
@@ -114,11 +114,13 @@ v1_52 = ["ffi/v1_52", "v1_50"]
 The lib.rs file will not be replaced when you run gir.
 All the code that gir will generate for us is going to be in src/auto.
 We need to include all `auto` files in our library.
+Also it needs to include sys create so auto files can use it.
 To do so, let's update the `src/lib.rs` file as follows:
 
 ```rust
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
+use ffi;
 pub use auto::*;
 mod auto;
 ```


### PR DESCRIPTION
Hi,
at first let me thanks you for this nice project that is quite useful. I use it to setup some first draft for using gobject API from rust for my project and when I follow instructions in book and failed to compile it. After debugging I found that `use ffi;` in lib.rs solve my issue with generated code and I think it should be part of book so others do not need to face it.
Thanks