### PR TITLE
Revert "codegen: seal Ext traits"

### DIFF
--- a/src/codegen/object.rs
+++ b/src/codegen/object.rs
@@ -471,12 +471,7 @@ fn generate_builder(w: &mut dyn Write, env: &Env, analysis: &analysis::object::I
 fn generate_trait(w: &mut dyn Write, env: &Env, analysis: &analysis::object::Info) -> Result<()> {
     write!(
         w,
-        "mod sealed {{
-    pub trait Sealed {{}}
-    impl<T: super::IsA<super::{1}>> Sealed for T {{}}
-}}
-
-pub trait {}: IsA<{}> + sealed::Sealed + 'static {{",
+        "pub trait {}: IsA<{}> + 'static {{",
         analysis.trait_name, analysis.name
     )?;
 


### PR DESCRIPTION
This reverts commit b0cfba0d135803f7895ba514dd4639d239b85176.

This is not actually necessary because IsA<T> is a requirement for the extension trait, and IsA is an unsafe trait and must only be implemented on types that are actually conforming.

----

CC @felinira as discussed.