### PR TITLE
codegen/object: Check for generate_safety_asserts when generating builders

### DIFF
--- a/src/analysis/safety_assertion_mode.rs
+++ b/src/analysis/safety_assertion_mode.rs
@@ -11,6 +11,17 @@ pub enum SafetyAssertionMode {
     InMainThread,
 }
 
+impl std::fmt::Display for SafetyAssertionMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SafetyAssertionMode::None => f.write_str(""),
+            SafetyAssertionMode::NotInitialized => f.write_str("assert_not_initialized!();"),
+            SafetyAssertionMode::Skip => f.write_str("skip_assert_initialized!();"),
+            SafetyAssertionMode::InMainThread => f.write_str("assert_initialized_main_thread!();"),
+        }
+    }
+}
+
 impl FromStr for SafetyAssertionMode {
     type Err = String;
     fn from_str(name: &str) -> Result<SafetyAssertionMode, String> {

--- a/src/codegen/function.rs
+++ b/src/codegen/function.rs
@@ -23,7 +23,7 @@ use crate::{
     library::{self, TypeId},
     nameutil::use_glib_type,
     version::Version,
-    writer::{primitives::tabs, safety_assertion_mode_to_str, ToCode},
+    writer::{primitives::tabs, ToCode},
 };
 
 // We follow the rules of the `return_self_not_must_use` clippy lint:
@@ -421,11 +421,7 @@ pub fn body_chunk_futures(
     writeln!(body)?;
 
     if !async_future.assertion.is_none() {
-        writeln!(
-            body,
-            "{}",
-            safety_assertion_mode_to_str(async_future.assertion)
-        )?;
+        writeln!(body, "{}", async_future.assertion)?;
     }
     let skip = usize::from(async_future.is_method);
 

--- a/src/codegen/object.rs
+++ b/src/codegen/object.rs
@@ -20,7 +20,6 @@ use crate::{
     library::{self, Nullable},
     nameutil,
     traits::IntoString,
-    writer::safety_assertion_mode_to_str,
 };
 
 pub fn generate(w: &mut dyn Write, env: &Env, analysis: &analysis::object::Info) -> Result<()> {
@@ -459,11 +458,7 @@ fn generate_builder(w: &mut dyn Write, env: &Env, analysis: &analysis::object::I
     )?;
 
     if env.config.generate_safety_asserts {
-        writeln!(
-            w,
-            "{}",
-            safety_assertion_mode_to_str(SafetyAssertionMode::InMainThread)
-        )?;
+        writeln!(w, "{}", SafetyAssertionMode::InMainThread)?;
     }
 
     // The split allows us to not have clippy::let_and_return lint disabled

--- a/src/codegen/object.rs
+++ b/src/codegen/object.rs
@@ -457,11 +457,14 @@ fn generate_builder(w: &mut dyn Write, env: &Env, analysis: &analysis::object::I
     pub fn build(self) -> {name} {{",
         name = analysis.name,
     )?;
-    writeln!(
-        w,
-        "{}",
-        safety_assertion_mode_to_str(SafetyAssertionMode::InMainThread)
-    )?;
+
+    if env.config.generate_safety_asserts {
+        writeln!(
+            w,
+            "{}",
+            safety_assertion_mode_to_str(SafetyAssertionMode::InMainThread)
+        )?;
+    }
 
     // The split allows us to not have clippy::let_and_return lint disabled
     if let Some(code) = analysis.builder_postprocess.as_ref() {

--- a/src/writer/mod.rs
+++ b/src/writer/mod.rs
@@ -4,13 +4,3 @@ pub mod to_code; // TODO:remove pub
 pub mod untabber;
 
 pub use self::{defines::TAB, to_code::ToCode};
-use crate::analysis::safety_assertion_mode::SafetyAssertionMode;
-
-pub fn safety_assertion_mode_to_str(s: SafetyAssertionMode) -> &'static str {
-    match s {
-        SafetyAssertionMode::None => "",
-        SafetyAssertionMode::NotInitialized => "assert_not_initialized!();",
-        SafetyAssertionMode::Skip => "skip_assert_initialized!();",
-        SafetyAssertionMode::InMainThread => "assert_initialized_main_thread!();",
-    }
-}

--- a/src/writer/to_code.rs
+++ b/src/writer/to_code.rs
@@ -1,6 +1,6 @@
 use std::fmt::Write;
 
-use super::{primitives::*, safety_assertion_mode_to_str};
+use super::primitives::*;
 use crate::{
     chunk::{Chunk, Param, TupleMode},
     codegen::{translate_from_glib::TranslateFromGlib, translate_to_glib::TranslateToGlib},
@@ -137,7 +137,7 @@ impl ToCode for Chunk {
                 lines.push(s);
                 lines
             }
-            AssertInit(x) => vec![safety_assertion_mode_to_str(x).to_owned()],
+            AssertInit(x) => vec![x.to_string()],
             Connect {
                 ref signal,
                 ref trampoline,


### PR DESCRIPTION
cc @sdroege 