### PR TITLE
generator.py: Restore pre-building `gir` with build/progress output

### DIFF
--- a/generator.py
+++ b/generator.py
@@ -7,7 +7,7 @@ import sys
 import asyncio
 
 DEFAULT_GIR_FILES_DIRECTORY = Path("./gir-files")
-DEFAULT_GIR_DIRECTORY = Path("./gir/")
+DEFAULT_GIR_DIRECTORY = Path("./gir/") # TODO: This is typically the directory _of this Python script_ (which external projects symlink to)
 
 
 def run_command(command, folder=None):
@@ -223,6 +223,9 @@ async def main():
 
     if conf.gir_path is None:
         update_submodule(DEFAULT_GIR_DIRECTORY, conf)
+        print("=> Building gir...")
+        run_command(["cargo", "build", "--release", "--manifest-path", DEFAULT_GIR_DIRECTORY / "Cargo.toml"])
+        print("<= Done!")
 
     print("=> Regenerating crates...")
     for path in conf.path:


### PR DESCRIPTION
In commit c6ba79ed ("generator.py: Use cargo run instead of guessing path") the `cargo build` command on the default (hardcoded) `"gir"` directory was replaced with a single `cargo run` for correctly finding the right executable.

This isn't an issue given that `cargo run` also builds the tool, and above all makes it easier / more correct to find the binary as the primary reason for that commit, but it does make us lose the build log as a progress indicator (thanks to `--quiet` and capturing `stderr`). In addition, it causes the first `` => Looking in path `xxx` `` item to take a very long time without aforementioned progres indication, making the user wonder what is going on.

By building `gir` again with a separate `cargo build` invocation before running, this issue is alleviated somewhat.
