### PR TITLE
Don't cast callbacks as `&Box<T>` but use `&T` instead to make clippy…

### DIFF
--- a/src/codegen/function_body_chunk.rs
+++ b/src/codegen/function_body_chunk.rs
@@ -183,6 +183,19 @@ impl Builder {
                                             .join(", ")
                                     ),
                                 ))
+                            } else if !calls
+                                .iter()
+                                .any(|c| c.scope.is_async() || c.scope.is_call())
+                            {
+                                let s = format!(
+                                    "&({})",
+                                    calls
+                                        .iter()
+                                        .map(|c| c.bound_name.to_string())
+                                        .collect::<Vec<_>>()
+                                        .join(", ")
+                                );
+                                Some((s.clone(), s))
                             } else {
                                 let s = format!(
                                     "Box_<({})>",
@@ -482,13 +495,7 @@ impl Builder {
                         },
                         func
                     ))),
-                    type_: Some(Box::new(Chunk::Custom(
-                        if !trampoline.scope.is_async() && !trampoline.scope.is_call() {
-                            format!("&{}", full_type.1)
-                        } else {
-                            full_type.1.clone()
-                        },
-                    ))),
+                    type_: Some(Box::new(Chunk::Custom(full_type.1.clone()))),
                 });
                 if trampoline.scope.is_async() {
                     body.push(Chunk::Custom(format!(


### PR DESCRIPTION
… happy

----

```
error: you seem to be trying to use `&Box<T>`. Consider using just `&T`
   --> gstreamer-rtsp-server/src/auto/rtsp_stream_transport.rs:178:27
    |
178 |             let callback: &Box_<(P, Q)> = &*(user_data as *mut _);
    |                           ^^^^^^^^^^^^^ help: try: `&(P, Q)`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#borrowed_box
    = note: `-D clippy::borrowed-box` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::borrowed_box)]`
error: you seem to be trying to use `&Box<T>`. Consider using just `&T`
   --> gstreamer-rtsp-server/src/auto/rtsp_stream_transport.rs:193:27
    |
193 |             let callback: &Box_<(P, Q)> = &*(user_data as *mut _);
    |                           ^^^^^^^^^^^^^ help: try: `&(P, Q)`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#borrowed_box
```