### PR TITLE
signals: work-around ObjectType shadowing

### DIFF
--- a/src/analysis/signals.rs
+++ b/src/analysis/signals.rs
@@ -102,6 +102,7 @@ fn analyze_signal(
     if trampoline.is_ok() {
         imports.add_used_types(&used_types);
         imports.add("glib::prelude::*");
+        imports.add("glib::object::ObjectType as _");
         imports.add("glib::signal::{connect_raw, SignalHandlerId}");
         imports.add("std::boxed::Box as Box_");
     }


### PR DESCRIPTION
Related to #772

This is needed because `use glib::prelude::*` will not pull in `ObjectType` (even though we only need the trait in scope) because it's shadowed.

Another way to fix this is by using a fully-qualified path to `ObjectType` at the call-site (happy to submit another PR for that if that's preferred, I do have one somewhere...), but this is more consistent with what's already being done.