### PR TITLE
Adds FromStr and TryFrom<&str> traits to enums implementations

### DIFF
--- a/src/library.rs
+++ b/src/library.rs
@@ -393,6 +393,7 @@ pub struct Member {
     pub name: String,
     pub c_identifier: String,
     pub value: String,
+    pub nick: Option<String>,
     pub doc: Option<String>,
     pub doc_deprecated: Option<String>,
     pub status: GStatus,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -991,6 +991,7 @@ impl Library {
         let member_name = elem.attr_required("name")?;
         let value = elem.attr_required("value")?;
         let c_identifier = elem.attr("identifier").map(|x| x.into());
+        let nick = elem.attr("nick").map(|x| x.into());
         let version = self.read_version(parser, ns_id, elem)?;
         let deprecated_version = self.read_deprecated_version(parser, ns_id, elem)?;
 
@@ -1010,6 +1011,7 @@ impl Library {
             doc,
             doc_deprecated,
             c_identifier: c_identifier.unwrap_or_else(|| member_name.into()),
+            nick,
             status: crate::config::gobjects::GStatus::Generate,
             version,
             deprecated_version,


### PR DESCRIPTION
This adds the generation of `FromStr` and `TryFrom<&str>` trait impls for enums.

- Contrary to FromGlib / IntoGlib, I removed the `doc(hidden)` attribute so that the traits get documented by cargo doc
- As discussed on matrix, the error type is `BoolError`
- The parsing is based on the enum member's nick; for members with no nick specified, the original "name" is used

This does **not** use a configuration parameter. After implementing it, I'm leaning on the opinion that a configuration flag should be provided, as it's not entirely unlikely for somebody to have implemented FromStr or TryFrom in their `/manual/` module, and if that implementation does not use the same nicks it can be a little painful to migrate.

## Not part of this PR
These are not in the PR, might be desired in future PRs:
- Same support for bitfields (might conflict with bitfield's default parser)
- `impl Display for $enum` for the reverse operation

## gtk-rs-core
Tested gtk-core-rs with this and it seems to work. Also a couple of personal projects build just fine.
If/when this gets merged, I can follow-up with a PR on gtk-core-rs.


