### PR TITLE
Address clippy warning

### DIFF
--- a/src/writer/to_code.rs
+++ b/src/writer/to_code.rs
@@ -150,7 +150,7 @@ impl ToCode for Chunk {
                         r#"let detailed_signal_name = detail.map(|name| {{ format!("{signal}::{{name}}\0") }});"#
                     ));
                     v.push(format!(
-                        r#"let signal_name: &[u8] = detailed_signal_name.as_ref().map_or(&b"{signal}\0"[..], |n| n.as_bytes());"#
+                        r#"let signal_name: &[u8] = detailed_signal_name.as_ref().map_or(c"{signal}".to_bytes(), |n| n.as_bytes());"#
                     ));
                     v.push(
                         "connect_raw(self.as_ptr() as *mut _, signal_name.as_ptr() as *const _,"


### PR DESCRIPTION
NUL-terminated  strings are  currently  generated  as b"<string>\0"  for signal names rather than as c"<string>" as recommended in:

https://rust-lang.github.io/rust-clippy/master/index.html#manual_c_str_literals