### PR TITLE
parser: Add doc format support

### DIFF
--- a/book/src/config/api.md
+++ b/book/src/config/api.md
@@ -14,7 +14,6 @@ target_path = "."
 # auto_path = "src/auto"
 work_mode = "normal"
 # Whether the library uses https://gitlab.gnome.org/GNOME/gi-docgen for its documentation
-use_gi_docgen = false
 generate_safety_asserts = true
 deprecate_by_min_version = true
 # With this option enabled, versions for gir and gir-files saved only to one file to minimize noise,
@@ -123,7 +122,7 @@ visibility = "pub" # or 'crate' / 'private' / 'super'
 # works for flags and enums. You have to pass the "GIR" member name.
 default_value = "fill"
 # Change the name of the generated trait to e.g avoid naming conflicts
-trait_name = "TraitnameExt" 
+trait_name = "TraitnameExt"
 # In case you don't want to generate the documentation for this type.
 generate_doc = false
     # define overrides for function
@@ -336,7 +335,7 @@ status = "generate"
     name = "stock_list_ids"
     # allows to ignore global functions
     ignore = true
-    # allows to define if the function was moved to a trait 
+    # allows to define if the function was moved to a trait
     doc_trait_name = "StockExt"
     # allows to define if the function was moved to a struct
     doc_struct_name = "Stock"

--- a/src/codegen/doc/format.rs
+++ b/src/codegen/doc/format.rs
@@ -8,7 +8,9 @@ use super::{gi_docgen, LocationInObject};
 use crate::{
     analysis::functions::Info,
     library::{FunctionKind, TypeId},
-    nameutil, Env,
+    nameutil,
+    parser::DocFormat,
+    Env,
 };
 
 const LANGUAGE_SEP_BEGIN: &str = "<!-- language=\"";
@@ -138,7 +140,7 @@ fn replace_symbols(
     env: &Env,
     in_type: Option<(&TypeId, Option<LocationInObject>)>,
 ) -> String {
-    if env.config.use_gi_docgen {
+    if env.library.doc_format == DocFormat::GiDocgen {
         let out = gi_docgen::replace_c_types(input, env, in_type);
         let out = gi_docgen_symbol().replace_all(&out, |caps: &Captures<'_>| match &caps[2] {
             "TRUE" => "[`true`]".to_string(),

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -105,7 +105,6 @@ pub struct Config {
     pub external_libraries: Vec<ExternalLibrary>,
     pub objects: gobjects::GObjects,
     pub min_cfg_version: Version,
-    pub use_gi_docgen: bool,
     pub make_backup: bool,
     pub generate_safety_asserts: bool,
     pub deprecate_by_min_version: bool,
@@ -286,11 +285,6 @@ impl Config {
             None => Default::default(),
         };
 
-        let use_gi_docgen = match toml.lookup("options.use_gi_docgen") {
-            Some(v) => v.as_result_bool("options.use_gi_docgen")?,
-            None => false,
-        };
-
         let generate_safety_asserts = match toml.lookup("options.generate_safety_asserts") {
             Some(v) => v.as_result_bool("options.generate_safety_asserts")?,
             None => false,
@@ -344,7 +338,6 @@ impl Config {
             external_libraries,
             objects,
             min_cfg_version,
-            use_gi_docgen,
             make_backup,
             generate_safety_asserts,
             deprecate_by_min_version,

--- a/src/library.rs
+++ b/src/library.rs
@@ -9,7 +9,7 @@ use std::{
 
 use crate::{
     analysis::conversion_type::ConversionType, config::gobjects::GStatus, env::Env,
-    nameutil::split_namespace_name, traits::*, version::Version,
+    nameutil::split_namespace_name, parser::DocFormat, traits::*, version::Version,
 };
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -1056,18 +1056,16 @@ pub const INTERNAL_NAMESPACE_NAME: &str = "*";
 pub const INTERNAL_NAMESPACE: u16 = 0;
 pub const MAIN_NAMESPACE: u16 = 1;
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct Library {
     pub namespaces: Vec<Namespace>,
     pub index: HashMap<String, u16>,
+    pub doc_format: DocFormat,
 }
 
 impl Library {
     pub fn new(main_namespace_name: &str) -> Self {
-        let mut library = Self {
-            namespaces: Vec::new(),
-            index: HashMap::new(),
-        };
+        let mut library = Self::default();
         assert_eq!(
             INTERNAL_NAMESPACE,
             library.add_namespace(INTERNAL_NAMESPACE_NAME)

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -11,6 +11,31 @@ use crate::{
     xmlparser::{Element, XmlParser},
 };
 
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub enum DocFormat {
+    GtkDocMarkdown,
+    GtkDocDocbook,
+    GiDocgen,
+    HotDoc,
+    #[default]
+    Unknown,
+}
+
+impl std::str::FromStr for DocFormat {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "gtk-doc-markdown" => Ok(Self::GtkDocMarkdown),
+            "gtk-doc-docbook" => Ok(Self::GtkDocDocbook),
+            "gi-docgen" => Ok(Self::GiDocgen),
+            "hotdoc" => Ok(Self::HotDoc),
+            "unknown" => Ok(Self::Unknown),
+            e => Err(format!("Invalid doc:format {e}")),
+        }
+    }
+}
+
 const EMPTY_CTYPE: &str = "/*EMPTY*/";
 
 pub fn is_empty_c_type(c_type: &str) -> bool {
@@ -81,6 +106,11 @@ impl Library {
                 std::mem::take(&mut includes),
             ),
             "attribute" => parser.ignore_element(),
+            "doc" => {
+                let format = DocFormat::from_str(elem.attr_required("name")?)?;
+                self.doc_format = format;
+                Ok(())
+            }
             _ => Err(parser.unexpected_element(elem)),
         })?;
         Ok(())


### PR DESCRIPTION
Replaces the current use_gi_docgen key

We would need https://github.com/gtk-rs/gir-files/pull/237 to land first but that is blocked on more core libraries defining the doc:format properly.