### PR TITLE
Update rustdoc-stripper to 0.1.19

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,7 +185,8 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 [[package]]
 name = "rustdoc-stripper"
 version = "0.1.19"
-source = "git+https://github.com/GuillaumeGomez/rustdoc-stripper#1170265c0f2a3728c086c717aa0603ccaad18a81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ab2432ada69d3b404987a137436b0e475c6776f7a0c86ee00b356c0348ef40d"
 
 [[package]]
 name = "serde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ env_logger = { version = "0.11", default-features = false }
 log = "0.4"
 regex = "1.11"
 hprof = "0.1"
-rustdoc-stripper = { git = "https://github.com/GuillaumeGomez/rustdoc-stripper" }
+rustdoc-stripper = "0.1.19"
 
 [profile.release]
 codegen-units = 4


### PR DESCRIPTION
This dependency used the "git" version [many years ago](https://github.com/gtk-rs/gir/commit/7011eeb), but we can just use a released version instead now. This also helps Debian's build tools.

~I didn't touch Cargo.lock~