### PR TITLE
Fix two clippy warnings in generated code.

### DIFF
--- a/src/codegen/enums.rs
+++ b/src/codegen/enums.rs
@@ -115,6 +115,19 @@ fn generate_enum(
         });
     }
 
+    // Check if we can use #[derive(Default)] instead of a manual impl.
+    // This is possible when the default member has no version or cfg condition.
+    let derive_default_member = config.default_value.as_ref().and_then(|default_value| {
+        let m = members
+            .iter()
+            .find(|m| m.name == enum_member_name(default_value))?;
+        if m.version.is_none() && m.cfg_condition.is_none() {
+            Some(m.name.clone())
+        } else {
+            None
+        }
+    });
+
     cfg_deprecated(
         w,
         env,
@@ -134,7 +147,11 @@ fn generate_enum(
     } else {
         writeln!(w, "#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]")?;
     }
-    writeln!(w, "#[derive(Clone, Copy)]")?;
+    if derive_default_member.is_some() {
+        writeln!(w, "#[derive(Clone, Copy, Default)]")?;
+    } else {
+        writeln!(w, "#[derive(Clone, Copy)]")?;
+    }
     if config.exhaustive {
         writeln!(w, "#[repr(i32)]")?;
     } else {
@@ -157,6 +174,9 @@ fn generate_enum(
         // Don't generate a doc_alias if the C name is the same as the Rust one
         if member.c_name != member.name {
             doc_alias(w, &member.c_name, "", 1)?;
+        }
+        if derive_default_member.as_deref() == Some(&*member.name) {
+            writeln!(w, "\t#[default]")?;
         }
         if config.exhaustive {
             writeln!(
@@ -538,24 +558,26 @@ impl FromGlib<{sys_crate_name}::{ffi_name}> for {name} {{
         writeln!(w)?;
     }
 
-    generate_default_impl(
-        w,
-        env,
-        config,
-        &enum_.name,
-        enum_.version,
-        enum_.members.iter(),
-        |member| {
-            let e_member = members.iter().find(|m| m.c_name == member.c_identifier)?;
-            let member_config = config.members.matched(&member.name);
-            let version = member_config
-                .iter()
-                .find_map(|m| m.version)
-                .or(e_member.version);
-            let cfg_condition = member_config.iter().find_map(|m| m.cfg_condition.as_ref());
-            Some((version, cfg_condition, e_member.name.as_str()))
-        },
-    )?;
+    if derive_default_member.is_none() {
+        generate_default_impl(
+            w,
+            env,
+            config,
+            &enum_.name,
+            enum_.version,
+            enum_.members.iter(),
+            |member| {
+                let e_member = members.iter().find(|m| m.c_name == member.c_identifier)?;
+                let member_config = config.members.matched(&member.name);
+                let version = member_config
+                    .iter()
+                    .find_map(|m| m.version)
+                    .or(e_member.version);
+                let cfg_condition = member_config.iter().find_map(|m| m.cfg_condition.as_ref());
+                Some((version, cfg_condition, e_member.name.as_str()))
+            },
+        )?;
+    }
 
     Ok(())
 }

--- a/src/codegen/function.rs
+++ b/src/codegen/function.rs
@@ -140,10 +140,28 @@ pub fn generate(
         String::new()
     };
 
+    let allow_new_ret_no_self = if analysis.codegen_name() == "new"
+        && parent_type_id.is_some_and(|tid| {
+            analysis
+                .ret
+                .parameter
+                .as_ref()
+                .is_some_and(|par| par.lib_par.typ != tid)
+        }) {
+        format!(
+            "{}{}#[allow(clippy::new_ret_no_self)]\n",
+            tabs(indent),
+            comment_prefix
+        )
+    } else {
+        String::new()
+    };
+
     writeln!(
         w,
-        "{}{}{}{}{}{}{}{}{}",
+        "{}{}{}{}{}{}{}{}{}{}",
         allow_should_implement_trait,
+        allow_new_ret_no_self,
         dead_code_cfg,
         get_must_use_if_needed(parent_type_id, analysis, comment_prefix).unwrap_or_default(),
         tabs(indent),


### PR DESCRIPTION
1. Emit `#[derive(Default)]` with a `#[default]` attribute on the variant
instead of a manual `impl Default` block. Falls back to the manual impl
when the default variant has a version or `cfg` condition.

2. `GObject` constructors often return a base class rather than the concrete
type, which triggers `clippy::new_ret_no_self`. Suppress the warning on
generated `new()` methods when the return type differs from `Self`.

