### PR TITLE
codegen: Compare versions when it makes sense

### DIFF
--- a/src/codegen/object.rs
+++ b/src/codegen/object.rs
@@ -55,7 +55,12 @@ pub fn generate(w: &mut dyn Write, env: &Env, analysis: &analysis::object::Info)
                     let namespace_min_version = env
                         .config
                         .min_required_version(env, Some(object.type_id.ns_id));
-                    if parent_version > analysis.version && parent_version > namespace_min_version {
+                    // We should only compare the versions if they come from the
+                    // same namespace.
+                    let is_same_lib = object.type_id.ns_id == analysis.base.type_id.ns_id;
+                    if (parent_version > analysis.version || !is_same_lib)
+                        && parent_version > namespace_min_version
+                    {
                         ns_versions
                             .entry(object.type_id.ns_id)
                             .or_default()


### PR DESCRIPTION
Considered the following scenario:

 - gtk::Accessible added in gtk_4_10
 - sourceview5::StyleSchemePreview added in 5_4, implementing the former

Then the inequality 4.10 > 5.4 is not true and the guard for gtk_4_10 is not added when generating the glib::wrapper! macros for the later.